### PR TITLE
sap_vm_provision: feat: aws security enhancements

### DIFF
--- a/roles/sap_vm_provision/PLATFORM_GUIDANCE.md
+++ b/roles/sap_vm_provision/PLATFORM_GUIDANCE.md
@@ -148,6 +148,56 @@ aws iam attach-group-policy --group-name 'ag-sap-automation' --policy-arn arn:aw
 aws iam attach-group-policy --group-name 'ag-sap-automation' --policy-arn arn:aws:iam::aws:policy/AmazonRoute53FullAccess
 ```
 
+It is recommended to create new AWS IAM Policy with detailed actions to improve security.
+```json
+{
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+			"Sid": "VisualEditor0",
+			"Effect": "Allow",
+			"Action": [
+				"ec2:DescribeImages",
+				"ec2:DescribeInstances",
+				"ec2:DescribeTags",
+				"ec2:DescribeInstanceAttribute",
+				"ec2:DescribeSubnets",
+				"ec2:DescribeSecurityGroups",
+				"ec2:RunInstances",
+				"ec2:CreateTags",
+				"ec2:DescribeInstanceStatus",
+				"ec2:ModifyInstanceAttribute",
+				"ec2:DescribeRouteTables",
+				"route53:ListHostedZones",
+				"route53:ListResourceRecordSets",
+				"route53:ChangeResourceRecordSets",
+				"route53:GetChange",
+				"ec2:DescribeVolumes",
+				"ec2:CreateVolume",
+				"ec2:DeleteVolume",
+				"ec2:AttachVolume",
+				"ec2:DetachVolume",
+				"ec2:TerminateInstances",
+				"ec2:CreateRoute",
+				"iam:GetRole",
+				"iam:CreateRole",
+				"iam:ListInstanceProfilesForRole",
+				"iam:CreateInstanceProfile",
+				"iam:AddRoleToInstanceProfile",
+				"iam:ListAttachedRolePolicies",
+				"iam:ListRoleTags",
+				"iam:PutRolePolicy",
+				"iam:GetInstanceProfile",
+				"iam:PassRole",
+				"ec2:AssociateIamInstanceProfile",
+				"ec2:ReplaceRoute"
+			],
+			"Resource": "*"
+		}
+	]
+}
+```
+
 </details>
 
 <details>

--- a/roles/sap_vm_provision/tasks/common/set_ansible_vars.yml
+++ b/roles/sap_vm_provision/tasks/common/set_ansible_vars.yml
@@ -10,6 +10,7 @@
     sap_id_user_password: "{{ sap_id_user_password }}"
     sap_software_download_directory: "{{ sap_software_download_directory }}"
     sap_install_media_detect_source_directory: "{{ sap_software_download_directory }}"
+  no_log: true  # Hide SAP S-User password
 
 - name: Set facts for all hosts - use facts from localhost - Ansible only
   ansible.builtin.set_fact:
@@ -52,6 +53,7 @@
   when:
     - sap_ha_pacemaker_cluster_aws_region is defined
     - sap_vm_provision_iac_platform == "aws_ec2_vs"
+  no_log: true  # Hide AWS Credentials
 
 # - name: Set facts for all hosts - use facts from localhost - HA/DR - GCP
 #   ansible.builtin.set_fact:

--- a/roles/sap_vm_provision/tasks/common/set_ansible_vars.yml
+++ b/roles/sap_vm_provision/tasks/common/set_ansible_vars.yml
@@ -6,10 +6,10 @@
     sap_vm_provision_host_specification_plan: "{{ sap_vm_provision_host_specification_plan }}"
     sap_vm_provision_nfs_mount_point: "{{ sap_vm_provision_nfs_mount_point | default('') }}"
     sap_vm_provision_nfs_mount_point_separate_sap_transport_dir: "{{ sap_vm_provision_nfs_mount_point_separate_sap_transport_dir | default('') }}"
-    sap_id_user: "{{ sap_id_user }}"
-    sap_id_user_password: "{{ sap_id_user_password }}"
-    sap_software_download_directory: "{{ sap_software_download_directory }}"
-    sap_install_media_detect_source_directory: "{{ sap_software_download_directory }}"
+    sap_id_user: "{{ sap_id_user | default('') }}"
+    sap_id_user_password: "{{ sap_id_user_password | default('') }}"
+    sap_software_download_directory: "{{ sap_software_download_directory | default('/software') }}"
+    sap_install_media_detect_source_directory: "{{ sap_software_download_directory | default('/software') }}"
   no_log: "{{ __sap_vm_provision_no_log }}"
 
 - name: Set facts for all hosts - use facts from localhost - Ansible only

--- a/roles/sap_vm_provision/tasks/common/set_ansible_vars.yml
+++ b/roles/sap_vm_provision/tasks/common/set_ansible_vars.yml
@@ -10,7 +10,7 @@
     sap_id_user_password: "{{ sap_id_user_password }}"
     sap_software_download_directory: "{{ sap_software_download_directory }}"
     sap_install_media_detect_source_directory: "{{ sap_software_download_directory }}"
-  no_log: true  # Hide SAP S-User password
+  no_log: "{{ __sap_vm_provision_no_log }}"
 
 - name: Set facts for all hosts - use facts from localhost - Ansible only
   ansible.builtin.set_fact:
@@ -49,11 +49,11 @@
     sap_ha_pacemaker_cluster_aws_region: "{{ sap_ha_pacemaker_cluster_aws_region }}"
     sap_ha_pacemaker_cluster_aws_access_key_id: "{{ sap_ha_pacemaker_cluster_aws_access_key_id }}"
     sap_ha_pacemaker_cluster_aws_secret_access_key: "{{ sap_ha_pacemaker_cluster_aws_secret_access_key }}"
-    sap_ha_pacemaker_cluster_aws_vip_update_rt: "{{ aws_vpc_subnet_rt_info.route_tables[0].route_table_id }}"
+    sap_ha_pacemaker_cluster_aws_vip_update_rt: "{{ __sap_vm_provision_task_vpc_subnet_rt_info.route_tables[0].route_table_id }}"
   when:
     - sap_ha_pacemaker_cluster_aws_region is defined
     - sap_vm_provision_iac_platform == "aws_ec2_vs"
-  no_log: true  # Hide AWS Credentials
+  no_log: "{{ __sap_vm_provision_no_log }}"
 
 # - name: Set facts for all hosts - use facts from localhost - HA/DR - GCP
 #   ansible.builtin.set_fact:

--- a/roles/sap_vm_provision/tasks/platform_ansible/aws_ec2_vs/execute_main.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/aws_ec2_vs/execute_main.yml
@@ -2,37 +2,34 @@
 
 - name: Ansible Task block for looped provisioning of AWS EC2 instances
   environment:
-    # AWS_ACCESS_KEY_ID: "{{ sap_vm_provision_aws_access_key }}"
-    # AWS_SECRET_ACCESS_KEY: "{{ sap_vm_provision_aws_secret_access_key }}"
     AWS_REGION: "{{ sap_vm_provision_aws_region }}"
+  any_errors_fatal: true
   block:
 
     - name: Identify OS Image (AWS AMI)
-      register: register_aws_ami
+      register: __sap_vm_provision_task_aws_ami
       amazon.aws.ec2_ami_info:
         owners: ["aws-marketplace"]
         filters:
           name: "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_os_image_dictionary')[sap_vm_provision_aws_ec2_vs_host_os_image] }}"
         access_key: "{{ sap_vm_provision_aws_access_key }}"
         secret_key: "{{ sap_vm_provision_aws_secret_access_key }}"
-      no_log: true
+      no_log: "{{ __sap_vm_provision_no_log }}"
 
     - name: Set fact to hold loop variables from include_tasks
       ansible.builtin.set_fact:
         register_provisioned_host_all: []
 
     - name: Provision hosts to AWS
-      register: register_provisioned_hosts
+      register: __sap_vm_provision_task_register_provisioned_hosts
       ansible.builtin.include_tasks:
         file: "{{ 'platform_' + sap_vm_provision_iac_type }}/{{ sap_vm_provision_iac_platform }}/execute_provision.yml"
-        apply:
-          environment:
-            # AWS_ACCESS_KEY_ID: "{{ sap_vm_provision_aws_access_key }}"
-            # AWS_SECRET_ACCESS_KEY: "{{ sap_vm_provision_aws_secret_access_key }}"
-            AWS_REGION: "{{ sap_vm_provision_aws_region }}"
+        # apply:
+        #   environment:
+        #     AWS_REGION: "{{ sap_vm_provision_aws_region }}"
 
     - name: Add hosts provisioned to the Ansible Inventory
-      register: register_add_hosts
+      register: __sap_vm_provision_task_register_add_hosts
       ansible.builtin.add_host:
         name: "{{ add_item[0].host_node }}"
         groups: "{{ add_item[0].sap_system_type + '_' if (add_item[0].sap_system_type != '') }}{{ add_item[0].sap_host_type }}"
@@ -44,7 +41,7 @@
       loop_control:
         label: "{{ add_item[0].host_node }}"
         loop_var: add_item
-      no_log: true
+      no_log: "{{ __sap_vm_provision_no_log }}"
 
 # Cannot override any variables from extravars input, see https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_variables.html#understanding-variable-precedence
 # Ensure no default value exists for any prompted variable before execution of Ansible Playbook
@@ -55,8 +52,8 @@
           association.subnet-id: "{{ sap_vm_provision_aws_vpc_subnet_id }}"
         access_key: "{{ sap_vm_provision_aws_access_key }}"
         secret_key: "{{ sap_vm_provision_aws_secret_access_key }}"
-      register: aws_vpc_subnet_rt_info
-      no_log: true
+      register: __sap_vm_provision_task_vpc_subnet_rt_info
+      no_log: "{{ __sap_vm_provision_no_log }}"
 
     - name: Set fact to hold all inventory hosts in all groups
       ansible.builtin.set_fact:
@@ -77,13 +74,35 @@
         ttl: 7200
         value: "{{ hostvars[inventory_hostname].ansible_host }}"
         wait: true
-        overwrite: true  # Provides idempotency
         access_key: "{{ sap_vm_provision_aws_access_key }}"
         secret_key: "{{ sap_vm_provision_aws_secret_access_key }}"
-      no_log: true
+      register: __sap_vm_provision_task_route53
+      no_log: "{{ __sap_vm_provision_no_log }}"
 
-  #  - ansible.builtin.debug:
-  #      var: register_add_hosts.results
+  rescue:
+    # This requires no_log set on each Ansible Task, and not set on the Ansible Task Block
+    # This requires an Ansible Task Block containing the Ansible Tasks for calling
+    # Infrastructure Platform APIs (via Ansible Modules)
+    - name: Show errors in task outputs
+      ansible.builtin.fail:
+        msg: "{{ lookup('ansible.builtin.vars', loop_item) }}"
+      loop:
+        - __sap_vm_provision_task_aws_ami
+        - __sap_vm_provision_task_provisioned_host_single
+        - __sap_vm_provision_task_instance_info
+        - __sap_vm_provision_task_volume_provisioning
+        - __sap_vm_provision_task_register_provisioned_hosts
+        - __sap_vm_provision_task_register_add_hosts
+        - __sap_vm_provision_task_vpc_subnet_rt_info
+        - __sap_vm_provision_task_route53
+      loop_control:
+        loop_var: loop_item
+        index_var: loop_item_index
+        label: "{{ 'Variable No. ' + (loop_item_index | string) }}"
+      when:
+        - lookup('ansible.builtin.vars', loop_item, default='') | length > 0
+        - not lookup('ansible.builtin.vars', loop_item, default='') is skipped
+        - lookup('ansible.builtin.vars', loop_item, default='') is failed
 
 - name: Ansible Task block to execute on target inventory hosts
   delegate_to: "{{ inventory_hostname }}"
@@ -130,8 +149,6 @@
   delegate_to: localhost
   run_once: true
   environment:
-    # AWS_ACCESS_KEY_ID: "{{ sap_vm_provision_aws_access_key }}"
-    # AWS_SECRET_ACCESS_KEY: "{{ sap_vm_provision_aws_secret_access_key }}"
     AWS_REGION: "{{ sap_vm_provision_aws_region }}"
   when:
     - sap_ha_pacemaker_cluster_aws_region is defined
@@ -141,8 +158,41 @@
     - name: Provision High Availability resources for AWS EC2 hosts
       ansible.builtin.include_tasks:
         file: "{{ 'platform_' + sap_vm_provision_iac_type }}/{{ sap_vm_provision_iac_platform }}/execute_setup_ha.yml"
-        apply:
-          environment:
-            # AWS_ACCESS_KEY_ID: "{{ sap_vm_provision_aws_access_key }}"
-            # AWS_SECRET_ACCESS_KEY: "{{ sap_vm_provision_aws_secret_access_key }}"
-            AWS_REGION: "{{ sap_vm_provision_aws_region }}"
+        # apply:
+        #   environment:
+        #     AWS_REGION: "{{ sap_vm_provision_aws_region }}"
+
+  rescue:
+    # This requires no_log set on each Ansible Task, and not set on the Ansible Task Block
+    # This requires an Ansible Task Block containing the Ansible Tasks for calling
+    # Infrastructure Platform APIs (via Ansible Modules)
+    - name: Show errors in task outputs
+      ansible.builtin.fail:
+        msg: "{{ lookup('ansible.builtin.vars', loop_item) }}"
+      loop:
+        - __sap_vm_provision_task_aws_account_info
+        - __sap_vm_provision_task_vpc_subnet_rt_info
+        - __sap_vm_provision_task_vpc_subnet_rt_route_sap_hana
+        - __sap_vm_provision_task_route53_sap_hana
+        - __sap_vm_provision_task_vpc_subnet_rt_route_sap_anydb
+        - __sap_vm_provision_task_route53_sap_anydb
+        - __sap_vm_provision_task_vpc_subnet_rt_route_sap_netweaver_ascs
+        - __sap_vm_provision_task_route53_sap_netweaver_ascs
+        - __sap_vm_provision_task_vpc_subnet_rt_route_sap_netweaver_ers
+        - __sap_vm_provision_task_route53_sap_netweaver_ers
+        - __sap_vm_provision_task_iam_role_ha_pacemaker
+        - __sap_vm_provision_task_iam_policy_dataprovider
+        - __sap_vm_provision_task_iam_policy_overlayip
+        - __sap_vm_provision_task_iam_policy_stonith_saphana
+        - __sap_vm_provision_task_iam_policy_stonith_sapnwas
+        - __sap_vm_provision_task_iam_attach_role
+        - __sap_vm_provision_task_iam_attach_instance_saphana
+        - __sap_vm_provision_task_iam_attach_instance_sapnwas
+      loop_control:
+        loop_var: loop_item
+        index_var: loop_item_index
+        label: "{{ 'Variable No. ' + (loop_item_index | string) }}"
+      when:
+        - lookup('ansible.builtin.vars', loop_item, default='') | length > 0
+        - not lookup('ansible.builtin.vars', loop_item, default='') is skipped
+        - lookup('ansible.builtin.vars', loop_item, default='') is failed

--- a/roles/sap_vm_provision/tasks/platform_ansible/aws_ec2_vs/execute_main.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/aws_ec2_vs/execute_main.yml
@@ -153,6 +153,7 @@
   when:
     - sap_ha_pacemaker_cluster_aws_region is defined
     - (groups["hana_secondary"] is defined and (groups["hana_secondary"] | length>0)) or (groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0)) or (groups["anydb_secondary"] is defined and (groups["anydb_secondary"] | length>0))
+  any_errors_fatal: true
   block:
 
     - name: Provision High Availability resources for AWS EC2 hosts

--- a/roles/sap_vm_provision/tasks/platform_ansible/aws_ec2_vs/execute_main.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/aws_ec2_vs/execute_main.yml
@@ -2,8 +2,8 @@
 
 - name: Ansible Task block for looped provisioning of AWS EC2 instances
   environment:
-    AWS_ACCESS_KEY_ID: "{{ sap_vm_provision_aws_access_key }}"
-    AWS_SECRET_ACCESS_KEY: "{{ sap_vm_provision_aws_secret_access_key }}"
+    # AWS_ACCESS_KEY_ID: "{{ sap_vm_provision_aws_access_key }}"
+    # AWS_SECRET_ACCESS_KEY: "{{ sap_vm_provision_aws_secret_access_key }}"
     AWS_REGION: "{{ sap_vm_provision_aws_region }}"
   block:
 
@@ -13,6 +13,9 @@
         owners: ["aws-marketplace"]
         filters:
           name: "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_os_image_dictionary')[sap_vm_provision_aws_ec2_vs_host_os_image] }}"
+        access_key: "{{ sap_vm_provision_aws_access_key }}"
+        secret_key: "{{ sap_vm_provision_aws_secret_access_key }}"
+      no_log: true
 
     - name: Set fact to hold loop variables from include_tasks
       ansible.builtin.set_fact:
@@ -24,8 +27,8 @@
         file: "{{ 'platform_' + sap_vm_provision_iac_type }}/{{ sap_vm_provision_iac_platform }}/execute_provision.yml"
         apply:
           environment:
-            AWS_ACCESS_KEY_ID: "{{ sap_vm_provision_aws_access_key }}"
-            AWS_SECRET_ACCESS_KEY: "{{ sap_vm_provision_aws_secret_access_key }}"
+            # AWS_ACCESS_KEY_ID: "{{ sap_vm_provision_aws_access_key }}"
+            # AWS_SECRET_ACCESS_KEY: "{{ sap_vm_provision_aws_secret_access_key }}"
             AWS_REGION: "{{ sap_vm_provision_aws_region }}"
 
     - name: Add hosts provisioned to the Ansible Inventory
@@ -41,7 +44,7 @@
       loop_control:
         label: "{{ add_item[0].host_node }}"
         loop_var: add_item
-
+      no_log: true
 
 # Cannot override any variables from extravars input, see https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_variables.html#understanding-variable-precedence
 # Ensure no default value exists for any prompted variable before execution of Ansible Playbook
@@ -50,7 +53,10 @@
       amazon.aws.ec2_vpc_route_table_info:
         filters:
           association.subnet-id: "{{ sap_vm_provision_aws_vpc_subnet_id }}"
+        access_key: "{{ sap_vm_provision_aws_access_key }}"
+        secret_key: "{{ sap_vm_provision_aws_secret_access_key }}"
       register: aws_vpc_subnet_rt_info
+      no_log: true
 
     - name: Set fact to hold all inventory hosts in all groups
       ansible.builtin.set_fact:
@@ -71,6 +77,10 @@
         ttl: 7200
         value: "{{ hostvars[inventory_hostname].ansible_host }}"
         wait: true
+        overwrite: true  # Provides idempotency
+        access_key: "{{ sap_vm_provision_aws_access_key }}"
+        secret_key: "{{ sap_vm_provision_aws_secret_access_key }}"
+      no_log: true
 
   #  - ansible.builtin.debug:
   #      var: register_add_hosts.results
@@ -120,8 +130,8 @@
   delegate_to: localhost
   run_once: true
   environment:
-    AWS_ACCESS_KEY_ID: "{{ sap_vm_provision_aws_access_key }}"
-    AWS_SECRET_ACCESS_KEY: "{{ sap_vm_provision_aws_secret_access_key }}"
+    # AWS_ACCESS_KEY_ID: "{{ sap_vm_provision_aws_access_key }}"
+    # AWS_SECRET_ACCESS_KEY: "{{ sap_vm_provision_aws_secret_access_key }}"
     AWS_REGION: "{{ sap_vm_provision_aws_region }}"
   when:
     - sap_ha_pacemaker_cluster_aws_region is defined
@@ -133,6 +143,6 @@
         file: "{{ 'platform_' + sap_vm_provision_iac_type }}/{{ sap_vm_provision_iac_platform }}/execute_setup_ha.yml"
         apply:
           environment:
-            AWS_ACCESS_KEY_ID: "{{ sap_vm_provision_aws_access_key }}"
-            AWS_SECRET_ACCESS_KEY: "{{ sap_vm_provision_aws_secret_access_key }}"
+            # AWS_ACCESS_KEY_ID: "{{ sap_vm_provision_aws_access_key }}"
+            # AWS_SECRET_ACCESS_KEY: "{{ sap_vm_provision_aws_secret_access_key }}"
             AWS_REGION: "{{ sap_vm_provision_aws_region }}"

--- a/roles/sap_vm_provision/tasks/platform_ansible/aws_ec2_vs/execute_provision.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/aws_ec2_vs/execute_provision.yml
@@ -28,6 +28,9 @@
     network:
       assign_public_ip: false
       source_dest_check: "{{ not lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][scaleout_origin_host_spec | default(inventory_hostname)].disable_ip_anti_spoofing }}" # Disable the Anti IP Spoofing by setting Source/Destination Check to false
+    access_key: "{{ sap_vm_provision_aws_access_key }}"
+    secret_key: "{{ sap_vm_provision_aws_secret_access_key }}"
+  no_log: true
 
 - name: Set fact for storage volume letters calculations (max 25 volumes)
   ansible.builtin.set_fact:
@@ -38,7 +41,10 @@
     filters:
       "tag:Name": "{{ inventory_hostname }}"
       "instance-state-name": ["running"]
+    access_key: "{{ sap_vm_provision_aws_access_key }}"
+    secret_key: "{{ sap_vm_provision_aws_secret_access_key }}"
   register: instance_info
+  no_log: true
 
 - name: Set fact for available storage volume device names
   ansible.builtin.set_fact:
@@ -95,6 +101,8 @@
     volume_size: "{{ vol_item.size }}"
     device_name: "{{ vol_item.device }}"
     delete_on_termination: true
+    access_key: "{{ sap_vm_provision_aws_access_key }}"
+    secret_key: "{{ sap_vm_provision_aws_secret_access_key }}"
   loop: "{{ filesystem_volume_map }}"
   loop_control:
     loop_var: vol_item
@@ -104,12 +112,16 @@
     - vol_item.fstype is defined
     - vol_item.size > 0
   register: volume_provisioning
+  no_log: true
 
 - name: Read AWS EC2 instance information
   amazon.aws.ec2_instance_info:
     filters:
       "tag:Name": "{{ inventory_hostname }}"
+    access_key: "{{ sap_vm_provision_aws_access_key }}"
+    secret_key: "{{ sap_vm_provision_aws_secret_access_key }}"
   register: instance_info
+  no_log: true
 
 - name: Add host facts
   ansible.builtin.set_fact:
@@ -118,7 +130,7 @@
     instance_info: "{{ instance_info }}"
   delegate_to: "{{ inventory_hostname }}"
   delegate_facts: true
-
+  no_log: true
 
 - name: Create fact for delegate host IP
   ansible.builtin.set_fact:

--- a/roles/sap_vm_provision/tasks/platform_ansible/aws_ec2_vs/execute_provision.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/aws_ec2_vs/execute_provision.yml
@@ -10,11 +10,11 @@
     - not inventory_hostname in lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan].keys()
 
 - name: Provision AWS EC2 Virtual Server instance
-  register: register_provisioned_host_single
+  register: __sap_vm_provision_task_provisioned_host_single
   amazon.aws.ec2_instance:
     state: started
     name: "{{ inventory_hostname }}"
-    image_id: "{{ (register_aws_ami.images | sort(attribute='creation_date') | last).image_id }}"
+    image_id: "{{ (__sap_vm_provision_task_aws_ami.images | sort(attribute='creation_date') | last).image_id }}"
     instance_type: "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][scaleout_origin_host_spec | default(inventory_hostname)].virtual_machine_profile }}"
     key_name: "{{ sap_vm_provision_aws_key_pair_name_ssh_host_public_key }}"
     security_groups: "{{ sap_vm_provision_aws_vpc_sg_names }}"
@@ -30,7 +30,7 @@
       source_dest_check: "{{ not lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][scaleout_origin_host_spec | default(inventory_hostname)].disable_ip_anti_spoofing }}" # Disable the Anti IP Spoofing by setting Source/Destination Check to false
     access_key: "{{ sap_vm_provision_aws_access_key }}"
     secret_key: "{{ sap_vm_provision_aws_secret_access_key }}"
-  no_log: true
+  no_log: "{{ __sap_vm_provision_no_log }}"
 
 - name: Set fact for storage volume letters calculations (max 25 volumes)
   ansible.builtin.set_fact:
@@ -43,8 +43,8 @@
       "instance-state-name": ["running"]
     access_key: "{{ sap_vm_provision_aws_access_key }}"
     secret_key: "{{ sap_vm_provision_aws_secret_access_key }}"
-  register: instance_info
-  no_log: true
+  register: __sap_vm_provision_task_instance_info
+  no_log: "{{ __sap_vm_provision_no_log }}"
 
 - name: Set fact for available storage volume device names
   ansible.builtin.set_fact:
@@ -52,7 +52,7 @@
       {% set letters = 'bcdefghijklmnopqrstuvwxyz' %}
       {% set volumes = [] %}
       {%- for letter in letters -%}
-        {% for device in instance_info.instances[0].block_device_mappings -%}
+        {% for device in __sap_vm_provision_task_instance_info.instances[0].block_device_mappings -%}
           {% if '/dev/sd' + letter not in device.device_name -%}
             {% set dev = volumes.append('/dev/sd' + letter) %}
           {%- endif %}
@@ -96,7 +96,7 @@
 - name: Provision AWS EBS volumes for AWS EC2 Virtual Server instance filesystems
   amazon.aws.ec2_vol:
     name: "{{ inventory_hostname }}-vol_{{ vol_item.name }}"
-    instance: "{{ register_provisioned_host_single.instance_ids[0] }}"
+    instance: "{{ __sap_vm_provision_task_provisioned_host_single.instance_ids[0] }}"
     volume_type: "{{ vol_item.type }}"
     volume_size: "{{ vol_item.size }}"
     device_name: "{{ vol_item.device }}"
@@ -111,8 +111,8 @@
   when:
     - vol_item.fstype is defined
     - vol_item.size > 0
-  register: volume_provisioning
-  no_log: true
+  register: __sap_vm_provision_task_volume_provisioning
+  no_log: "{{ __sap_vm_provision_no_log }}"
 
 - name: Read AWS EC2 instance information
   amazon.aws.ec2_instance_info:
@@ -120,21 +120,21 @@
       "tag:Name": "{{ inventory_hostname }}"
     access_key: "{{ sap_vm_provision_aws_access_key }}"
     secret_key: "{{ sap_vm_provision_aws_secret_access_key }}"
-  register: instance_info
-  no_log: true
+  register: __sap_vm_provision_task_instance_info
+  no_log: "{{ __sap_vm_provision_no_log }}"
 
 - name: Add host facts
   ansible.builtin.set_fact:
     filesystem_volume_map: "{{ filesystem_volume_map }}"
-    volume_provisioning: "{{ volume_provisioning }}"
-    instance_info: "{{ instance_info }}"
+    __sap_vm_provision_task_volume_provisioning: "{{ __sap_vm_provision_task_volume_provisioning }}"
+    instance_info: "{{ __sap_vm_provision_task_instance_info }}"
   delegate_to: "{{ inventory_hostname }}"
   delegate_facts: true
-  no_log: true
+  no_log: "{{ __sap_vm_provision_no_log }}"
 
 - name: Create fact for delegate host IP
   ansible.builtin.set_fact:
-    provisioned_private_ip: "{{ register_provisioned_host_single.instances[0].private_ip_address }}"
+    provisioned_private_ip: "{{ __sap_vm_provision_task_provisioned_host_single.instances[0].private_ip_address }}"
 
 
 - name: Copy facts to delegate host
@@ -146,7 +146,7 @@
     delegate_sap_vm_provision_bastion_ssh_port: "{{ sap_vm_provision_bastion_ssh_port }}"
     delegate_sap_vm_provision_ssh_bastion_private_key_file_path: "{{ sap_vm_provision_ssh_bastion_private_key_file_path }}"
     delegate_sap_vm_provision_ssh_host_private_key_file_path: "{{ sap_vm_provision_ssh_host_private_key_file_path }}"
-    delegate_private_ip: "{{ register_provisioned_host_single.instances[0].private_ip_address }}"
+    delegate_private_ip: "{{ __sap_vm_provision_task_provisioned_host_single.instances[0].private_ip_address }}"
     delegate_hostname: "{{ inventory_hostname }}"
     delegate_sap_vm_provision_dns_root_domain_name: "{{ sap_vm_provision_dns_root_domain }}"
 
@@ -188,8 +188,8 @@
 
 - name: Append loop value to register
   ansible.builtin.set_fact:
-    register_provisioned_host_single: "{{ register_provisioned_host_single | combine( { 'host_node' : inventory_hostname } , { 'sap_host_type' : lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][scaleout_origin_host_spec | default(inventory_hostname)].sap_host_type } , { 'sap_system_type' : (lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][scaleout_origin_host_spec | default(inventory_hostname)].sap_system_type | default('')) } ) }}"
+    __sap_vm_provision_task_provisioned_host_single: "{{ __sap_vm_provision_task_provisioned_host_single | combine( { 'host_node' : inventory_hostname } , { 'sap_host_type' : lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][scaleout_origin_host_spec | default(inventory_hostname)].sap_host_type } , { 'sap_system_type' : (lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][scaleout_origin_host_spec | default(inventory_hostname)].sap_system_type | default('')) } ) }}"
 
 - name: Append output to merged register
   ansible.builtin.set_fact:
-    register_provisioned_host_all: "{{ register_provisioned_host_all + [register_provisioned_host_single] }}"
+    register_provisioned_host_all: "{{ register_provisioned_host_all + [__sap_vm_provision_task_provisioned_host_single] }}"

--- a/roles/sap_vm_provision/tasks/platform_ansible/aws_ec2_vs/execute_setup_ha.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/aws_ec2_vs/execute_setup_ha.yml
@@ -2,14 +2,19 @@
 
 - name: Gather information about AWS account
   amazon.aws.aws_caller_info:
+    access_key: "{{ sap_vm_provision_aws_access_key }}"
+    secret_key: "{{ sap_vm_provision_aws_secret_access_key }}"
   register: aws_account_info
+  no_log: true
 
 - name: Gather information about AWS VPC Route Table for the VPC Subnet
   amazon.aws.ec2_vpc_route_table_info:
     filters:
       association.subnet-id: "{{ sap_vm_provision_aws_vpc_subnet_id }}"
+    access_key: "{{ sap_vm_provision_aws_access_key }}"
+    secret_key: "{{ sap_vm_provision_aws_secret_access_key }}"
   register: aws_vpc_subnet_rt_info
-
+  no_log: true
 
 - name: Ansible AWS VPC Route Table append route for SAP HANA HA
   amazon.aws.ec2_vpc_route_table:
@@ -22,12 +27,15 @@
     routes:
       - dest: "{{ sap_ha_pacemaker_cluster_vip_hana_primary_ip_address | default('192.168.1.90/32') }}"
         instance_id: "{{ hostvars[host_node].ansible_board_asset_tag }}"
+    access_key: "{{ sap_vm_provision_aws_access_key }}"
+    secret_key: "{{ sap_vm_provision_aws_secret_access_key }}"
   loop: "{{ (groups['hana_primary'] | default([])) }}"
   loop_control:
     loop_var: host_node
   register: aws_vpc_subnet_rt_route_sap_hana
   when:
     - groups["hana_secondary"] is defined and (groups["hana_secondary"] | length>0)
+  no_log: true
 
 - name: Ansible AWS Route53 DNS Records for SAP HANA HA Virtual Hostname
   amazon.aws.route53:
@@ -39,12 +47,14 @@
     ttl: 7200
     value: "{{ (sap_ha_pacemaker_cluster_vip_hana_primary_ip_address | default('192.168.1.90/32')) | regex_replace('/.*', '') }}"
     wait: true
+    access_key: "{{ sap_vm_provision_aws_access_key }}"
+    secret_key: "{{ sap_vm_provision_aws_secret_access_key }}"
   loop: "{{ (groups['hana_primary'] | default([])) }}"
   loop_control:
     loop_var: host_node
   when:
     - groups["hana_secondary"] is defined and (groups["hana_secondary"]|length>0)
-
+  no_log: true
 
 - name: Ansible AWS VPC Route Table append route for SAP AnyDB HA
   amazon.aws.ec2_vpc_route_table:
@@ -57,12 +67,15 @@
     routes:
       - dest: "{{ sap_vm_temp_vip_anydb_primary | default('192.168.1.90/32') }}"
         instance_id: "{{ hostvars[host_node].ansible_board_asset_tag }}"
+    access_key: "{{ sap_vm_provision_aws_access_key }}"
+    secret_key: "{{ sap_vm_provision_aws_secret_access_key }}"
   loop: "{{ (groups['anydb_primary'] | default([])) }}"
   loop_control:
     loop_var: host_node
   register: aws_vpc_subnet_rt_route_sap_anydb
   when:
     - groups["anydb_secondary"] is defined and (groups["anydb_secondary"] | length>0)
+  no_log: true
 
 - name: Ansible AWS Route53 DNS Records for SAP AnyDB HA Virtual Hostname
   amazon.aws.route53:
@@ -74,12 +87,14 @@
     ttl: 7200
     value: "{{ (sap_vm_temp_vip_anydb_primary | default('192.168.1.90/32')) | regex_replace('/.*', '') }}"
     wait: true
+    access_key: "{{ sap_vm_provision_aws_access_key }}"
+    secret_key: "{{ sap_vm_provision_aws_secret_access_key }}"
   loop: "{{ (groups['anydb_primary'] | default([])) }}"
   loop_control:
     loop_var: host_node
   when:
     - groups["anydb_secondary"] is defined and (groups["anydb_secondary"]|length>0)
-
+  no_log: true
 
 - name: Ansible AWS VPC Route Table append route for SAP NetWeaver ASCS HA
   amazon.aws.ec2_vpc_route_table:
@@ -92,12 +107,15 @@
     routes:
       - dest: "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_ascs_ip_address | default('192.168.2.10/32') }}"
         instance_id: "{{ hostvars[host_node].ansible_board_asset_tag }}"
+    access_key: "{{ sap_vm_provision_aws_access_key }}"
+    secret_key: "{{ sap_vm_provision_aws_secret_access_key }}"
   loop: "{{ (groups['nwas_ascs'] | default([])) }}"
   loop_control:
     loop_var: host_node
   register: aws_vpc_subnet_rt_route_sap_netweaver_ascs
   when:
     - groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0)
+  no_log: true
 
 - name: Ansible AWS Route53 DNS Records for SAP NetWeaver ASCS HA Virtual Hostname
   amazon.aws.route53:
@@ -109,12 +127,14 @@
     ttl: 7200
     value: "{{ (sap_ha_pacemaker_cluster_vip_nwas_abap_ascs_ip_address | default('192.168.2.10/32')) | regex_replace('/.*', '') }}"
     wait: true
+    access_key: "{{ sap_vm_provision_aws_access_key }}"
+    secret_key: "{{ sap_vm_provision_aws_secret_access_key }}"
   loop: "{{ (groups['nwas_ascs'] | default([])) }}"
   loop_control:
     loop_var: host_node
   when:
     - groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
-
+  no_log: true
 
 - name: Ansible AWS VPC Route Table append route for SAP NetWeaver ERS HA
   amazon.aws.ec2_vpc_route_table:
@@ -127,12 +147,15 @@
     routes:
       - dest: "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_ers_ip_address | default('192.168.2.11/32') }}"
         instance_id: "{{ hostvars[host_node].ansible_board_asset_tag }}"
+    access_key: "{{ sap_vm_provision_aws_access_key }}"
+    secret_key: "{{ sap_vm_provision_aws_secret_access_key }}"
   loop: "{{ (groups['nwas_ers'] | default([])) }}"
   loop_control:
     loop_var: host_node
   register: aws_vpc_subnet_rt_route_sap_netweaver_ers
   when:
     - groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0)
+  no_log: true
 
 - name: Ansible AWS Route53 DNS Records for SAP NetWeaver ERS HA Virtual Hostname
   amazon.aws.route53:
@@ -144,12 +167,14 @@
     ttl: 7200
     value: "{{ (sap_ha_pacemaker_cluster_vip_nwas_abap_ers_ip_address | default('192.168.2.11/32')) | regex_replace('/.*', '') }}"
     wait: true
+    access_key: "{{ sap_vm_provision_aws_access_key }}"
+    secret_key: "{{ sap_vm_provision_aws_secret_access_key }}"
   loop: "{{ (groups['nwas_ers'] | default([])) }}"
   loop_control:
     loop_var: host_node
   when:
     - groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
-
+  no_log: true
 
 ## For HA of PAS and AAS, if required
 
@@ -240,6 +265,9 @@
               }
           ]
       }
+    access_key: "{{ sap_vm_provision_aws_access_key }}"
+    secret_key: "{{ sap_vm_provision_aws_secret_access_key }}"
+  no_log: true
 
 # AWS HA for SAP - DataProvider
 - name: AWS IAM Policy - HA-Policy-DataProvider
@@ -272,6 +300,9 @@
               }
           ]
       }
+    access_key: "{{ sap_vm_provision_aws_access_key }}"
+    secret_key: "{{ sap_vm_provision_aws_secret_access_key }}"
+  no_log: true
 
 # AWS HA for SAP - OverlayVirtualIPAgent
 - name: AWS IAM Policy - HA-Policy-OverlayVirtualIPAgent
@@ -301,6 +332,9 @@
               }
           ]
       }
+    access_key: "{{ sap_vm_provision_aws_access_key }}"
+    secret_key: "{{ sap_vm_provision_aws_secret_access_key }}"
+  no_log: true
 
 # AWS HA for SAP - STONITH of SAP HANA
 - name: AWS IAM Policy - HA-Policy-STONITH-SAPHANA
@@ -338,7 +372,10 @@
               }
           ]
       }
+    access_key: "{{ sap_vm_provision_aws_access_key }}"
+    secret_key: "{{ sap_vm_provision_aws_secret_access_key }}"
   when: groups["hana_secondary"] is defined and (groups["hana_secondary"]|length>0)
+  no_log: true
 
 # AWS HA for SAP - STONITH of SAP NWAS
 - name: AWS IAM Policy - HA-Policy-STONITH-SAPNWAS
@@ -376,8 +413,10 @@
               }
           ]
       }
+    access_key: "{{ sap_vm_provision_aws_access_key }}"
+    secret_key: "{{ sap_vm_provision_aws_secret_access_key }}"
   when: groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
-
+  no_log: true
 
 # Equivalent to
 # aws iam create-instance-profile --instance-profile-name "HA-Instance-Profile-Pacemaker-Cluster"
@@ -388,6 +427,9 @@
     name: "HA-Instance-Profile-Pacemaker-Cluster"
     role: "HA-Role-Pacemaker"
     path: "/"
+    access_key: "{{ sap_vm_provision_aws_access_key }}"
+    secret_key: "{{ sap_vm_provision_aws_secret_access_key }}"
+  no_log: true
 
 # - name: AWS IAM Instance Profile - "HA-Instance-Profile-Pacemaker-Cluster"
 #   ansible.builtin.command: aws iam create-instance-profile
@@ -405,11 +447,14 @@
   amazon.aws.ec2_instance:
     instance_ids: "{{ hostvars[host_node].ansible_board_asset_tag }}"
     iam_instance_profile: "HA-Instance-Profile-Pacemaker-Cluster"
+    access_key: "{{ sap_vm_provision_aws_access_key }}"
+    secret_key: "{{ sap_vm_provision_aws_secret_access_key }}"
   loop: "{{ [ [ groups['hana_primary'] | default([]) ] , [ groups['hana_secondary'] | default([]) ] ] | flatten | select() }}"
   loop_control:
     loop_var: host_node
   when: groups["hana_secondary"] is defined and (groups["hana_secondary"]|length>0)
   ignore_errors: true
+  no_log: true
 
 # - name: AWS EC2 Instances - attach AWS IAM Instance Profile for SAP HANA
 #   ansible.builtin.command: aws ec2 associate-iam-instance-profile
@@ -426,11 +471,14 @@
   amazon.aws.ec2_instance:
     instance_ids: "{{ hostvars[host_node].ansible_board_asset_tag }}"
     iam_instance_profile: "HA-Instance-Profile-Pacemaker-Cluster"
+    access_key: "{{ sap_vm_provision_aws_access_key }}"
+    secret_key: "{{ sap_vm_provision_aws_secret_access_key }}"
   loop: "{{ [ [ groups['nwas_ascs'] | default([]) ] , [ groups['nwas_ers'] | default([]) ] , [ groups['nwas_pas'] | default([]) ] , [ groups['nwas_aas'] | default([]) ] ] | flatten | select() }}"
   loop_control:
     loop_var: host_node
   when: groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
   ignore_errors: true
+  no_log: true
 
 # - name: AWS EC2 Instances - attach AWS IAM Instance Profile for SAP NetWeaver
 #   ansible.builtin.command: aws ec2 associate-iam-instance-profile

--- a/roles/sap_vm_provision/tasks/platform_ansible/aws_ec2_vs/execute_setup_ha.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/aws_ec2_vs/execute_setup_ha.yml
@@ -4,8 +4,8 @@
   amazon.aws.aws_caller_info:
     access_key: "{{ sap_vm_provision_aws_access_key }}"
     secret_key: "{{ sap_vm_provision_aws_secret_access_key }}"
-  register: aws_account_info
-  no_log: true
+  register: __sap_vm_provision_task_aws_account_info
+  no_log: "{{ __sap_vm_provision_no_log }}"
 
 - name: Gather information about AWS VPC Route Table for the VPC Subnet
   amazon.aws.ec2_vpc_route_table_info:
@@ -13,14 +13,14 @@
       association.subnet-id: "{{ sap_vm_provision_aws_vpc_subnet_id }}"
     access_key: "{{ sap_vm_provision_aws_access_key }}"
     secret_key: "{{ sap_vm_provision_aws_secret_access_key }}"
-  register: aws_vpc_subnet_rt_info
-  no_log: true
+  register: __sap_vm_provision_task_vpc_subnet_rt_info
+  no_log: "{{ __sap_vm_provision_no_log }}"
 
 - name: Ansible AWS VPC Route Table append route for SAP HANA HA
   amazon.aws.ec2_vpc_route_table:
     lookup: id
-    vpc_id: "{{ aws_vpc_subnet_rt_info.route_tables[0].vpc_id }}"
-    route_table_id: "{{ aws_vpc_subnet_rt_info.route_tables[0].route_table_id }}"
+    vpc_id: "{{ __sap_vm_provision_task_vpc_subnet_rt_info.route_tables[0].vpc_id }}"
+    route_table_id: "{{ __sap_vm_provision_task_vpc_subnet_rt_info.route_tables[0].route_table_id }}"
     purge_subnets: false
     purge_routes: false
     state: present
@@ -32,10 +32,10 @@
   loop: "{{ (groups['hana_primary'] | default([])) }}"
   loop_control:
     loop_var: host_node
-  register: aws_vpc_subnet_rt_route_sap_hana
+  register: __sap_vm_provision_task_vpc_subnet_rt_route_sap_hana  
   when:
     - groups["hana_secondary"] is defined and (groups["hana_secondary"] | length>0)
-  no_log: true
+  no_log: "{{ __sap_vm_provision_no_log }}"
 
 - name: Ansible AWS Route53 DNS Records for SAP HANA HA Virtual Hostname
   amazon.aws.route53:
@@ -54,13 +54,14 @@
     loop_var: host_node
   when:
     - groups["hana_secondary"] is defined and (groups["hana_secondary"]|length>0)
-  no_log: true
+  register: __sap_vm_provision_task_route53_sap_hana
+  no_log: "{{ __sap_vm_provision_no_log }}"
 
 - name: Ansible AWS VPC Route Table append route for SAP AnyDB HA
   amazon.aws.ec2_vpc_route_table:
     lookup: id
-    vpc_id: "{{ aws_vpc_subnet_rt_info.route_tables[0].vpc_id }}"
-    route_table_id: "{{ aws_vpc_subnet_rt_info.route_tables[0].route_table_id }}"
+    vpc_id: "{{ __sap_vm_provision_task_vpc_subnet_rt_info.route_tables[0].vpc_id }}"
+    route_table_id: "{{ __sap_vm_provision_task_vpc_subnet_rt_info.route_tables[0].route_table_id }}"
     purge_subnets: false
     purge_routes: false
     state: present
@@ -72,10 +73,10 @@
   loop: "{{ (groups['anydb_primary'] | default([])) }}"
   loop_control:
     loop_var: host_node
-  register: aws_vpc_subnet_rt_route_sap_anydb
+  register: __sap_vm_provision_task_vpc_subnet_rt_route_sap_anydb
   when:
     - groups["anydb_secondary"] is defined and (groups["anydb_secondary"] | length>0)
-  no_log: true
+  no_log: "{{ __sap_vm_provision_no_log }}"
 
 - name: Ansible AWS Route53 DNS Records for SAP AnyDB HA Virtual Hostname
   amazon.aws.route53:
@@ -94,13 +95,14 @@
     loop_var: host_node
   when:
     - groups["anydb_secondary"] is defined and (groups["anydb_secondary"]|length>0)
-  no_log: true
+  register: __sap_vm_provision_task_route53_sap_anydb
+  no_log: "{{ __sap_vm_provision_no_log }}"
 
 - name: Ansible AWS VPC Route Table append route for SAP NetWeaver ASCS HA
   amazon.aws.ec2_vpc_route_table:
     lookup: id
-    vpc_id: "{{ aws_vpc_subnet_rt_info.route_tables[0].vpc_id }}"
-    route_table_id: "{{ aws_vpc_subnet_rt_info.route_tables[0].route_table_id }}"
+    vpc_id: "{{ __sap_vm_provision_task_vpc_subnet_rt_info.route_tables[0].vpc_id }}"
+    route_table_id: "{{ __sap_vm_provision_task_vpc_subnet_rt_info.route_tables[0].route_table_id }}"
     purge_subnets: false
     purge_routes: false
     state: present
@@ -112,10 +114,10 @@
   loop: "{{ (groups['nwas_ascs'] | default([])) }}"
   loop_control:
     loop_var: host_node
-  register: aws_vpc_subnet_rt_route_sap_netweaver_ascs
+  register: __sap_vm_provision_task_vpc_subnet_rt_route_sap_netweaver_ascs  
   when:
     - groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0)
-  no_log: true
+  no_log: "{{ __sap_vm_provision_no_log }}"
 
 - name: Ansible AWS Route53 DNS Records for SAP NetWeaver ASCS HA Virtual Hostname
   amazon.aws.route53:
@@ -134,13 +136,14 @@
     loop_var: host_node
   when:
     - groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
-  no_log: true
+  register: __sap_vm_provision_task_route53_sap_netweaver_ascs
+  no_log: "{{ __sap_vm_provision_no_log }}"
 
 - name: Ansible AWS VPC Route Table append route for SAP NetWeaver ERS HA
   amazon.aws.ec2_vpc_route_table:
     lookup: id
-    vpc_id: "{{ aws_vpc_subnet_rt_info.route_tables[0].vpc_id }}"
-    route_table_id: "{{ aws_vpc_subnet_rt_info.route_tables[0].route_table_id }}"
+    vpc_id: "{{ __sap_vm_provision_task_vpc_subnet_rt_info.route_tables[0].vpc_id }}"
+    route_table_id: "{{ __sap_vm_provision_task_vpc_subnet_rt_info.route_tables[0].route_table_id }}"
     purge_subnets: false
     purge_routes: false
     state: present
@@ -152,10 +155,10 @@
   loop: "{{ (groups['nwas_ers'] | default([])) }}"
   loop_control:
     loop_var: host_node
-  register: aws_vpc_subnet_rt_route_sap_netweaver_ers
+  register: __sap_vm_provision_task_vpc_subnet_rt_route_sap_netweaver_ers
   when:
     - groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0)
-  no_log: true
+  no_log: "{{ __sap_vm_provision_no_log }}"
 
 - name: Ansible AWS Route53 DNS Records for SAP NetWeaver ERS HA Virtual Hostname
   amazon.aws.route53:
@@ -174,15 +177,16 @@
     loop_var: host_node
   when:
     - groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
-  no_log: true
+  register: __sap_vm_provision_task_route53_sap_netweaver_ers
+  no_log: "{{ __sap_vm_provision_no_log }}"
 
 ## For HA of PAS and AAS, if required
 
 # - name: Ansible AWS VPC Route Table append route for SAP NetWeaver PAS HA
 #   amazon.aws.ec2_vpc_route_table:
 #     lookup: id
-#     vpc_id: "{{ aws_vpc_subnet_rt_info.route_tables[0].vpc_id }}"
-#     route_table_id: "{{ aws_vpc_subnet_rt_info.route_tables[0].route_table_id }}"
+#     vpc_id: "{{ __sap_vm_provision_task_vpc_subnet_rt_info.route_tables[0].vpc_id }}"
+#     route_table_id: "{{ __sap_vm_provision_task_vpc_subnet_rt_info.route_tables[0].route_table_id }}"
 #     purge_subnets: false
 #     purge_routes: false
 #     state: present
@@ -216,8 +220,8 @@
 # - name: Ansible AWS VPC Route Table append route for SAP NetWeaver AAS HA
 #   amazon.aws.ec2_vpc_route_table:
 #     lookup: id
-#     vpc_id: "{{ aws_vpc_subnet_rt_info.route_tables[0].vpc_id }}"
-#     route_table_id: "{{ aws_vpc_subnet_rt_info.route_tables[0].route_table_id }}"
+#     vpc_id: "{{ __sap_vm_provision_task_vpc_subnet_rt_info.route_tables[0].vpc_id }}"
+#     route_table_id: "{{ __sap_vm_provision_task_vpc_subnet_rt_info.route_tables[0].route_table_id }}"
 #     purge_subnets: false
 #     purge_routes: false
 #     state: present
@@ -267,7 +271,8 @@
       }
     access_key: "{{ sap_vm_provision_aws_access_key }}"
     secret_key: "{{ sap_vm_provision_aws_secret_access_key }}"
-  no_log: true
+  register: __sap_vm_provision_task_iam_role_ha_pacemaker
+  no_log: "{{ __sap_vm_provision_no_log }}"
 
 # AWS HA for SAP - DataProvider
 - name: AWS IAM Policy - HA-Policy-DataProvider
@@ -302,7 +307,8 @@
       }
     access_key: "{{ sap_vm_provision_aws_access_key }}"
     secret_key: "{{ sap_vm_provision_aws_secret_access_key }}"
-  no_log: true
+  register: __sap_vm_provision_task_iam_policy_dataprovider
+  no_log: "{{ __sap_vm_provision_no_log }}"
 
 # AWS HA for SAP - OverlayVirtualIPAgent
 - name: AWS IAM Policy - HA-Policy-OverlayVirtualIPAgent
@@ -328,13 +334,14 @@
                       "ec2:ReplaceRoute"
                   ],
                   "Effect": "Allow",
-                  "Resource": "arn:aws:ec2:{{ sap_vm_provision_aws_region }}:{{ aws_account_info.account }}:route-table/{{ aws_vpc_subnet_rt_info.route_tables[0].route_table_id }}"
+                  "Resource": "arn:aws:ec2:{{ sap_vm_provision_aws_region }}:{{ __sap_vm_provision_task_aws_account_info.account }}:route-table/{{ __sap_vm_provision_task_vpc_subnet_rt_info.route_tables[0].route_table_id }}"
               }
           ]
       }
     access_key: "{{ sap_vm_provision_aws_access_key }}"
     secret_key: "{{ sap_vm_provision_aws_secret_access_key }}"
-  no_log: true
+  register: __sap_vm_provision_task_iam_policy_overlayip
+  no_log: "{{ __sap_vm_provision_no_log }}"
 
 # AWS HA for SAP - STONITH of SAP HANA
 - name: AWS IAM Policy - HA-Policy-STONITH-SAPHANA
@@ -366,8 +373,8 @@
                       "ec2:StopInstances"
                   ],
                   "Resource": [
-                      "arn:aws:ec2:{{ sap_vm_provision_aws_region }}:{{ aws_account_info.account }}:instance/{{ hostvars[groups['hana_primary'][0]].ansible_host }}",
-                      "arn:aws:ec2:{{ sap_vm_provision_aws_region }}:{{ aws_account_info.account }}:instance/{{ hostvars[groups['hana_secondary'][0]].ansible_host }}"
+                      "arn:aws:ec2:{{ sap_vm_provision_aws_region }}:{{ __sap_vm_provision_task_aws_account_info.account }}:instance/{{ hostvars[groups['hana_primary'][0]].ansible_host }}",
+                      "arn:aws:ec2:{{ sap_vm_provision_aws_region }}:{{ __sap_vm_provision_task_aws_account_info.account }}:instance/{{ hostvars[groups['hana_secondary'][0]].ansible_host }}"
                   ]
               }
           ]
@@ -375,7 +382,8 @@
     access_key: "{{ sap_vm_provision_aws_access_key }}"
     secret_key: "{{ sap_vm_provision_aws_secret_access_key }}"
   when: groups["hana_secondary"] is defined and (groups["hana_secondary"]|length>0)
-  no_log: true
+  register: __sap_vm_provision_task_iam_policy_stonith_saphana
+  no_log: "{{ __sap_vm_provision_no_log }}"
 
 # AWS HA for SAP - STONITH of SAP NWAS
 - name: AWS IAM Policy - HA-Policy-STONITH-SAPNWAS
@@ -383,7 +391,7 @@
     state: present
     iam_type: role
     iam_name: "HA-Role-Pacemaker"
-    policy_name: "HA-Policy-STONITH-SAPHANA"
+    policy_name: "HA-Policy-STONITH-SAPNWAS"
     policy_json: |
       {
           "Version": "2012-10-17",
@@ -407,8 +415,8 @@
                       "ec2:StopInstances"
                   ],
                   "Resource": [
-                      "arn:aws:ec2:{{ sap_vm_provision_aws_region }}:{{ aws_account_info.account }}:instance/{{ hostvars[groups['nwas_ascs'][0]].ansible_host }}",
-                      "arn:aws:ec2:{{ sap_vm_provision_aws_region }}:{{ aws_account_info.account }}:instance/{{ hostvars[groups['nwas_ers'][0]].ansible_host }}"
+                      "arn:aws:ec2:{{ sap_vm_provision_aws_region }}:{{ __sap_vm_provision_task_aws_account_info.account }}:instance/{{ hostvars[groups['nwas_ascs'][0]].ansible_host }}",
+                      "arn:aws:ec2:{{ sap_vm_provision_aws_region }}:{{ __sap_vm_provision_task_aws_account_info.account }}:instance/{{ hostvars[groups['nwas_ers'][0]].ansible_host }}"
                   ]
               }
           ]
@@ -416,7 +424,8 @@
     access_key: "{{ sap_vm_provision_aws_access_key }}"
     secret_key: "{{ sap_vm_provision_aws_secret_access_key }}"
   when: groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
-  no_log: true
+  register: __sap_vm_provision_task_iam_policy_stonith_sapnwas
+  no_log: "{{ __sap_vm_provision_no_log }}"
 
 # Equivalent to
 # aws iam create-instance-profile --instance-profile-name "HA-Instance-Profile-Pacemaker-Cluster"
@@ -429,7 +438,8 @@
     path: "/"
     access_key: "{{ sap_vm_provision_aws_access_key }}"
     secret_key: "{{ sap_vm_provision_aws_secret_access_key }}"
-  no_log: true
+  register: __sap_vm_provision_task_iam_attach_role
+  no_log: "{{ __sap_vm_provision_no_log }}"
 
 # - name: AWS IAM Instance Profile - "HA-Instance-Profile-Pacemaker-Cluster"
 #   ansible.builtin.command: aws iam create-instance-profile
@@ -454,7 +464,8 @@
     loop_var: host_node
   when: groups["hana_secondary"] is defined and (groups["hana_secondary"]|length>0)
   ignore_errors: true
-  no_log: true
+  register: __sap_vm_provision_task_iam_attach_instance_saphana
+  no_log: "{{ __sap_vm_provision_no_log }}"
 
 # - name: AWS EC2 Instances - attach AWS IAM Instance Profile for SAP HANA
 #   ansible.builtin.command: aws ec2 associate-iam-instance-profile
@@ -478,7 +489,8 @@
     loop_var: host_node
   when: groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
   ignore_errors: true
-  no_log: true
+  register: __sap_vm_provision_task_iam_attach_instance_sapnwas
+  no_log: "{{ __sap_vm_provision_no_log }}"
 
 # - name: AWS EC2 Instances - attach AWS IAM Instance Profile for SAP NetWeaver
 #   ansible.builtin.command: aws ec2 associate-iam-instance-profile


### PR DESCRIPTION
PR covers following enhancements:
https://github.com/sap-linuxlab/community.sap_infrastructure/issues/1 
- no_log: "{{ __sap_vm_provision_no_log }}" to hide secrets in -vvv debug mode
- access_key and secret_key were added directly into aws modules because of point above
- region was not added into modules, because Route53 module requires extra parameter interpreter. Region is kept as environment variable.

Additionally covered:
- S-User password assignment in var task is hidden with no_log: true
- Platform guidance was updated with detailed breakdown of IAM Actions as additional option for IAM Policy setup to enhance security.

Rescue block added for failed awscli calls.