### PR TITLE
[sap_hypervisor_node_preconfigure][Platform OCPv] patch masters unschedulable

### DIFF
--- a/roles/sap_hypervisor_node_preconfigure/tasks/platform/redhat_ocp_virt/main.yml
+++ b/roles/sap_hypervisor_node_preconfigure/tasks/platform/redhat_ocp_virt/main.yml
@@ -81,8 +81,6 @@
 - name: Include install virtctl
   ansible.builtin.include_tasks: "platform/{{ sap_hypervisor_node_platform }}/install-virtctl.yml"
 
-- debug: var=sap_hypervisor_node_preconfigure_setup_worker_nodes
-
 - name: Include setup worker nodes
   ansible.builtin.include_tasks: "platform/{{ sap_hypervisor_node_platform }}/setup-worker-nodes.yml"
   when: sap_hypervisor_node_preconfigure_setup_worker_nodes

--- a/roles/sap_hypervisor_node_preconfigure/tasks/platform/redhat_ocp_virt/main.yml
+++ b/roles/sap_hypervisor_node_preconfigure/tasks/platform/redhat_ocp_virt/main.yml
@@ -63,6 +63,9 @@
 - name: Include prepare
   ansible.builtin.include_tasks: "platform/{{ sap_hypervisor_node_platform }}/prepare.yml"
 
+- name: Include patch cluster masters unschedulable
+  ansible.builtin.include_tasks: "platform/{{ sap_hypervisor_node_platform }}/patch-cluster-masters-unschedulable.ymle.yml"
+
 - name: Include tuned virtual host
   ansible.builtin.include_tasks: "platform/{{ sap_hypervisor_node_platform }}/tuned-virtual-host.yml"
 

--- a/roles/sap_hypervisor_node_preconfigure/tasks/platform/redhat_ocp_virt/main.yml
+++ b/roles/sap_hypervisor_node_preconfigure/tasks/platform/redhat_ocp_virt/main.yml
@@ -81,9 +81,11 @@
 - name: Include install virtctl
   ansible.builtin.include_tasks: "platform/{{ sap_hypervisor_node_platform }}/install-virtctl.yml"
 
+- debug: var=sap_hypervisor_node_preconfigure_setup_worker_nodes
+
 - name: Include setup worker nodes
   ansible.builtin.include_tasks: "platform/{{ sap_hypervisor_node_platform }}/setup-worker-nodes.yml"
-  when: sap_hypervisor_node_preconfigure_setup_workers
+  when: sap_hypervisor_node_preconfigure_setup_worker_nodes
 
 # How to wait for node to be scheduleable? (NodeSchedulable)
 - name: Wait for all k8s nodes to be ready

--- a/roles/sap_hypervisor_node_preconfigure/tasks/platform/redhat_ocp_virt/patch-cluster-masters-unschedulable.yml
+++ b/roles/sap_hypervisor_node_preconfigure/tasks/platform/redhat_ocp_virt/patch-cluster-masters-unschedulable.yml
@@ -1,0 +1,10 @@
+- name: Set cluster master nodes unscheduable
+  kubernetes.core.k8s:
+    state: patched
+    definition:
+      apiVersion: config.openshift.io/v1
+      kind: Scheduler
+#      metadata:
+#        name: cluster
+      spec:
+        mastersSchedulable: false

--- a/roles/sap_hypervisor_node_preconfigure/tasks/platform/redhat_ocp_virt/patch-cluster-masters-unschedulable.yml
+++ b/roles/sap_hypervisor_node_preconfigure/tasks/platform/redhat_ocp_virt/patch-cluster-masters-unschedulable.yml
@@ -4,7 +4,7 @@
     definition:
       apiVersion: config.openshift.io/v1
       kind: Scheduler
-#      metadata:
-#        name: cluster
+      metadata:
+        name: cluster
       spec:
         mastersSchedulable: false

--- a/roles/sap_hypervisor_node_preconfigure/vars/platform_defaults_redhat_ocp_virt.yml
+++ b/roles/sap_hypervisor_node_preconfigure/vars/platform_defaults_redhat_ocp_virt.yml
@@ -9,7 +9,7 @@ sap_hypervisor_node_preconfigure_install_hpp: false
 sap_hypervisor_node_preconfigure_install_trident: false
 
 # URL of the trident installer package to use
-sap_hypervisor_node_preconfigure_install_trident_url: https://github.com/NetApp/trident/releases/download/v23.01.0/trident-installer-23.01.0.tar.gz
+sap_hypervisor_node_preconfigure_install_trident_url: https://github.com/NetApp/trident/releases/download/v23.10.0/trident-installer-23.10.0.tar.gz
 
 # should SRIOV be enabled for unsupported NICs
 sap_hypervisor_node_preconfigure_sriov_enable_unsupported_nics: true
@@ -27,4 +27,4 @@ sap_hypervisor_node_preconfigure_ignore_minimal_memory_check: false
 sap_hypervisor_node_preconfigure_install_operators: true
 
 # Configure the workers?
-sap_hypervisor_node_preconfigure_setup_workers: true
+sap_hypervisor_node_preconfigure_setup_worker_nodes: true


### PR DESCRIPTION
The master nodes are set to unschedulable so that no workload ends up running there