### PR TITLE
sap_hypervisor_node_preconfigure: platform OCPv patch masters unschedulable

### DIFF
--- a/roles/sap_hypervisor_node_preconfigure/tasks/platform/redhat_ocp_virt/main.yml
+++ b/roles/sap_hypervisor_node_preconfigure/tasks/platform/redhat_ocp_virt/main.yml
@@ -63,6 +63,9 @@
 - name: Include prepare
   ansible.builtin.include_tasks: "platform/{{ sap_hypervisor_node_platform }}/prepare.yml"
 
+- name: Include patch cluster masters unschedulable
+  ansible.builtin.include_tasks: "platform/{{ sap_hypervisor_node_platform }}/patch-cluster-masters-unschedulable.ymle.yml"
+
 - name: Include tuned virtual host
   ansible.builtin.include_tasks: "platform/{{ sap_hypervisor_node_platform }}/tuned-virtual-host.yml"
 

--- a/roles/sap_hypervisor_node_preconfigure/tasks/platform/redhat_ocp_virt/main.yml
+++ b/roles/sap_hypervisor_node_preconfigure/tasks/platform/redhat_ocp_virt/main.yml
@@ -64,7 +64,7 @@
   ansible.builtin.include_tasks: "platform/{{ sap_hypervisor_node_platform }}/prepare.yml"
 
 - name: Include patch cluster masters unschedulable
-  ansible.builtin.include_tasks: "platform/{{ sap_hypervisor_node_platform }}/patch-cluster-masters-unschedulable.ymle.yml"
+  ansible.builtin.include_tasks: "platform/{{ sap_hypervisor_node_platform }}/patch-cluster-masters-unschedulable.yml"
 
 - name: Include tuned virtual host
   ansible.builtin.include_tasks: "platform/{{ sap_hypervisor_node_platform }}/tuned-virtual-host.yml"

--- a/roles/sap_hypervisor_node_preconfigure/tasks/platform/redhat_ocp_virt/patch-cluster-masters-unschedulable.yml
+++ b/roles/sap_hypervisor_node_preconfigure/tasks/platform/redhat_ocp_virt/patch-cluster-masters-unschedulable.yml
@@ -1,3 +1,4 @@
+---
 - name: Set cluster master nodes unscheduable
   kubernetes.core.k8s:
     state: patched

--- a/roles/sap_hypervisor_node_preconfigure/tasks/platform/redhat_ocp_virt/patch-cluster-masters-unschedulable.yml
+++ b/roles/sap_hypervisor_node_preconfigure/tasks/platform/redhat_ocp_virt/patch-cluster-masters-unschedulable.yml
@@ -1,0 +1,10 @@
+- name: Set cluster master nodes unscheduable
+  kubernetes.core.k8s:
+    state: patched
+    definition:
+      apiVersion: config.openshift.io/v1
+      kind: Scheduler
+#      metadata:
+#        name: cluster
+      spec:
+        mastersSchedulable: false

--- a/roles/sap_hypervisor_node_preconfigure/tasks/platform/redhat_ocp_virt/patch-cluster-masters-unschedulable.yml
+++ b/roles/sap_hypervisor_node_preconfigure/tasks/platform/redhat_ocp_virt/patch-cluster-masters-unschedulable.yml
@@ -4,7 +4,7 @@
     definition:
       apiVersion: config.openshift.io/v1
       kind: Scheduler
-#      metadata:
-#        name: cluster
+      metadata:
+        name: cluster
       spec:
         mastersSchedulable: false


### PR DESCRIPTION
The master nodes are set to unschedulable so that no workload ends up running there.