### PR TITLE
sap_hypervisor_node_preconfigure: replace use of oc with kubernetes.core.k8s

### DIFF
--- a/.github/workflows/ansible-lint-sap_hypervisor_node_preconfigure.yml
+++ b/.github/workflows/ansible-lint-sap_hypervisor_node_preconfigure.yml
@@ -37,6 +37,7 @@ jobs:
           pip3 install ansible-compat==3.0.2
           pip3 install ansible-core==2.14.5
           pip3 install ansible-lint==6.8.6
+          pip3 install jmespath==1.0.1
 
       - name: Run ansible-lint
         working-directory: /home/runner/work/community.sap_infrastructure/community.sap_infrastructure/roles/sap_hypervisor_node_preconfigure

--- a/roles/sap_hypervisor_node_preconfigure/tasks/platform/redhat_ocp_virt/configure-worker-node.yml
+++ b/roles/sap_hypervisor_node_preconfigure/tasks/platform/redhat_ocp_virt/configure-worker-node.yml
@@ -1,9 +1,4 @@
 ---
-- name: Label nodes
-  ansible.builtin.command: "oc label node {{ __sap_hypervisor_node_preconfigure_register_worker.name }} cpumanager=true --overwrite=true"
-  register: __sap_hypervisor_node_preconfigure_label_node_result
-  changed_when: __sap_hypervisor_node_preconfigure_label_node_result.rc != 0
-
 - name: Include node network
   ansible.builtin.include_tasks: node-network.yml
   with_items: "{{ __sap_hypervisor_node_preconfigure_register_worker.networks }}"
@@ -14,6 +9,17 @@
 
 # How to wait for node to be scheduleable? (NodeSchedulable)
 - name: Wait for all k8s nodes to be ready
-  ansible.builtin.command: oc wait --for=condition=Ready nodes --all --timeout=3600s
-  register: __sap_hypervisor_node_preconfigure_register_nodes_ready
-  changed_when: __sap_hypervisor_node_preconfigure_register_nodes_ready.rc != 0
+  kubernetes.core.k8s_info:
+    kind: Node
+  register: __sap_hypervisor_node_preconfigure_register_nodes
+  until: __sap_hypervisor_node_preconfigure_register_nodes.resources | json_query('[?status.conditions[?type==`Ready` && status==`True`]].metadata.name') | length == __sap_hypervisor_node_preconfigure_register_nodes.resources | length
+  retries: 180
+  delay: 20
+  ignore_errors: True
+  changed_when: false
+
+- name: Check and fail if any node is not ready
+  fail:
+    msg: "Node '{{ item.metadata.name }}' is not ready."
+  loop: "{{ __sap_hypervisor_node_preconfigure_register_nodes.resources }}"
+  when: not item.status.conditions | selectattr('type', 'equalto', 'Ready') | map(attribute='status') | list | first == 'True'

--- a/roles/sap_hypervisor_node_preconfigure/tasks/platform/redhat_ocp_virt/install-cnv-operator.yml
+++ b/roles/sap_hypervisor_node_preconfigure/tasks/platform/redhat_ocp_virt/install-cnv-operator.yml
@@ -40,19 +40,44 @@
   ansible.builtin.pause:
     seconds: 300
 
-- name: Get Install Plan Name
+- name: Get Install Plan Name from Subscription
   retries: 10
   delay: 10
-  ansible.builtin.command: oc get subscriptions/hco-operatorhub --namespace openshift-cnv --output=jsonpath='{$.status.installplan.name}'
+  kubernetes.core.k8s_info:
+    api_version: operators.coreos.com/v1alpha1
+    kind: Subscription
+    name: hco-operatorhub
+    namespace: openshift-cnv
   register: __sap_hypervisor_node_preconfigure_register_cnv_subscription_install_plan_name
-  until: __sap_hypervisor_node_preconfigure_register_cnv_subscription_install_plan_name.stdout != ""
-  changed_when: __sap_hypervisor_node_preconfigure_register_cnv_subscription_install_plan_name.stdout != ""
+  until: __sap_hypervisor_node_preconfigure_register_cnv_subscription_install_plan_name.resources[0].status.installPlanRef.name is defined
+  changed_when: true
+
+- name: Set Install Plan Name
+  set_fact:
+    install_plan_name: "{{ __sap_hypervisor_node_preconfigure_register_cnv_subscription_install_plan_name.resources[0].status.installPlanRef.name }}"
+
 
 - name: Wait for Install Plan to finish
-  ansible.builtin.command: "oc wait installplan \
-    {{ __sap_hypervisor_node_preconfigure_register_cnv_subscription_install_plan_name.stdout }} --namespace openshift-cnv --for=condition='Installed' --timeout='5m'"
-  register: __sap_hypervisor_node_preconfigure_register_wait_for_installplan
-  changed_when: __sap_hypervisor_node_preconfigure_register_wait_for_installplan.rc != 0
+  vars:
+    install_plan_name: "{{ __sap_hypervisor_node_preconfigure_register_cnv_subscription_install_plan_name.stdout }}"
+    namespace: "openshift-cnv"
+  block:
+    - name: Get Install Plan details
+      kubernetes.core.k8s_info:
+        api_version: operators.coreos.com/v1alpha1
+        kind: InstallPlan
+        name: "{{ install_plan_name }}"
+        namespace: "{{ namespace }}"
+      register: __sap_hypervisor_node_preconfigure_register_wait_for_installplan
+      until: __sap_hypervisor_node_preconfigure_register_wait_for_installplan.resources[0].status.phase == "Complete"
+      retries: 60
+      delay: 5
+      ignore_errors: yes
+
+    - name: Fail if Install Plan is not Complete after waiting
+      ansible.builtin.fail:
+        msg: "Install Plan is not Complete after the specified wait period."
+      when: __sap_hypervisor_node_preconfigure_register_wait_for_installplan.resources[0].status.phase != "Complete"
 
 - name: Wait
   ansible.builtin.pause:

--- a/roles/sap_hypervisor_node_preconfigure/tasks/platform/redhat_ocp_virt/main.yml
+++ b/roles/sap_hypervisor_node_preconfigure/tasks/platform/redhat_ocp_virt/main.yml
@@ -87,13 +87,20 @@
 
 # How to wait for node to be scheduleable? (NodeSchedulable)
 - name: Wait for all k8s nodes to be ready
-  ansible.builtin.command: oc wait --for=condition=Ready nodes --all --timeout=3600s
-  register: __sap_hypervisor_node_preconfigure_register_nodes_ready
-  changed_when: __sap_hypervisor_node_preconfigure_register_nodes_ready.rc != 0
+  kubernetes.core.k8s_info:
+    kind: Node
+  register: __sap_hypervisor_node_preconfigure_register_nodes
+  until: __sap_hypervisor_node_preconfigure_register_nodes.resources | json_query('[?status.conditions[?type==`Ready` && status==`True`]].metadata.name') | length == __sap_hypervisor_node_preconfigure_register_nodes.resources | length
+  retries: 180
+  delay: 20
+  ignore_errors: True
+  changed_when: false
 
-- name: Print nodes
-  ansible.builtin.debug:
-    var: __sap_hypervisor_node_preconfigure_register_nodes_ready.stdout_lines
+- name: Check and fail if any node is not ready
+  fail:
+    msg: "Node '{{ item.metadata.name }}' is not ready."
+  loop: "{{ __sap_hypervisor_node_preconfigure_register_nodes.resources }}"
+  when: not item.status.conditions | selectattr('type', 'equalto', 'Ready') | map(attribute='status') | list | first == 'True'
 
 - name: Include Trident installation
   ansible.builtin.include_tasks: "platform/{{ sap_hypervisor_node_platform }}/install-trident.yml"


### PR DESCRIPTION
roles/sap_hypervisor_node_preconfigure/tasks/platform/redhat_ocp_virt/main.yml
- Check and fail is added if any node is not available

roles/sap_hypervisor_node_preconfigure/tasks/platform/redhat_ocp_virt/configure-worker-node.yml
- Check and fail is added if any node is not available
- Change oc label node to use kubernetes.core