### PR TITLE
[sap_hypervisor_node_preconfigure] updated trident and fixed variable name

### DIFF
--- a/roles/sap_hypervisor_node_preconfigure/tasks/platform/redhat_ocp_virt/main.yml
+++ b/roles/sap_hypervisor_node_preconfigure/tasks/platform/redhat_ocp_virt/main.yml
@@ -81,8 +81,6 @@
 - name: Include install virtctl
   ansible.builtin.include_tasks: "platform/{{ sap_hypervisor_node_platform }}/install-virtctl.yml"
 
-- debug: var=sap_hypervisor_node_preconfigure_setup_worker_nodes
-
 - name: Include setup worker nodes
   ansible.builtin.include_tasks: "platform/{{ sap_hypervisor_node_platform }}/setup-worker-nodes.yml"
   when: sap_hypervisor_node_preconfigure_setup_worker_nodes

--- a/roles/sap_hypervisor_node_preconfigure/tasks/platform/redhat_ocp_virt/main.yml
+++ b/roles/sap_hypervisor_node_preconfigure/tasks/platform/redhat_ocp_virt/main.yml
@@ -81,9 +81,11 @@
 - name: Include install virtctl
   ansible.builtin.include_tasks: "platform/{{ sap_hypervisor_node_platform }}/install-virtctl.yml"
 
+- debug: var=sap_hypervisor_node_preconfigure_setup_worker_nodes
+
 - name: Include setup worker nodes
   ansible.builtin.include_tasks: "platform/{{ sap_hypervisor_node_platform }}/setup-worker-nodes.yml"
-  when: sap_hypervisor_node_preconfigure_setup_workers
+  when: sap_hypervisor_node_preconfigure_setup_worker_nodes
 
 # How to wait for node to be scheduleable? (NodeSchedulable)
 - name: Wait for all k8s nodes to be ready

--- a/roles/sap_hypervisor_node_preconfigure/vars/platform_defaults_redhat_ocp_virt.yml
+++ b/roles/sap_hypervisor_node_preconfigure/vars/platform_defaults_redhat_ocp_virt.yml
@@ -9,7 +9,7 @@ sap_hypervisor_node_preconfigure_install_hpp: false
 sap_hypervisor_node_preconfigure_install_trident: false
 
 # URL of the trident installer package to use
-sap_hypervisor_node_preconfigure_install_trident_url: https://github.com/NetApp/trident/releases/download/v23.01.0/trident-installer-23.01.0.tar.gz
+sap_hypervisor_node_preconfigure_install_trident_url: https://github.com/NetApp/trident/releases/download/v23.10.0/trident-installer-23.10.0.tar.gz
 
 # should SRIOV be enabled for unsupported NICs
 sap_hypervisor_node_preconfigure_sriov_enable_unsupported_nics: true
@@ -27,4 +27,4 @@ sap_hypervisor_node_preconfigure_ignore_minimal_memory_check: false
 sap_hypervisor_node_preconfigure_install_operators: true
 
 # Configure the workers?
-sap_hypervisor_node_preconfigure_setup_workers: true
+sap_hypervisor_node_preconfigure_setup_worker_nodes: true


### PR DESCRIPTION
* updated trident to 23.10 
* renamed variable switch for setting up worker nodes to sap_hypervisor_node_preconfigure_setup_worker_nodes