### PR TITLE
sap_vm_provision: nolog changes for all platforms

### DIFF
--- a/roles/sap_vm_provision/defaults/main.yml
+++ b/roles/sap_vm_provision/defaults/main.yml
@@ -573,3 +573,8 @@ sap_vm_provision_vmware_vm_host_specifications_dictionary:
           disk_count: 1                  # default: 1
           disk_size: 512                 # size in GB, integer
           disk_type: scsi                # VMware Virtual Disk Node (scsi, ide, sata)
+
+
+# Default to prevent Infrastructure Platform credential secrets leaking
+# This should only be amended for debugging
+__sap_vm_provision_no_log: true

--- a/roles/sap_vm_provision/tasks/common/set_ansible_vars.yml
+++ b/roles/sap_vm_provision/tasks/common/set_ansible_vars.yml
@@ -6,10 +6,13 @@
     sap_vm_provision_host_specification_plan: "{{ sap_vm_provision_host_specification_plan }}"
     sap_vm_provision_nfs_mount_point: "{{ sap_vm_provision_nfs_mount_point | default('') }}"
     sap_vm_provision_nfs_mount_point_separate_sap_transport_dir: "{{ sap_vm_provision_nfs_mount_point_separate_sap_transport_dir | default('') }}"
-    sap_id_user: "{{ sap_id_user | default('') }}"
-    sap_id_user_password: "{{ sap_id_user_password | default('') }}"
     sap_software_download_directory: "{{ sap_software_download_directory | default('/software') }}"
     sap_install_media_detect_source_directory: "{{ sap_software_download_directory | default('/software') }}"
+
+- name: Set facts for all hosts - use facts from localhost - Generic - SAP ID
+  ansible.builtin.set_fact:
+    sap_id_user: "{{ sap_id_user | default('') }}"
+    sap_id_user_password: "{{ sap_id_user_password | default('') }}"
   no_log: "{{ __sap_vm_provision_no_log }}"
 
 # - name: Set facts for all hosts - use facts from localhost - Ansible only
@@ -60,6 +63,7 @@
 #     - sap_ha_pacemaker_cluster_gcp_region_zone is defined
 #     - sap_vm_provision_iac_type == "ansible"
 #     - sap_vm_provision_iac_platform == "gcp_ce_vm"
+#   no_log: "{{ __sap_vm_provision_no_log }}"
 
 - name: Set facts for all hosts - use facts from localhost - HA/DR - IBM Cloud, IBM Power VS
   ansible.builtin.set_fact:
@@ -69,6 +73,7 @@
   when:
     - sap_ha_pacemaker_cluster_ibmcloud_api_key is defined
     - sap_vm_provision_iac_platform == "ibmcloud_powervs"
+  no_log: "{{ __sap_vm_provision_no_log }}"
 
 - name: Set facts for all hosts - use facts from localhost - HA/DR - IBM Cloud
   ansible.builtin.set_fact:
@@ -77,13 +82,15 @@
   when:
     - sap_ha_pacemaker_cluster_ibmcloud_region is defined
     - sap_vm_provision_iac_platform == "ibmcloud_vs"
+  no_log: "{{ __sap_vm_provision_no_log }}"
 
-  #  - name: Set facts for all hosts - use facts from localhost - HA/DR - MS Azure
-  #    ansible.builtin.set_fact:
-  #    when:
-  #     - sap_ha_pacemaker_cluster_msazure_resource_group is defined
-  #     - sap_vm_provision_iac_type == "ansible"
-  #     - sap_vm_provision_iac_platform == "msazure_vm"
+# - name: Set facts for all hosts - use facts from localhost - HA/DR - MS Azure
+#   ansible.builtin.set_fact:
+#   when:
+#     - sap_ha_pacemaker_cluster_msazure_resource_group is defined
+#     - sap_vm_provision_iac_type == "ansible"
+#     - sap_vm_provision_iac_platform == "msazure_vm"
+#   no_log: "{{ __sap_vm_provision_no_log }}"
 
 # - name: Set facts for all hosts - use facts from localhost - HA/DR - IBM PowerVM
 #   ansible.builtin.set_fact:
@@ -91,6 +98,7 @@
 #     - sap_ha_pacemaker_cluster_ibmpower_vm_hmc_host is defined
 #     - sap_vm_provision_iac_type == "ansible"
 #     - sap_vm_provision_iac_platform == "ibmpowervm_vm"
+#   no_log: "{{ __sap_vm_provision_no_log }}"
 
 # - name: Set facts for all hosts - use facts from localhost - HA/DR - KubeVirt
 #   ansible.builtin.set_fact:
@@ -98,6 +106,7 @@
 #     - sap_ha_pacemaker_cluster___ is defined
 #     - sap_vm_provision_iac_type == "ansible"
 #     - sap_vm_provision_iac_platform == "kubevirt_vm"
+#   no_log: "{{ __sap_vm_provision_no_log }}"
 
 # - name: Set facts for all hosts - use facts from localhost - HA/DR - OVirt
 #   ansible.builtin.set_fact:
@@ -105,6 +114,7 @@
 #     - sap_ha_pacemaker_cluster_aws_region is defined
 #     - sap_vm_provision_iac_type == "ansible"
 #     - sap_vm_provision_iac_platform == "ovirt_vm"
+#   no_log: "{{ __sap_vm_provision_no_log }}"
 
 # - name: Set facts for all hosts - use facts from localhost - HA/DR - VMware
 #   ansible.builtin.set_fact:
@@ -112,6 +122,7 @@
 #     - sap_ha_pacemaker_cluster_aws_region is defined
 #     - sap_vm_provision_iac_type == "ansible"
 #     - sap_vm_provision_iac_platform == "vmware_vm"
+#   no_log: "{{ __sap_vm_provision_no_log }}"
 
 - name: Set facts for all hosts - IBM Power (ppc64le) only
   ansible.builtin.set_fact:

--- a/roles/sap_vm_provision/tasks/platform_ansible/aws_ec2_vs/execute_main.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/aws_ec2_vs/execute_main.yml
@@ -66,7 +66,7 @@
         groups_merged_list: "{{ [ [ groups['hana_primary'] | default([]) ] , [ groups['hana_secondary'] | default([]) ] , [ groups['nwas_ascs'] | default([]) ] , [ groups['nwas_ers'] | default([]) ] , [ groups['nwas_pas'] | default([]) ] , [ groups['nwas_aas'] | default([]) ] ] | flatten | select() }}"
 
     - name: Set Ansible Vars
-      register: register_set_ansible_vars
+      register: __sap_vm_provision_task_ansible_vars_set
       ansible.builtin.include_tasks:
         file: common/set_ansible_vars.yml
 
@@ -128,26 +128,26 @@
         name: "{{ inventory_hostname_short }}"
 
     - name: Set /etc/hosts
-      register: register_etc_hosts_file
+      register: __sap_vm_provision_task_os_etc_hosts
       ansible.builtin.include_tasks:
         file: common/set_etc_hosts.yml
 
     - name: Set /etc/hosts for HA
-      register: register_etc_hosts_file_ha
+      register: __sap_vm_provision_task_os_etc_hosts_ha
       ansible.builtin.include_tasks:
         file: common/set_etc_hosts_ha.yml
       when:
         - (groups["hana_secondary"] is defined and (groups["hana_secondary"] | length>0)) or (groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0)) or (groups["anydb_secondary"] is defined and (groups["anydb_secondary"] | length>0))
 
     - name: Set /etc/hosts for Scale-Out
-      register: register_etc_hosts_file_scaleout
+      register: __sap_vm_provision_task_os_etc_hosts_scaleout
       ansible.builtin.include_tasks:
         file: common/set_etc_hosts_scaleout.yml
       when:
         - (groups["hana_primary"] is defined and (groups["hana_primary"] | length>0)) and (sap_hana_scaleout_active_coordinator is defined or sap_hana_scaleout_active_worker is defined or sap_hana_scaleout_standby is defined)
 
     - name: Set vars for sap_storage_setup Ansible Role
-      register: register_ansible_vars_storage
+      register: __sap_vm_provision_task_ansible_vars_storage
       ansible.builtin.include_tasks:
         file: common/set_ansible_vars_storage.yml
 

--- a/roles/sap_vm_provision/tasks/platform_ansible/aws_ec2_vs/execute_main.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/aws_ec2_vs/execute_main.yml
@@ -1,35 +1,42 @@
 ---
 
 - name: Ansible Task block for looped provisioning of AWS EC2 instances
-  environment:
-    AWS_REGION: "{{ sap_vm_provision_aws_region }}"
   any_errors_fatal: true
+  # Using environment, no_log is ineffective and log will show 'EXEC /bin/sh -c 'ENV_VAR=value python3 /AnsiballZ_ansible_module_name.py && sleep 0'
+  # Therefore do not use environment for secrets, use only for non-sensitive values as this will reduce Ansible Task parameters.
+  environment:
+    # AWS_ACCESS_KEY_ID: "{{ sap_vm_provision_aws_access_key }}"
+    # AWS_SECRET_ACCESS_KEY: "{{ sap_vm_provision_aws_secret_access_key }}"
+    AWS_REGION: "{{ sap_vm_provision_aws_region }}"
   block:
 
     - name: Identify OS Image (AWS AMI)
       register: __sap_vm_provision_task_aws_ami
+      no_log: "{{ __sap_vm_provision_no_log }}"
       amazon.aws.ec2_ami_info:
         owners: ["aws-marketplace"]
         filters:
           name: "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_os_image_dictionary')[sap_vm_provision_aws_ec2_vs_host_os_image] }}"
         access_key: "{{ sap_vm_provision_aws_access_key }}"
         secret_key: "{{ sap_vm_provision_aws_secret_access_key }}"
-      no_log: "{{ __sap_vm_provision_no_log }}"
 
     - name: Set fact to hold loop variables from include_tasks
       ansible.builtin.set_fact:
         register_provisioned_host_all: []
 
     - name: Provision hosts to AWS
-      register: __sap_vm_provision_task_register_provisioned_hosts
+      register: __sap_vm_provision_task_provision_host_all_run
       ansible.builtin.include_tasks:
         file: "{{ 'platform_' + sap_vm_provision_iac_type }}/{{ sap_vm_provision_iac_platform }}/execute_provision.yml"
         # apply:
-        #   environment:
-        #     AWS_REGION: "{{ sap_vm_provision_aws_region }}"
+          # environment:
+          #   # AWS_ACCESS_KEY_ID: "{{ sap_vm_provision_aws_access_key }}"
+          #   # AWS_SECRET_ACCESS_KEY: "{{ sap_vm_provision_aws_secret_access_key }}"
+          #   AWS_REGION: "{{ sap_vm_provision_aws_region }}"
 
     - name: Add hosts provisioned to the Ansible Inventory
-      register: __sap_vm_provision_task_register_add_hosts
+      register: __sap_vm_provision_task_provision_host_all_add
+      no_log: "{{ __sap_vm_provision_no_log }}"
       ansible.builtin.add_host:
         name: "{{ add_item[0].host_node }}"
         groups: "{{ add_item[0].sap_system_type + '_' if (add_item[0].sap_system_type != '') }}{{ add_item[0].sap_host_type }}"
@@ -41,19 +48,18 @@
       loop_control:
         label: "{{ add_item[0].host_node }}"
         loop_var: add_item
-      no_log: "{{ __sap_vm_provision_no_log }}"
 
 # Cannot override any variables from extravars input, see https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_variables.html#understanding-variable-precedence
 # Ensure no default value exists for any prompted variable before execution of Ansible Playbook
 
     - name: Gather information about AWS VPC Route Table for the VPC Subnet
+      register: __sap_vm_provision_task_aws_vpc_subnet_rt_info
+      no_log: "{{ __sap_vm_provision_no_log }}"
       amazon.aws.ec2_vpc_route_table_info:
         filters:
           association.subnet-id: "{{ sap_vm_provision_aws_vpc_subnet_id }}"
         access_key: "{{ sap_vm_provision_aws_access_key }}"
         secret_key: "{{ sap_vm_provision_aws_secret_access_key }}"
-      register: __sap_vm_provision_task_vpc_subnet_rt_info
-      no_log: "{{ __sap_vm_provision_no_log }}"
 
     - name: Set fact to hold all inventory hosts in all groups
       ansible.builtin.set_fact:
@@ -65,6 +71,8 @@
         file: common/set_ansible_vars.yml
 
     - name: Ansible AWS Route53 DNS Records for hosts
+      register: __sap_vm_provision_task_route53
+      no_log: "{{ __sap_vm_provision_no_log }}"
       amazon.aws.route53:
         state: present
         private_zone: true
@@ -76,8 +84,6 @@
         wait: true
         access_key: "{{ sap_vm_provision_aws_access_key }}"
         secret_key: "{{ sap_vm_provision_aws_secret_access_key }}"
-      register: __sap_vm_provision_task_route53
-      no_log: "{{ __sap_vm_provision_no_log }}"
 
   rescue:
     # This requires no_log set on each Ansible Task, and not set on the Ansible Task Block
@@ -88,12 +94,12 @@
         msg: "{{ lookup('ansible.builtin.vars', loop_item) }}"
       loop:
         - __sap_vm_provision_task_aws_ami
-        - __sap_vm_provision_task_provisioned_host_single
-        - __sap_vm_provision_task_instance_info
-        - __sap_vm_provision_task_volume_provisioning
-        - __sap_vm_provision_task_register_provisioned_hosts
-        - __sap_vm_provision_task_register_add_hosts
-        - __sap_vm_provision_task_vpc_subnet_rt_info
+        - __sap_vm_provision_task_provision_host_all_run
+        - __sap_vm_provision_task_provision_host_single
+        - __sap_vm_provision_task_provision_host_single_info
+        - __sap_vm_provision_task_provision_host_single_volumes
+        - __sap_vm_provision_task_provision_host_all_add
+        - __sap_vm_provision_task_aws_vpc_subnet_rt_info
         - __sap_vm_provision_task_route53
       loop_control:
         loop_var: loop_item
@@ -103,6 +109,7 @@
         - lookup('ansible.builtin.vars', loop_item, default='') | length > 0
         - not lookup('ansible.builtin.vars', loop_item, default='') is skipped
         - lookup('ansible.builtin.vars', loop_item, default='') is failed
+
 
 - name: Ansible Task block to execute on target inventory hosts
   delegate_to: "{{ inventory_hostname }}"
@@ -147,21 +154,27 @@
 
 - name: Ansible Task block for provisioning of High Availability resources for AWS EC2 instances
   delegate_to: localhost
+  any_errors_fatal: true
   run_once: true
+  # Using environment, no_log is ineffective and log will show 'EXEC /bin/sh -c 'ENV_VAR=value python3 /AnsiballZ_ansible_module_name.py && sleep 0'
+  # Therefore do not use environment for secrets, use only for non-sensitive values as this will reduce Ansible Task parameters.
   environment:
+    # AWS_ACCESS_KEY_ID: "{{ sap_vm_provision_aws_access_key }}"
+    # AWS_SECRET_ACCESS_KEY: "{{ sap_vm_provision_aws_secret_access_key }}"
     AWS_REGION: "{{ sap_vm_provision_aws_region }}"
   when:
     - sap_ha_pacemaker_cluster_aws_region is defined
     - (groups["hana_secondary"] is defined and (groups["hana_secondary"] | length>0)) or (groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0)) or (groups["anydb_secondary"] is defined and (groups["anydb_secondary"] | length>0))
-  any_errors_fatal: true
   block:
 
     - name: Provision High Availability resources for AWS EC2 hosts
       ansible.builtin.include_tasks:
         file: "{{ 'platform_' + sap_vm_provision_iac_type }}/{{ sap_vm_provision_iac_platform }}/execute_setup_ha.yml"
         # apply:
-        #   environment:
-        #     AWS_REGION: "{{ sap_vm_provision_aws_region }}"
+          # environment:
+          #   # AWS_ACCESS_KEY_ID: "{{ sap_vm_provision_aws_access_key }}"
+          #   # AWS_SECRET_ACCESS_KEY: "{{ sap_vm_provision_aws_secret_access_key }}"
+          #   AWS_REGION: "{{ sap_vm_provision_aws_region }}"
 
   rescue:
     # This requires no_log set on each Ansible Task, and not set on the Ansible Task Block
@@ -172,23 +185,23 @@
         msg: "{{ lookup('ansible.builtin.vars', loop_item) }}"
       loop:
         - __sap_vm_provision_task_aws_account_info
-        - __sap_vm_provision_task_vpc_subnet_rt_info
-        - __sap_vm_provision_task_vpc_subnet_rt_route_sap_hana
-        - __sap_vm_provision_task_route53_sap_hana
-        - __sap_vm_provision_task_vpc_subnet_rt_route_sap_anydb
-        - __sap_vm_provision_task_route53_sap_anydb
-        - __sap_vm_provision_task_vpc_subnet_rt_route_sap_netweaver_ascs
-        - __sap_vm_provision_task_route53_sap_netweaver_ascs
-        - __sap_vm_provision_task_vpc_subnet_rt_route_sap_netweaver_ers
-        - __sap_vm_provision_task_route53_sap_netweaver_ers
-        - __sap_vm_provision_task_iam_role_ha_pacemaker
-        - __sap_vm_provision_task_iam_policy_dataprovider
-        - __sap_vm_provision_task_iam_policy_overlayip
-        - __sap_vm_provision_task_iam_policy_stonith_saphana
-        - __sap_vm_provision_task_iam_policy_stonith_sapnwas
-        - __sap_vm_provision_task_iam_attach_role
-        - __sap_vm_provision_task_iam_attach_instance_saphana
-        - __sap_vm_provision_task_iam_attach_instance_sapnwas
+        - __sap_vm_provision_task_aws_vpc_subnet_rt_info
+        - __sap_vm_provision_task_aws_vpc_subnet_rt_route_sap_hana
+        - __sap_vm_provision_task_aws_route53_sap_hana
+        - __sap_vm_provision_task_aws_vpc_subnet_rt_route_sap_anydb
+        - __sap_vm_provision_task_aws_route53_sap_anydb
+        - __sap_vm_provision_task_aws_vpc_subnet_rt_route_sap_netweaver_ascs
+        - __sap_vm_provision_task_aws_route53_sap_netweaver_ascs
+        - __sap_vm_provision_task_aws_vpc_subnet_rt_route_sap_netweaver_ers
+        - __sap_vm_provision_task_aws_route53_sap_netweaver_ers
+        - __sap_vm_provision_task_aws_iam_role_ha_pacemaker
+        - __sap_vm_provision_task_aws_iam_policy_dataprovider
+        - __sap_vm_provision_task_aws_iam_policy_overlayip
+        - __sap_vm_provision_task_aws_iam_policy_stonith_saphana
+        - __sap_vm_provision_task_aws_iam_policy_stonith_sapnwas
+        - __sap_vm_provision_task_aws_iam_attach_role
+        - __sap_vm_provision_task_aws_iam_associate_instance_saphana
+        - __sap_vm_provision_task_aws_iam_associate_instance_sapnwas
       loop_control:
         loop_var: loop_item
         index_var: loop_item_index

--- a/roles/sap_vm_provision/tasks/platform_ansible/aws_ec2_vs/execute_provision.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/aws_ec2_vs/execute_provision.yml
@@ -175,7 +175,7 @@
         replace: 'ssh-rsa'
 
     - name: Permit root login
-      register: sshd_config
+      register: __sap_vm_provision_task_os_sshd_config
       ansible.builtin.replace:
         path: /etc/ssh/sshd_config
         regexp: '(^PermitRootLogin no)'

--- a/roles/sap_vm_provision/tasks/platform_ansible/aws_ec2_vs/execute_provision.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/aws_ec2_vs/execute_provision.yml
@@ -15,7 +15,8 @@
     - not inventory_hostname in lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan].keys()
 
 - name: Provision AWS EC2 Virtual Server instance
-  register: __sap_vm_provision_task_provisioned_host_single
+  register: __sap_vm_provision_task_provision_host_single
+  no_log: "{{ __sap_vm_provision_no_log }}"
   amazon.aws.ec2_instance:
     state: started
     name: "{{ inventory_hostname }}"
@@ -35,21 +36,20 @@
       source_dest_check: "{{ not lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][scaleout_origin_host_spec | default(inventory_hostname)].disable_ip_anti_spoofing }}" # Disable the Anti IP Spoofing by setting Source/Destination Check to false
     access_key: "{{ sap_vm_provision_aws_access_key }}"
     secret_key: "{{ sap_vm_provision_aws_secret_access_key }}"
-  no_log: "{{ __sap_vm_provision_no_log }}"
 
 - name: Set fact for storage volume letters calculations (max 25 volumes)
   ansible.builtin.set_fact:
     storage_vol_letters: "bcdefghijklmnopqrstuvwxyz"
 
 - name: Read AWS EC2 instance information
-  amazon.aws.ec2_instance_info:
+  register: __sap_vm_provision_task_provision_host_single_info
+  no_log: "{{ __sap_vm_provision_no_log }}"
+  amazon.aws.ec2___sap_vm_provision_task_provision_host_single_info:
     filters:
       "tag:Name": "{{ inventory_hostname }}"
       "instance-state-name": ["running"]
     access_key: "{{ sap_vm_provision_aws_access_key }}"
     secret_key: "{{ sap_vm_provision_aws_secret_access_key }}"
-  register: __sap_vm_provision_task_instance_info
-  no_log: "{{ __sap_vm_provision_no_log }}"
 
 - name: Set fact for available storage volume device names
   ansible.builtin.set_fact:
@@ -57,7 +57,7 @@
       {% set letters = 'bcdefghijklmnopqrstuvwxyz' %}
       {% set volumes = [] %}
       {%- for letter in letters -%}
-        {% for device in __sap_vm_provision_task_instance_info.instances[0].block_device_mappings -%}
+        {% for device in __sap_vm_provision_task_provision_host_single_info.instances[0].block_device_mappings -%}
           {% if '/dev/sd' + letter not in device.device_name -%}
             {% set dev = volumes.append('/dev/sd' + letter) %}
           {%- endif %}
@@ -99,9 +99,11 @@
 # The volume creation task requires the above task to define the parameter
 # which contains the calculated unique device names.
 - name: Provision AWS EBS volumes for AWS EC2 Virtual Server instance filesystems
+  register: __sap_vm_provision_task_provision_host_single_volumes
+  no_log: "{{ __sap_vm_provision_no_log }}"
   amazon.aws.ec2_vol:
     name: "{{ inventory_hostname }}-vol_{{ vol_item.name }}"
-    instance: "{{ __sap_vm_provision_task_provisioned_host_single.instance_ids[0] }}"
+    instance: "{{ __sap_vm_provision_task_provision_host_single.instance_ids[0] }}"
     volume_type: "{{ vol_item.type }}"
     volume_size: "{{ vol_item.size }}"
     device_name: "{{ vol_item.device }}"
@@ -116,30 +118,28 @@
   when:
     - vol_item.fstype is defined
     - vol_item.size > 0
-  register: __sap_vm_provision_task_volume_provisioning
-  no_log: "{{ __sap_vm_provision_no_log }}"
 
 - name: Read AWS EC2 instance information
-  amazon.aws.ec2_instance_info:
+  register: __sap_vm_provision_task_provision_host_single_info
+  no_log: "{{ __sap_vm_provision_no_log }}"
+  amazon.aws.ec2___sap_vm_provision_task_provision_host_single_info:
     filters:
       "tag:Name": "{{ inventory_hostname }}"
     access_key: "{{ sap_vm_provision_aws_access_key }}"
     secret_key: "{{ sap_vm_provision_aws_secret_access_key }}"
-  register: __sap_vm_provision_task_instance_info
-  no_log: "{{ __sap_vm_provision_no_log }}"
 
 - name: Add host facts
+  no_log: "{{ __sap_vm_provision_no_log }}"
   ansible.builtin.set_fact:
     filesystem_volume_map: "{{ filesystem_volume_map }}"
-    __sap_vm_provision_task_volume_provisioning: "{{ __sap_vm_provision_task_volume_provisioning }}"
-    instance_info: "{{ __sap_vm_provision_task_instance_info }}"
+    __sap_vm_provision_task_provision_host_single_volumes: "{{ __sap_vm_provision_task_provision_host_single_volumes }}"
+    __sap_vm_provision_task_provision_host_single_info: "{{ __sap_vm_provision_task_provision_host_single_info }}"
   delegate_to: "{{ inventory_hostname }}"
   delegate_facts: true
-  no_log: "{{ __sap_vm_provision_no_log }}"
 
 - name: Create fact for delegate host IP
   ansible.builtin.set_fact:
-    provisioned_private_ip: "{{ __sap_vm_provision_task_provisioned_host_single.instances[0].private_ip_address }}"
+    provisioned_private_ip: "{{ __sap_vm_provision_task_provision_host_single.instances[0].private_ip_address }}"
 
 
 - name: Copy facts to delegate host
@@ -151,7 +151,7 @@
     delegate_sap_vm_provision_bastion_ssh_port: "{{ sap_vm_provision_bastion_ssh_port }}"
     delegate_sap_vm_provision_ssh_bastion_private_key_file_path: "{{ sap_vm_provision_ssh_bastion_private_key_file_path }}"
     delegate_sap_vm_provision_ssh_host_private_key_file_path: "{{ sap_vm_provision_ssh_host_private_key_file_path }}"
-    delegate_private_ip: "{{ __sap_vm_provision_task_provisioned_host_single.instances[0].private_ip_address }}"
+    delegate_private_ip: "{{ __sap_vm_provision_task_provision_host_single.instances[0].private_ip_address }}"
     delegate_hostname: "{{ inventory_hostname }}"
     delegate_sap_vm_provision_dns_root_domain_name: "{{ sap_vm_provision_dns_root_domain }}"
 
@@ -175,11 +175,11 @@
         replace: 'ssh-rsa'
 
     - name: Permit root login
+      register: sshd_config
       ansible.builtin.replace:
         path: /etc/ssh/sshd_config
         regexp: '(^PermitRootLogin no)'
         replace: 'PermitRootLogin yes'
-      register: sshd_config
 
     - name: Reload sshd service
       ansible.builtin.service:
@@ -193,8 +193,8 @@
 
 - name: Append loop value to register
   ansible.builtin.set_fact:
-    __sap_vm_provision_task_provisioned_host_single: "{{ __sap_vm_provision_task_provisioned_host_single | combine( { 'host_node' : inventory_hostname } , { 'sap_host_type' : lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][scaleout_origin_host_spec | default(inventory_hostname)].sap_host_type } , { 'sap_system_type' : (lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][scaleout_origin_host_spec | default(inventory_hostname)].sap_system_type | default('')) } ) }}"
+    __sap_vm_provision_task_provision_host_single: "{{ __sap_vm_provision_task_provision_host_single | combine( { 'host_node' : inventory_hostname } , { 'sap_host_type' : lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][scaleout_origin_host_spec | default(inventory_hostname)].sap_host_type } , { 'sap_system_type' : (lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][scaleout_origin_host_spec | default(inventory_hostname)].sap_system_type | default('')) } ) }}"
 
 - name: Append output to merged register
   ansible.builtin.set_fact:
-    register_provisioned_host_all: "{{ register_provisioned_host_all + [__sap_vm_provision_task_provisioned_host_single] }}"
+    register_provisioned_host_all: "{{ register_provisioned_host_all + [__sap_vm_provision_task_provision_host_single] }}"

--- a/roles/sap_vm_provision/tasks/platform_ansible/aws_ec2_vs/execute_setup_ha.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/aws_ec2_vs/execute_setup_ha.yml
@@ -183,7 +183,7 @@
 ## For HA of PAS and AAS, if required
 
 # - name: Ansible AWS VPC Route Table append route for SAP NetWeaver PAS HA
-#   register: aws_vpc_subnet_rt_route_sap_netweaver_pas
+#   register: __sap_vm_provision_task_aws_route53_sap_netweaver_pas
 #   no_log: "{{ __sap_vm_provision_no_log }}"
 #   amazon.aws.ec2_vpc_route_table:
 #     lookup: id
@@ -219,7 +219,7 @@
 
 
 # - name: Ansible AWS VPC Route Table append route for SAP NetWeaver AAS HA
-#   register: aws_vpc_subnet_rt_route_sap_netweaver_aas
+#   register: __sap_vm_provision_task_aws_route53_sap_netweaver_aas
 #   no_log: "{{ __sap_vm_provision_no_log }}"
 #   amazon.aws.ec2_vpc_route_table:
 #     lookup: id

--- a/roles/sap_vm_provision/tasks/platform_ansible/aws_ec2_vs/execute_setup_ha.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/aws_ec2_vs/execute_setup_ha.yml
@@ -1,26 +1,28 @@
 ---
 
 - name: Gather information about AWS account
+  register: __sap_vm_provision_task_aws_account_info
+  no_log: "{{ __sap_vm_provision_no_log }}"
   amazon.aws.aws_caller_info:
     access_key: "{{ sap_vm_provision_aws_access_key }}"
     secret_key: "{{ sap_vm_provision_aws_secret_access_key }}"
-  register: __sap_vm_provision_task_aws_account_info
-  no_log: "{{ __sap_vm_provision_no_log }}"
 
 - name: Gather information about AWS VPC Route Table for the VPC Subnet
+  register: __sap_vm_provision_task_aws_vpc_subnet_rt_info
+  no_log: "{{ __sap_vm_provision_no_log }}"
   amazon.aws.ec2_vpc_route_table_info:
     filters:
       association.subnet-id: "{{ sap_vm_provision_aws_vpc_subnet_id }}"
     access_key: "{{ sap_vm_provision_aws_access_key }}"
     secret_key: "{{ sap_vm_provision_aws_secret_access_key }}"
-  register: __sap_vm_provision_task_vpc_subnet_rt_info
-  no_log: "{{ __sap_vm_provision_no_log }}"
 
 - name: Ansible AWS VPC Route Table append route for SAP HANA HA
+  register: __sap_vm_provision_task_aws_vpc_subnet_rt_route_sap_hana
+  no_log: "{{ __sap_vm_provision_no_log }}"
   amazon.aws.ec2_vpc_route_table:
     lookup: id
-    vpc_id: "{{ __sap_vm_provision_task_vpc_subnet_rt_info.route_tables[0].vpc_id }}"
-    route_table_id: "{{ __sap_vm_provision_task_vpc_subnet_rt_info.route_tables[0].route_table_id }}"
+    vpc_id: "{{ __sap_vm_provision_task_aws_vpc_subnet_rt_info.route_tables[0].vpc_id }}"
+    route_table_id: "{{ __sap_vm_provision_task_aws_vpc_subnet_rt_info.route_tables[0].route_table_id }}"
     purge_subnets: false
     purge_routes: false
     state: present
@@ -32,12 +34,12 @@
   loop: "{{ (groups['hana_primary'] | default([])) }}"
   loop_control:
     loop_var: host_node
-  register: __sap_vm_provision_task_vpc_subnet_rt_route_sap_hana  
   when:
     - groups["hana_secondary"] is defined and (groups["hana_secondary"] | length>0)
-  no_log: "{{ __sap_vm_provision_no_log }}"
 
 - name: Ansible AWS Route53 DNS Records for SAP HANA HA Virtual Hostname
+  register: __sap_vm_provision_task_aws_route53_sap_hana
+  no_log: "{{ __sap_vm_provision_no_log }}"
   amazon.aws.route53:
     state: present
     private_zone: true
@@ -54,14 +56,14 @@
     loop_var: host_node
   when:
     - groups["hana_secondary"] is defined and (groups["hana_secondary"]|length>0)
-  register: __sap_vm_provision_task_route53_sap_hana
-  no_log: "{{ __sap_vm_provision_no_log }}"
 
 - name: Ansible AWS VPC Route Table append route for SAP AnyDB HA
+  register: __sap_vm_provision_task_aws_vpc_subnet_rt_route_sap_anydb
+  no_log: "{{ __sap_vm_provision_no_log }}"
   amazon.aws.ec2_vpc_route_table:
     lookup: id
-    vpc_id: "{{ __sap_vm_provision_task_vpc_subnet_rt_info.route_tables[0].vpc_id }}"
-    route_table_id: "{{ __sap_vm_provision_task_vpc_subnet_rt_info.route_tables[0].route_table_id }}"
+    vpc_id: "{{ __sap_vm_provision_task_aws_vpc_subnet_rt_info.route_tables[0].vpc_id }}"
+    route_table_id: "{{ __sap_vm_provision_task_aws_vpc_subnet_rt_info.route_tables[0].route_table_id }}"
     purge_subnets: false
     purge_routes: false
     state: present
@@ -73,12 +75,12 @@
   loop: "{{ (groups['anydb_primary'] | default([])) }}"
   loop_control:
     loop_var: host_node
-  register: __sap_vm_provision_task_vpc_subnet_rt_route_sap_anydb
   when:
     - groups["anydb_secondary"] is defined and (groups["anydb_secondary"] | length>0)
-  no_log: "{{ __sap_vm_provision_no_log }}"
 
 - name: Ansible AWS Route53 DNS Records for SAP AnyDB HA Virtual Hostname
+  register: __sap_vm_provision_task_aws_route53_sap_anydb
+  no_log: "{{ __sap_vm_provision_no_log }}"
   amazon.aws.route53:
     state: present
     private_zone: true
@@ -95,14 +97,14 @@
     loop_var: host_node
   when:
     - groups["anydb_secondary"] is defined and (groups["anydb_secondary"]|length>0)
-  register: __sap_vm_provision_task_route53_sap_anydb
-  no_log: "{{ __sap_vm_provision_no_log }}"
 
 - name: Ansible AWS VPC Route Table append route for SAP NetWeaver ASCS HA
+  register: __sap_vm_provision_task_aws_vpc_subnet_rt_route_sap_netweaver_ascs
+  no_log: "{{ __sap_vm_provision_no_log }}"
   amazon.aws.ec2_vpc_route_table:
     lookup: id
-    vpc_id: "{{ __sap_vm_provision_task_vpc_subnet_rt_info.route_tables[0].vpc_id }}"
-    route_table_id: "{{ __sap_vm_provision_task_vpc_subnet_rt_info.route_tables[0].route_table_id }}"
+    vpc_id: "{{ __sap_vm_provision_task_aws_vpc_subnet_rt_info.route_tables[0].vpc_id }}"
+    route_table_id: "{{ __sap_vm_provision_task_aws_vpc_subnet_rt_info.route_tables[0].route_table_id }}"
     purge_subnets: false
     purge_routes: false
     state: present
@@ -114,12 +116,12 @@
   loop: "{{ (groups['nwas_ascs'] | default([])) }}"
   loop_control:
     loop_var: host_node
-  register: __sap_vm_provision_task_vpc_subnet_rt_route_sap_netweaver_ascs  
   when:
     - groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0)
-  no_log: "{{ __sap_vm_provision_no_log }}"
 
 - name: Ansible AWS Route53 DNS Records for SAP NetWeaver ASCS HA Virtual Hostname
+  register: __sap_vm_provision_task_aws_route53_sap_netweaver_ascs
+  no_log: "{{ __sap_vm_provision_no_log }}"
   amazon.aws.route53:
     state: present
     private_zone: true
@@ -136,14 +138,14 @@
     loop_var: host_node
   when:
     - groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
-  register: __sap_vm_provision_task_route53_sap_netweaver_ascs
-  no_log: "{{ __sap_vm_provision_no_log }}"
 
 - name: Ansible AWS VPC Route Table append route for SAP NetWeaver ERS HA
+  register: __sap_vm_provision_task_aws_vpc_subnet_rt_route_sap_netweaver_ers
+  no_log: "{{ __sap_vm_provision_no_log }}"
   amazon.aws.ec2_vpc_route_table:
     lookup: id
-    vpc_id: "{{ __sap_vm_provision_task_vpc_subnet_rt_info.route_tables[0].vpc_id }}"
-    route_table_id: "{{ __sap_vm_provision_task_vpc_subnet_rt_info.route_tables[0].route_table_id }}"
+    vpc_id: "{{ __sap_vm_provision_task_aws_vpc_subnet_rt_info.route_tables[0].vpc_id }}"
+    route_table_id: "{{ __sap_vm_provision_task_aws_vpc_subnet_rt_info.route_tables[0].route_table_id }}"
     purge_subnets: false
     purge_routes: false
     state: present
@@ -155,12 +157,12 @@
   loop: "{{ (groups['nwas_ers'] | default([])) }}"
   loop_control:
     loop_var: host_node
-  register: __sap_vm_provision_task_vpc_subnet_rt_route_sap_netweaver_ers
   when:
     - groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0)
-  no_log: "{{ __sap_vm_provision_no_log }}"
 
 - name: Ansible AWS Route53 DNS Records for SAP NetWeaver ERS HA Virtual Hostname
+  register: __sap_vm_provision_task_aws_route53_sap_netweaver_ers
+  no_log: "{{ __sap_vm_provision_no_log }}"
   amazon.aws.route53:
     state: present
     private_zone: true
@@ -177,16 +179,16 @@
     loop_var: host_node
   when:
     - groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
-  register: __sap_vm_provision_task_route53_sap_netweaver_ers
-  no_log: "{{ __sap_vm_provision_no_log }}"
 
 ## For HA of PAS and AAS, if required
 
 # - name: Ansible AWS VPC Route Table append route for SAP NetWeaver PAS HA
+#   register: aws_vpc_subnet_rt_route_sap_netweaver_pas
+#   no_log: "{{ __sap_vm_provision_no_log }}"
 #   amazon.aws.ec2_vpc_route_table:
 #     lookup: id
-#     vpc_id: "{{ __sap_vm_provision_task_vpc_subnet_rt_info.route_tables[0].vpc_id }}"
-#     route_table_id: "{{ __sap_vm_provision_task_vpc_subnet_rt_info.route_tables[0].route_table_id }}"
+#     vpc_id: "{{ __sap_vm_provision_task_aws_vpc_subnet_rt_info.route_tables[0].vpc_id }}"
+#     route_table_id: "{{ __sap_vm_provision_task_aws_vpc_subnet_rt_info.route_tables[0].route_table_id }}"
 #     purge_subnets: false
 #     purge_routes: false
 #     state: present
@@ -196,7 +198,6 @@
 #   loop: "{{ (groups['nwas_pas'] | default([])) }}"
 #   loop_control:
 #     loop_var: host_node
-#   register: aws_vpc_subnet_rt_route_sap_netweaver_pas
 #   when:
 #     - groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0)
 
@@ -218,10 +219,12 @@
 
 
 # - name: Ansible AWS VPC Route Table append route for SAP NetWeaver AAS HA
+#   register: aws_vpc_subnet_rt_route_sap_netweaver_aas
+#   no_log: "{{ __sap_vm_provision_no_log }}"
 #   amazon.aws.ec2_vpc_route_table:
 #     lookup: id
-#     vpc_id: "{{ __sap_vm_provision_task_vpc_subnet_rt_info.route_tables[0].vpc_id }}"
-#     route_table_id: "{{ __sap_vm_provision_task_vpc_subnet_rt_info.route_tables[0].route_table_id }}"
+#     vpc_id: "{{ __sap_vm_provision_task_aws_vpc_subnet_rt_info.route_tables[0].vpc_id }}"
+#     route_table_id: "{{ __sap_vm_provision_task_aws_vpc_subnet_rt_info.route_tables[0].route_table_id }}"
 #     purge_subnets: false
 #     purge_routes: false
 #     state: present
@@ -231,7 +234,6 @@
 #   loop: "{{ (groups['nwas_aas'] | default([])) }}"
 #   loop_control:
 #     loop_var: host_node
-#   register: aws_vpc_subnet_rt_route_sap_netweaver_aas
 #   when:
 #     - groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0)
 
@@ -253,6 +255,8 @@
 
 
 - name: AWS IAM Role - HA-Role-Pacemaker
+  register: __sap_vm_provision_task_aws_iam_role_ha_pacemaker
+  no_log: "{{ __sap_vm_provision_no_log }}"
   amazon.aws.iam_role:
     name: "HA-Role-Pacemaker"
     assume_role_policy_document: |
@@ -271,11 +275,11 @@
       }
     access_key: "{{ sap_vm_provision_aws_access_key }}"
     secret_key: "{{ sap_vm_provision_aws_secret_access_key }}"
-  register: __sap_vm_provision_task_iam_role_ha_pacemaker
-  no_log: "{{ __sap_vm_provision_no_log }}"
 
 # AWS HA for SAP - DataProvider
 - name: AWS IAM Policy - HA-Policy-DataProvider
+  register: __sap_vm_provision_task_aws_iam_policy_dataprovider
+  no_log: "{{ __sap_vm_provision_no_log }}"
   amazon.aws.iam_policy:
     state: present
     iam_type: role
@@ -307,11 +311,11 @@
       }
     access_key: "{{ sap_vm_provision_aws_access_key }}"
     secret_key: "{{ sap_vm_provision_aws_secret_access_key }}"
-  register: __sap_vm_provision_task_iam_policy_dataprovider
-  no_log: "{{ __sap_vm_provision_no_log }}"
 
 # AWS HA for SAP - OverlayVirtualIPAgent
 - name: AWS IAM Policy - HA-Policy-OverlayVirtualIPAgent
+  register: __sap_vm_provision_task_aws_iam_policy_overlayip
+  no_log: "{{ __sap_vm_provision_no_log }}"
   amazon.aws.iam_policy:
     state: present
     iam_type: role
@@ -334,17 +338,17 @@
                       "ec2:ReplaceRoute"
                   ],
                   "Effect": "Allow",
-                  "Resource": "arn:aws:ec2:{{ sap_vm_provision_aws_region }}:{{ __sap_vm_provision_task_aws_account_info.account }}:route-table/{{ __sap_vm_provision_task_vpc_subnet_rt_info.route_tables[0].route_table_id }}"
+                  "Resource": "arn:aws:ec2:{{ sap_vm_provision_aws_region }}:{{ __sap_vm_provision_task_aws_account_info.account }}:route-table/{{ __sap_vm_provision_task_aws_vpc_subnet_rt_info.route_tables[0].route_table_id }}"
               }
           ]
       }
     access_key: "{{ sap_vm_provision_aws_access_key }}"
     secret_key: "{{ sap_vm_provision_aws_secret_access_key }}"
-  register: __sap_vm_provision_task_iam_policy_overlayip
-  no_log: "{{ __sap_vm_provision_no_log }}"
 
 # AWS HA for SAP - STONITH of SAP HANA
 - name: AWS IAM Policy - HA-Policy-STONITH-SAPHANA
+  register: __sap_vm_provision_task_aws_iam_policy_stonith_saphana
+  no_log: "{{ __sap_vm_provision_no_log }}"
   amazon.aws.iam_policy:
     state: present
     iam_type: role
@@ -382,11 +386,11 @@
     access_key: "{{ sap_vm_provision_aws_access_key }}"
     secret_key: "{{ sap_vm_provision_aws_secret_access_key }}"
   when: groups["hana_secondary"] is defined and (groups["hana_secondary"]|length>0)
-  register: __sap_vm_provision_task_iam_policy_stonith_saphana
-  no_log: "{{ __sap_vm_provision_no_log }}"
 
 # AWS HA for SAP - STONITH of SAP NWAS
 - name: AWS IAM Policy - HA-Policy-STONITH-SAPNWAS
+  register: __sap_vm_provision_task_aws_iam_policy_stonith_sapnwas
+  no_log: "{{ __sap_vm_provision_no_log }}"
   amazon.aws.iam_policy:
     state: present
     iam_type: role
@@ -424,13 +428,13 @@
     access_key: "{{ sap_vm_provision_aws_access_key }}"
     secret_key: "{{ sap_vm_provision_aws_secret_access_key }}"
   when: groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
-  register: __sap_vm_provision_task_iam_policy_stonith_sapnwas
-  no_log: "{{ __sap_vm_provision_no_log }}"
 
 # Equivalent to
 # aws iam create-instance-profile --instance-profile-name "HA-Instance-Profile-Pacemaker-Cluster"
 # aws iam add-role-to-instance-profile --role-name "HA-Role-Pacemaker" --instance-profile-name "HA-Instance-Profile-Pacemaker-Cluster"
 - name: AWS IAM Instance Profile and attach AWS IAM Role - "HA-Instance-Profile-Pacemaker-Cluster"
+  register: __sap_vm_provision_task_aws_iam_attach_role
+  no_log: "{{ __sap_vm_provision_no_log }}"
   amazon.aws.iam_instance_profile:
     state: present
     name: "HA-Instance-Profile-Pacemaker-Cluster"
@@ -438,22 +442,11 @@
     path: "/"
     access_key: "{{ sap_vm_provision_aws_access_key }}"
     secret_key: "{{ sap_vm_provision_aws_secret_access_key }}"
-  register: __sap_vm_provision_task_iam_attach_role
-  no_log: "{{ __sap_vm_provision_no_log }}"
-
-# - name: AWS IAM Instance Profile - "HA-Instance-Profile-Pacemaker-Cluster"
-#   ansible.builtin.command: aws iam create-instance-profile
-#     --instance-profile-name "HA-Instance-Profile-Pacemaker-Cluster"
-#   ignore_errors: true
-
-# - name: AWS IAM Instance Profile attach AWS IAM Role
-#   ansible.builtin.command: aws iam add-role-to-instance-profile
-#     --role-name "HA-Role-Pacemaker"
-#     --instance-profile-name "HA-Instance-Profile-Pacemaker-Cluster"
-#   ignore_errors: true
 
 # Equivalent to aws ec2 associate-iam-instance-profile --iam-instance-profile "Name=HA-Instance-Profile-Pacemaker-Cluster" --instance-id {{ hostvars[host_node].ansible_board_asset_tag }}
-- name: AWS EC2 Instances - attach AWS IAM Instance Profile for SAP HANA
+- name: AWS EC2 Instances - associate AWS IAM Instance Profile for SAP HANA
+  register: __sap_vm_provision_task_aws_iam_associate_instance_saphana
+  no_log: "{{ __sap_vm_provision_no_log }}"
   amazon.aws.ec2_instance:
     instance_ids: "{{ hostvars[host_node].ansible_board_asset_tag }}"
     iam_instance_profile: "HA-Instance-Profile-Pacemaker-Cluster"
@@ -464,21 +457,11 @@
     loop_var: host_node
   when: groups["hana_secondary"] is defined and (groups["hana_secondary"]|length>0)
   ignore_errors: true
-  register: __sap_vm_provision_task_iam_attach_instance_saphana
-  no_log: "{{ __sap_vm_provision_no_log }}"
-
-# - name: AWS EC2 Instances - attach AWS IAM Instance Profile for SAP HANA
-#   ansible.builtin.command: aws ec2 associate-iam-instance-profile
-#     --iam-instance-profile "Name=HA-Instance-Profile-Pacemaker-Cluster"
-#     --instance-id {{ hostvars[host_node].ansible_board_asset_tag }}
-#   loop: "{{ [ [ groups['hana_primary'] | default([]) ] , [ groups['hana_secondary'] | default([]) ] ] | flatten | select() }}"
-#   loop_control:
-#     loop_var: host_node
-#   when: groups["hana_secondary"] is defined and (groups["hana_secondary"]|length>0)
-#   ignore_errors: true
 
 # Equivalent to aws ec2 associate-iam-instance-profile --iam-instance-profile "Name=HA-Instance-Profile-Pacemaker-Cluster" --instance-id {{ hostvars[host_node].ansible_board_asset_tag }}
-- name: AWS EC2 Instances - attach AWS IAM Instance Profile for SAP NetWeaver
+- name: AWS EC2 Instances - associate AWS IAM Instance Profile for SAP NetWeaver
+  register: __sap_vm_provision_task_aws_iam_associate_instance_sapnwas
+  no_log: "{{ __sap_vm_provision_no_log }}"
   amazon.aws.ec2_instance:
     instance_ids: "{{ hostvars[host_node].ansible_board_asset_tag }}"
     iam_instance_profile: "HA-Instance-Profile-Pacemaker-Cluster"
@@ -489,15 +472,3 @@
     loop_var: host_node
   when: groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
   ignore_errors: true
-  register: __sap_vm_provision_task_iam_attach_instance_sapnwas
-  no_log: "{{ __sap_vm_provision_no_log }}"
-
-# - name: AWS EC2 Instances - attach AWS IAM Instance Profile for SAP NetWeaver
-#   ansible.builtin.command: aws ec2 associate-iam-instance-profile
-#     --iam-instance-profile "Name=HA-Instance-Profile-Pacemaker-Cluster"
-#     --instance-id {{ hostvars[host_node].ansible_board_asset_tag }}
-#   loop: "{{ [ [ groups['nwas_ascs'] | default([]) ] , [ groups['nwas_ers'] | default([]) ] , [ groups['nwas_pas'] | default([]) ] , [ groups['nwas_aas'] | default([]) ] ] | flatten | select() }}"
-#   loop_control:
-#     loop_var: host_node
-#   when: groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
-#   ignore_errors: true

--- a/roles/sap_vm_provision/tasks/platform_ansible/gcp_ce_vm/execute_main.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/gcp_ce_vm/execute_main.yml
@@ -37,7 +37,7 @@
         register_provisioned_host_all: []
 
     - name: Provision hosts to Google Cloud
-      register: register_provisioned_hosts
+      register: __sap_vm_provision_task_provision_host_all_run
       ansible.builtin.include_tasks:
         file: "{{ 'platform_' + sap_vm_provision_iac_type }}/{{ sap_vm_provision_iac_platform }}/execute_provision.yml"
         apply:
@@ -46,7 +46,7 @@
             GCP_SERVICE_ACCOUNT_FILE: "{{ sap_vm_provision_gcp_credentials_json }}"
 
     - name: Add hosts provisioned to the Ansible Inventory
-      register: register_add_hosts
+      register: __sap_vm_provision_task_provision_host_all_add
       ansible.builtin.add_host:
         name: "{{ add_item[0].host_node }}"
         groups: "{{ add_item[0].sap_system_type + '_' if (add_item[0].sap_system_type != '') }}{{ add_item[0].sap_host_type }}"
@@ -73,7 +73,7 @@
         file: common/set_ansible_vars.yml
 
     - name: Gather GCP VM information
-      google.cloud.gcp_compute_instance_info:
+      google.cloud.gcp_compute___sap_vm_provision_task_provision_host_single_info:
         project: "{{ sap_vm_provision_gcp_project }}"
         zone: "{{ sap_vm_provision_gcp_region_zone }}"
         filters:
@@ -126,7 +126,7 @@
       delay: 5
 
 #  - ansible.builtin.debug:
-#      var: register_add_hosts.results
+#      var: __sap_vm_provision_task_provision_host_all_add.results
 
 - name: Ansible Task block to execute on target inventory hosts
   delegate_to: "{{ inventory_hostname }}"

--- a/roles/sap_vm_provision/tasks/platform_ansible/gcp_ce_vm/execute_main.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/gcp_ce_vm/execute_main.yml
@@ -73,7 +73,7 @@
         file: common/set_ansible_vars.yml
 
     - name: Gather GCP VM information
-      google.cloud.gcp_compute___sap_vm_provision_task_provision_host_single_info:
+      google.cloud.gcp_compute_instance_info:
         project: "{{ sap_vm_provision_gcp_project }}"
         zone: "{{ sap_vm_provision_gcp_region_zone }}"
         filters:

--- a/roles/sap_vm_provision/tasks/platform_ansible/gcp_ce_vm/execute_main.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/gcp_ce_vm/execute_main.yml
@@ -18,19 +18,19 @@
           - -deprecated.state = DEPRECATED
 
     - name: Identify GCP Network (VPC)
+      register: gcp_vpc_info
       google.cloud.gcp_compute_network_info:
         project: "{{ sap_vm_provision_gcp_project }}"
         filters:
           - name = "{{ sap_vm_provision_gcp_vpc_name }}"
-      register: gcp_vpc_info
 
     - name: Identify GCP Subnetwork (VPC Subnet)
+      register: gcp_vpc_subnet_info
       google.cloud.gcp_compute_subnetwork_info:
         project: "{{ sap_vm_provision_gcp_project }}"
         region: "{{ sap_vm_provision_gcp_region }}"
         filters:
           - name = "{{ sap_vm_provision_gcp_vpc_subnet_name }}"
-      register: gcp_vpc_subnet_info
 
     - name: Set fact to hold loop variables from include_tasks
       ansible.builtin.set_fact:
@@ -73,35 +73,35 @@
         file: common/set_ansible_vars.yml
 
     - name: Gather GCP VM information
+      register: gcp_vm_info
       google.cloud.gcp_compute_instance_info:
         project: "{{ sap_vm_provision_gcp_project }}"
         zone: "{{ sap_vm_provision_gcp_region_zone }}"
         filters:
           - name = {{ inventory_hostname }}
-      register: gcp_vm_info
 
     - name: Gather GCP VPC Subnet information
+      register: gcp_vpc_subnet_info
       google.cloud.gcp_compute_subnetwork_info:
         project: "{{ sap_vm_provision_gcp_project }}"
         region: "{{ sap_vm_provision_gcp_region }}"
         filters:
           - name = {{ sap_vm_provision_gcp_vpc_subnet_name }}
-      register: gcp_vpc_subnet_info
 
     - name: Gather GCP Private DNS information
+      register: gcp_pdns_info
       google.cloud.gcp_dns_managed_zone_info:
         project: "{{ sap_vm_provision_gcp_project }}"
         dns_name: "{{ sap_vm_provision_dns_root_domain }}."
-      register: gcp_pdns_info
 
     # - name: Gather information about GCP Router and table for the VPC Subnet
+    #   register: gcp_router_info
     #   google.cloud.gcp_compute_router_info:
     #     project: "{{ sap_vm_provision_gcp_project }}"
     #     region: "{{ sap_vm_provision_gcp_region }}"
     #     filters:
     #       - network = "{{ gcp_vpc_info.resources[0].selfLink }}"
     #     #  - name = sap-vpc-router
-    #   register: gcp_router_info
 
     # - name: Verify IP Forwarding for GCP VMs
     #   ansible.builtin.fail:
@@ -109,6 +109,7 @@
     #   when: not gcp_vm_info.resources[0].canIpForward
 
     - name: GCP Private DNS Records for hosts
+      register: gcp_pdns_records
       google.cloud.gcp_dns_resource_record_set:
         state: present
         project: "{{ sap_vm_provision_gcp_project }}"
@@ -120,7 +121,6 @@
           - "{{ hostvars[inventory_hostname].ansible_host }}"
         type: A
         ttl: 7200
-      register: gcp_pdns_records
       until: not gcp_pdns_records.failed
       retries: 5
       delay: 5

--- a/roles/sap_vm_provision/tasks/platform_ansible/gcp_ce_vm/execute_main.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/gcp_ce_vm/execute_main.yml
@@ -14,7 +14,7 @@
 
     - name: Identify GCP OS Image
       no_log: "{{ __sap_vm_provision_no_log }}"
-      register: register_gcp_os_image
+      register: __sap_vm_provision_task_gcp_os_image_info
       google.cloud.gcp_compute_image_info:
         project: "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_os_image_dictionary')[sap_vm_provision_gcp_ce_vm_host_os_image].project }}"
         filters:
@@ -25,7 +25,7 @@
 
     - name: Identify GCP Network (VPC)
       no_log: "{{ __sap_vm_provision_no_log }}"
-      register: gcp_vpc_info
+      register: __sap_vm_provision_task_gcp_vpc_info
       google.cloud.gcp_compute_network_info:
         project: "{{ sap_vm_provision_gcp_project }}"
         filters:
@@ -35,7 +35,7 @@
 
     - name: Identify GCP Subnetwork (VPC Subnet)
       no_log: "{{ __sap_vm_provision_no_log }}"
-      register: gcp_vpc_subnet_info
+      register: __sap_vm_provision_task_gcp_vpc_subnet_info
       google.cloud.gcp_compute_subnetwork_info:
         project: "{{ sap_vm_provision_gcp_project }}"
         region: "{{ sap_vm_provision_gcp_region }}"
@@ -86,7 +86,7 @@
 
     - name: Gather GCP VM information
       no_log: "{{ __sap_vm_provision_no_log }}"
-      register: gcp_vm_info
+      register: __sap_vm_provision_task_provision_host_single_info
       google.cloud.gcp_compute_instance_info:
         project: "{{ sap_vm_provision_gcp_project }}"
         zone: "{{ sap_vm_provision_gcp_region_zone }}"
@@ -97,7 +97,7 @@
 
     - name: Gather GCP VPC Subnet information
       no_log: "{{ __sap_vm_provision_no_log }}"
-      register: gcp_vpc_subnet_info
+      register: __sap_vm_provision_task_gcp_vpc_subnet_info
       google.cloud.gcp_compute_subnetwork_info:
         project: "{{ sap_vm_provision_gcp_project }}"
         region: "{{ sap_vm_provision_gcp_region }}"
@@ -108,7 +108,7 @@
 
     - name: Gather GCP Private DNS information
       no_log: "{{ __sap_vm_provision_no_log }}"
-      register: gcp_pdns_info
+      register: __sap_vm_provision_task_gcp_pdns_info
       google.cloud.gcp_dns_managed_zone_info:
         project: "{{ sap_vm_provision_gcp_project }}"
         dns_name: "{{ sap_vm_provision_dns_root_domain }}."
@@ -117,12 +117,12 @@
 
     # - name: Gather information about GCP Router and table for the VPC Subnet
     #   no_log: "{{ __sap_vm_provision_no_log }}"
-    #   register: gcp_router_info
+    #   register: __sap_vm_provision_task_gcp_router_info
     #   google.cloud.gcp_compute_router_info:
     #     project: "{{ sap_vm_provision_gcp_project }}"
     #     region: "{{ sap_vm_provision_gcp_region }}"
     #     filters:
-    #       - network = "{{ gcp_vpc_info.resources[0].selfLink }}"
+    #       - network = "{{ __sap_vm_provision_task_gcp_vpc_info.resources[0].selfLink }}"
     #     #  - name = sap-vpc-router
     #     auth_kind: "serviceaccount"
     #     service_account_contents: "{{ sap_vm_provision_gcp_credentials_json }}"
@@ -130,16 +130,16 @@
     # - name: Verify IP Forwarding for GCP VMs
     #   ansible.builtin.fail:
     #     msg: GCP CE VM does not have IP Forwarding enabled
-    #   when: not gcp_vm_info.resources[0].canIpForward
+    #   when: not __sap_vm_provision_task_provision_host_single_info.resources[0].canIpForward
 
     - name: GCP Private DNS Records for hosts
       no_log: "{{ __sap_vm_provision_no_log }}"
-      register: gcp_pdns_records
+      register: __sap_vm_provision_task_gcp_pdns_records
       google.cloud.gcp_dns_resource_record_set:
         state: present
         project: "{{ sap_vm_provision_gcp_project }}"
         managed_zone:
-          name: "{{ gcp_pdns_info.resources[0].name }}"
+          name: "{{ __sap_vm_provision_task_gcp_pdns_info.resources[0].name }}"
           dnsName: "{{ hostvars[inventory_hostname].sap_vm_provision_dns_root_domain }}."
         name: "{{ inventory_hostname }}.{{ hostvars[inventory_hostname].sap_vm_provision_dns_root_domain }}."
         target:
@@ -148,7 +148,7 @@
         ttl: 7200
         auth_kind: "serviceaccount"
         service_account_contents: "{{ sap_vm_provision_gcp_credentials_json }}"
-      until: not gcp_pdns_records.failed
+      until: not __sap_vm_provision_task_gcp_pdns_records.failed
       retries: 5
       delay: 5
 
@@ -163,21 +163,18 @@
       ansible.builtin.fail:
         msg: "{{ lookup('ansible.builtin.vars', loop_item) }}"
       loop:
-        - __sap_vm_provision_task_ibmcloud_resource_group
-        - __sap_vm_provision_task_ibmcloud_resource_group_dns
-        - __sap_vm_provision_task_ibmcloud_ssh_public_key
-        - __sap_vm_provision_task_ibmcloud_vpc_subnet
-        - __sap_vm_provision_task_ibmcloud_vpc_sg
-        - __sap_vm_provision_task_ibmcloud_pdns_service_instance
-        - __sap_vm_provision_task_ibmcloud_pdns
-        - __sap_vm_provision_task_ibmcloud_os_image_list
+        - __sap_vm_provision_task_gcp_os_image_info
+        - __sap_vm_provision_task_gcp_vpc_info
+        - __sap_vm_provision_task_gcp_vpc_subnet_info
         - __sap_vm_provision_task_provision_host_all_run
-        - __sap_vm_provision_task_provision_host_all_add
-        - __sap_vm_provision_task_provision_host_single
         - __sap_vm_provision_task_provision_host_single_volumes
-        - __sap_vm_provision_task_provision_host_single_volume_attachments
+        - __sap_vm_provision_task_provision_host_single
         - __sap_vm_provision_task_provision_host_single_info
-        - __sap_vm_provision_task_ibmcloud_pdns_record
+        - __sap_vm_provision_task_provision_host_all_add
+        - __sap_vm_provision_task_gcp_vpc_subnet_info
+        - __sap_vm_provision_task_gcp_pdns_info
+        - __sap_vm_provision_task_gcp_router_info
+        - __sap_vm_provision_task_gcp_pdns_records
       loop_control:
         loop_var: loop_item
         index_var: loop_item_index
@@ -330,17 +327,23 @@
       ansible.builtin.fail:
         msg: "{{ lookup('ansible.builtin.vars', loop_item) }}"
       loop:
-        - __sap_vm_provision_task_ibmcloud_iam_auth_policy
-        - __sap_vm_provision_task_ibmcloud_lb_provision_parallel
-        - __sap_vm_provision_task_ibmcloud_lb_provision_parallel_async_status
-        - __sap_vm_provision_task_ibmcloud_lb_update_dns
-        - __sap_vm_provision_task_ibmcloud_vs_all_info
-        - __sap_vm_provision_task_ibmcloud_lb_all_info_shell
-        - __sap_vm_provision_task_ibmcloud_lb_pool_hana1
-        - __sap_vm_provision_task_ibmcloud_pdns_record_ha_hana
-        - __sap_vm_provision_task_ibmcloud_pdns_record_ha_anydb
-        - __sap_vm_provision_task_ibmcloud_pdns_record_ha_nwas_ascs
-        - __sap_vm_provision_task_ibmcloud_pdns_record_ha_nwas_ers
+        - __sap_vm_provision_task_gcp_vpc_subnet_rt_route_sap_hana
+        - __sap_vm_provision_task_gcp_vpc_subnet_rt_route_sap_netweaver_ascs
+        - __sap_vm_provision_task_gcp_vpc_subnet_rt_route_sap_netweaver_ers
+        - __sap_vm_provision_task_gcp_vpc_subnet_rt_route_sap_netweaver_pas
+        - __sap_vm_provision_task_gcp_vpc_subnet_rt_route_sap_netweaver_aas
+        - __sap_vm_provision_task_gcp_lb_reserved_address
+        - __sap_vm_provision_task_gcp_lb_healthcheck_service
+        - __sap_vm_provision_task_gcp_lb_healthcheck_service_ascs
+        - __sap_vm_provision_task_gcp_lb_healthcheck_service_ers
+        - __sap_vm_provision_task_provision_host_single_info
+        - __sap_vm_provision_task_gcp_lb_instance_group1
+        - __sap_vm_provision_task_gcp_lb_instance_group2
+        - __sap_vm_provision_task_gcp_lb_backend_service_regional
+        - __sap_vm_provision_task_gcp_lb_backend_service_regional_ascs
+        - __sap_vm_provision_task_gcp_lb_backend_service_regional_ers
+        - __sap_vm_provision_task_gcp_lb_forwarding_rule
+        - __sap_vm_provision_task_gcp_lb_reserved_address
       loop_control:
         loop_var: loop_item
         index_var: loop_item_index

--- a/roles/sap_vm_provision/tasks/platform_ansible/gcp_ce_vm/execute_main.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/gcp_ce_vm/execute_main.yml
@@ -1,36 +1,48 @@
 ---
 
 - name: Ansible Task block for looped provisioning of Google Cloud CE VMs
-  environment:
-    GCP_AUTH_KIND: "serviceaccount"
-    GCP_SERVICE_ACCOUNT_FILE: "{{ sap_vm_provision_gcp_credentials_json }}"
+  any_errors_fatal: true
+  # Using environment, no_log is ineffective and log will show 'EXEC /bin/sh -c 'ENV_VAR=value python3 /AnsiballZ_ansible_module_name.py && sleep 0'
+  # Therefore do not use environment for secrets, use only for non-sensitive values as this will reduce Ansible Task parameters.
+  # environment:
+  #   GCP_AUTH_KIND: "serviceaccount"
+  #   GCP_SERVICE_ACCOUNT_FILE: "{{ sap_vm_provision_gcp_credentials_json }}"
   block:
 
     # # Must be GlobalOnly or ZonalPreferred. The default is ZonalOnly
     # - name: GCP Project metadata - check VmDnsSetting variable
 
     - name: Identify GCP OS Image
+      no_log: "{{ __sap_vm_provision_no_log }}"
       register: register_gcp_os_image
       google.cloud.gcp_compute_image_info:
         project: "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_os_image_dictionary')[sap_vm_provision_gcp_ce_vm_host_os_image].project }}"
         filters:
           - family = "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_os_image_dictionary')[sap_vm_provision_gcp_ce_vm_host_os_image].family }}"
           - -deprecated.state = DEPRECATED
+        auth_kind: "serviceaccount"
+        service_account_contents: "{{ sap_vm_provision_gcp_credentials_json }}"
 
     - name: Identify GCP Network (VPC)
+      no_log: "{{ __sap_vm_provision_no_log }}"
       register: gcp_vpc_info
       google.cloud.gcp_compute_network_info:
         project: "{{ sap_vm_provision_gcp_project }}"
         filters:
           - name = "{{ sap_vm_provision_gcp_vpc_name }}"
+        auth_kind: "serviceaccount"
+        service_account_contents: "{{ sap_vm_provision_gcp_credentials_json }}"
 
     - name: Identify GCP Subnetwork (VPC Subnet)
+      no_log: "{{ __sap_vm_provision_no_log }}"
       register: gcp_vpc_subnet_info
       google.cloud.gcp_compute_subnetwork_info:
         project: "{{ sap_vm_provision_gcp_project }}"
         region: "{{ sap_vm_provision_gcp_region }}"
         filters:
           - name = "{{ sap_vm_provision_gcp_vpc_subnet_name }}"
+        auth_kind: "serviceaccount"
+        service_account_contents: "{{ sap_vm_provision_gcp_credentials_json }}"
 
     - name: Set fact to hold loop variables from include_tasks
       ansible.builtin.set_fact:
@@ -40,10 +52,10 @@
       register: __sap_vm_provision_task_provision_host_all_run
       ansible.builtin.include_tasks:
         file: "{{ 'platform_' + sap_vm_provision_iac_type }}/{{ sap_vm_provision_iac_platform }}/execute_provision.yml"
-        apply:
-          environment:
-            GCP_AUTH_KIND: "serviceaccount"
-            GCP_SERVICE_ACCOUNT_FILE: "{{ sap_vm_provision_gcp_credentials_json }}"
+        # apply:
+        #   environment:
+        #     GCP_AUTH_KIND: "serviceaccount"
+        #     GCP_SERVICE_ACCOUNT_FILE: "{{ sap_vm_provision_gcp_credentials_json }}"
 
     - name: Add hosts provisioned to the Ansible Inventory
       register: __sap_vm_provision_task_provision_host_all_add
@@ -73,28 +85,38 @@
         file: common/set_ansible_vars.yml
 
     - name: Gather GCP VM information
+      no_log: "{{ __sap_vm_provision_no_log }}"
       register: gcp_vm_info
       google.cloud.gcp_compute_instance_info:
         project: "{{ sap_vm_provision_gcp_project }}"
         zone: "{{ sap_vm_provision_gcp_region_zone }}"
         filters:
           - name = {{ inventory_hostname }}
+        auth_kind: "serviceaccount"
+        service_account_contents: "{{ sap_vm_provision_gcp_credentials_json }}"
 
     - name: Gather GCP VPC Subnet information
+      no_log: "{{ __sap_vm_provision_no_log }}"
       register: gcp_vpc_subnet_info
       google.cloud.gcp_compute_subnetwork_info:
         project: "{{ sap_vm_provision_gcp_project }}"
         region: "{{ sap_vm_provision_gcp_region }}"
         filters:
           - name = {{ sap_vm_provision_gcp_vpc_subnet_name }}
+        auth_kind: "serviceaccount"
+        service_account_contents: "{{ sap_vm_provision_gcp_credentials_json }}"
 
     - name: Gather GCP Private DNS information
+      no_log: "{{ __sap_vm_provision_no_log }}"
       register: gcp_pdns_info
       google.cloud.gcp_dns_managed_zone_info:
         project: "{{ sap_vm_provision_gcp_project }}"
         dns_name: "{{ sap_vm_provision_dns_root_domain }}."
+        auth_kind: "serviceaccount"
+        service_account_contents: "{{ sap_vm_provision_gcp_credentials_json }}"
 
     # - name: Gather information about GCP Router and table for the VPC Subnet
+    #   no_log: "{{ __sap_vm_provision_no_log }}"
     #   register: gcp_router_info
     #   google.cloud.gcp_compute_router_info:
     #     project: "{{ sap_vm_provision_gcp_project }}"
@@ -102,6 +124,8 @@
     #     filters:
     #       - network = "{{ gcp_vpc_info.resources[0].selfLink }}"
     #     #  - name = sap-vpc-router
+    #     auth_kind: "serviceaccount"
+    #     service_account_contents: "{{ sap_vm_provision_gcp_credentials_json }}"
 
     # - name: Verify IP Forwarding for GCP VMs
     #   ansible.builtin.fail:
@@ -109,6 +133,7 @@
     #   when: not gcp_vm_info.resources[0].canIpForward
 
     - name: GCP Private DNS Records for hosts
+      no_log: "{{ __sap_vm_provision_no_log }}"
       register: gcp_pdns_records
       google.cloud.gcp_dns_resource_record_set:
         state: present
@@ -121,12 +146,47 @@
           - "{{ hostvars[inventory_hostname].ansible_host }}"
         type: A
         ttl: 7200
+        auth_kind: "serviceaccount"
+        service_account_contents: "{{ sap_vm_provision_gcp_credentials_json }}"
       until: not gcp_pdns_records.failed
       retries: 5
       delay: 5
 
 #  - ansible.builtin.debug:
 #      var: __sap_vm_provision_task_provision_host_all_add.results
+
+  rescue:
+    # This requires no_log set on each Ansible Task, and not set on the Ansible Task Block
+    # This requires an Ansible Task Block containing the Ansible Tasks for calling
+    # Infrastructure Platform APIs (via Ansible Modules)
+    - name: Show errors in task outputs
+      ansible.builtin.fail:
+        msg: "{{ lookup('ansible.builtin.vars', loop_item) }}"
+      loop:
+        - __sap_vm_provision_task_ibmcloud_resource_group
+        - __sap_vm_provision_task_ibmcloud_resource_group_dns
+        - __sap_vm_provision_task_ibmcloud_ssh_public_key
+        - __sap_vm_provision_task_ibmcloud_vpc_subnet
+        - __sap_vm_provision_task_ibmcloud_vpc_sg
+        - __sap_vm_provision_task_ibmcloud_pdns_service_instance
+        - __sap_vm_provision_task_ibmcloud_pdns
+        - __sap_vm_provision_task_ibmcloud_os_image_list
+        - __sap_vm_provision_task_provision_host_all_run
+        - __sap_vm_provision_task_provision_host_all_add
+        - __sap_vm_provision_task_provision_host_single
+        - __sap_vm_provision_task_provision_host_single_volumes
+        - __sap_vm_provision_task_provision_host_single_volume_attachments
+        - __sap_vm_provision_task_provision_host_single_info
+        - __sap_vm_provision_task_ibmcloud_pdns_record
+      loop_control:
+        loop_var: loop_item
+        index_var: loop_item_index
+        label: "{{ 'Variable No. ' + (loop_item_index | string) }}"
+      when:
+        - lookup('ansible.builtin.vars', loop_item, default='') | length > 0
+        - not lookup('ansible.builtin.vars', loop_item, default='') is skipped
+        - lookup('ansible.builtin.vars', loop_item, default='') is failed
+
 
 - name: Ansible Task block to execute on target inventory hosts
   delegate_to: "{{ inventory_hostname }}"
@@ -242,10 +302,13 @@
 
 - name: Ansible Task block for looped provisioning of High Availability resources for Google Cloud CE VMs
   delegate_to: localhost
+  any_errors_fatal: true
   run_once: true
-  environment:
-    GCP_AUTH_KIND: "serviceaccount"
-    GCP_SERVICE_ACCOUNT_FILE: "{{ sap_vm_provision_gcp_credentials_json }}"
+  # Using environment, no_log is ineffective and log will show 'EXEC /bin/sh -c 'ENV_VAR=value python3 /AnsiballZ_ansible_module_name.py && sleep 0'
+  # Therefore do not use environment for secrets, use only for non-sensitive values as this will reduce Ansible Task parameters.
+  # environment:
+  #   GCP_AUTH_KIND: "serviceaccount"
+  #   GCP_SERVICE_ACCOUNT_FILE: "{{ sap_vm_provision_gcp_credentials_json }}"
   when:
     - sap_ha_pacemaker_cluster_gcp_region_zone is defined
     - (groups["hana_secondary"] is defined and (groups["hana_secondary"] | length>0)) or (groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0)) or (groups["anydb_secondary"] is defined and (groups["anydb_secondary"] | length>0))
@@ -254,7 +317,35 @@
     - name: Provision High Availability resources for GCP CE hosts
       ansible.builtin.include_tasks:
         file: "{{ 'platform_' + sap_vm_provision_iac_type }}/{{ sap_vm_provision_iac_platform }}/execute_setup_ha.yml"
-        apply:
-          environment:
-            GCP_AUTH_KIND: "serviceaccount"
-            GCP_SERVICE_ACCOUNT_FILE: "{{ sap_vm_provision_gcp_credentials_json }}"
+        # apply:
+        #   environment:
+        #     GCP_AUTH_KIND: "serviceaccount"
+        #     GCP_SERVICE_ACCOUNT_FILE: "{{ sap_vm_provision_gcp_credentials_json }}"
+
+  rescue:
+    # This requires no_log set on each Ansible Task, and not set on the Ansible Task Block
+    # This requires an Ansible Task Block containing the Ansible Tasks for calling
+    # Infrastructure Platform APIs (via Ansible Modules)
+    - name: Show errors in task outputs
+      ansible.builtin.fail:
+        msg: "{{ lookup('ansible.builtin.vars', loop_item) }}"
+      loop:
+        - __sap_vm_provision_task_ibmcloud_iam_auth_policy
+        - __sap_vm_provision_task_ibmcloud_lb_provision_parallel
+        - __sap_vm_provision_task_ibmcloud_lb_provision_parallel_async_status
+        - __sap_vm_provision_task_ibmcloud_lb_update_dns
+        - __sap_vm_provision_task_ibmcloud_vs_all_info
+        - __sap_vm_provision_task_ibmcloud_lb_all_info_shell
+        - __sap_vm_provision_task_ibmcloud_lb_pool_hana1
+        - __sap_vm_provision_task_ibmcloud_pdns_record_ha_hana
+        - __sap_vm_provision_task_ibmcloud_pdns_record_ha_anydb
+        - __sap_vm_provision_task_ibmcloud_pdns_record_ha_nwas_ascs
+        - __sap_vm_provision_task_ibmcloud_pdns_record_ha_nwas_ers
+      loop_control:
+        loop_var: loop_item
+        index_var: loop_item_index
+        label: "{{ 'Variable No. ' + (loop_item_index | string) }}"
+      when:
+        - lookup('ansible.builtin.vars', loop_item, default='') | length > 0
+        - not lookup('ansible.builtin.vars', loop_item, default='') is skipped
+        - lookup('ansible.builtin.vars', loop_item, default='') is failed

--- a/roles/sap_vm_provision/tasks/platform_ansible/gcp_ce_vm/execute_main.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/gcp_ce_vm/execute_main.yml
@@ -68,7 +68,7 @@
         groups_merged_list: "{{ [ [ groups['hana_primary'] | default([]) ] , [ groups['hana_secondary'] | default([]) ] , [ groups['nwas_ascs'] | default([]) ] , [ groups['nwas_ers'] | default([]) ] , [ groups['nwas_pas'] | default([]) ] , [ groups['nwas_aas'] | default([]) ] ] | flatten | select() }}"
 
     - name: Set Ansible Vars
-      register: register_set_ansible_vars
+      register: __sap_vm_provision_task_ansible_vars_set
       ansible.builtin.include_tasks:
         file: common/set_ansible_vars.yml
 
@@ -202,26 +202,26 @@
 
 
     - name: Set /etc/hosts
-      register: register_etc_hosts_file
+      register: __sap_vm_provision_task_os_etc_hosts
       ansible.builtin.include_tasks:
         file: common/set_etc_hosts.yml
 
     - name: Set /etc/hosts for HA
-      register: register_etc_hosts_file_ha
+      register: __sap_vm_provision_task_os_etc_hosts_ha
       ansible.builtin.include_tasks:
         file: common/set_etc_hosts_ha.yml
       when:
         - (groups["hana_secondary"] is defined and (groups["hana_secondary"] | length>0)) or (groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0)) or (groups["anydb_secondary"] is defined and (groups["anydb_secondary"] | length>0))
 
     - name: Set /etc/hosts for Scale-Out
-      register: register_etc_hosts_file_scaleout
+      register: __sap_vm_provision_task_os_etc_hosts_scaleout
       ansible.builtin.include_tasks:
         file: common/set_etc_hosts_scaleout.yml
       when:
         - (groups["hana_primary"] is defined and (groups["hana_primary"] | length>0)) and (sap_hana_scaleout_active_coordinator is defined or sap_hana_scaleout_active_worker is defined or sap_hana_scaleout_standby is defined)
 
     - name: Set vars for sap_storage_setup Ansible Role
-      register: register_ansible_vars_storage
+      register: __sap_vm_provision_task_ansible_vars_storage
       ansible.builtin.include_tasks:
         file: common/set_ansible_vars_storage.yml
 

--- a/roles/sap_vm_provision/tasks/platform_ansible/gcp_ce_vm/execute_provision.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/gcp_ce_vm/execute_provision.yml
@@ -74,7 +74,7 @@
           'interface': 'SCSI',
           'initialize_params': {
             'disk_type': 'pd-standard',
-            'source_image': register_gcp_os_image.resources[0].selfLink
+            'source_image': __sap_vm_provision_task_gcp_os_image_info.resources[0].selfLink
           }
         }
       ] -%}
@@ -105,9 +105,9 @@
     can_ip_forward: "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][scaleout_origin_host_spec | default(inventory_hostname)].disable_ip_anti_spoofing }}" # When disable the Anti IP Spoofing = true, then Can IP Forward = true
     network_interfaces:
       - network:
-          selfLink: "{{ gcp_vpc_info.resources[0].selfLink }}"
+          selfLink: "{{ __sap_vm_provision_task_gcp_vpc_info.resources[0].selfLink }}"
         subnetwork:
-          selfLink: "{{ gcp_vpc_subnet_info.resources[0].selfLink }}"
+          selfLink: "{{ __sap_vm_provision_task_gcp_vpc_subnet_info.resources[0].selfLink }}"
     # 'NVME interface is only supported for confidential VMs or the following VM families: [a3-vm, c1-metal, c2-metal, c3-metal, c3-vm, c3d-vm, ct5p-vm, g2-vm, h3-vm, m3-vm, t2a-vm]
     disks: "{{ provisioned_disks_map }}"
     metadata:

--- a/roles/sap_vm_provision/tasks/platform_ansible/gcp_ce_vm/execute_provision.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/gcp_ce_vm/execute_provision.yml
@@ -124,7 +124,7 @@
   when: __sap_vm_provision_task_provision_host_single.changed
 
 - name: Read Google Cloud VM information
-  google.cloud.gcp_compute___sap_vm_provision_task_provision_host_single_info:
+  google.cloud.gcp_compute_instance_info:
     project: "{{ sap_vm_provision_gcp_project }}"
     zone: "{{ sap_vm_provision_gcp_region_zone }}"
     filters:

--- a/roles/sap_vm_provision/tasks/platform_ansible/gcp_ce_vm/execute_provision.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/gcp_ce_vm/execute_provision.yml
@@ -43,6 +43,7 @@
 # The volume creation task requires the above task to define the parameter
 # which contains the calculated unique device names.
 - name: Provision Google Cloud Persistent Disk volumes for Google Cloud VM filesystems
+  register: __sap_vm_provision_task_provision_host_single_volumes
   google.cloud.gcp_compute_disk:
     state: present
     project: "{{ sap_vm_provision_gcp_project }}"
@@ -56,7 +57,6 @@
     label: "{{ vol_item.definition_key }}: {{ vol_item.name }} (size: {{ vol_item.size }})"
   when:
     - vol_item.size > 0
-  register: __sap_vm_provision_task_provision_host_single_volumes
 #  failed_when: "(__sap_vm_provision_task_provision_host_single_volumes.msg is defined) and ('already exists' not in __sap_vm_provision_task_provision_host_single_volumes.msg)"
 
 
@@ -124,12 +124,12 @@
   when: __sap_vm_provision_task_provision_host_single.changed
 
 - name: Read Google Cloud VM information
+  register: __sap_vm_provision_task_provision_host_single_info
   google.cloud.gcp_compute_instance_info:
     project: "{{ sap_vm_provision_gcp_project }}"
     zone: "{{ sap_vm_provision_gcp_region_zone }}"
     filters:
       - name = {{ inventory_hostname }}
-  register: __sap_vm_provision_task_provision_host_single_info
 
 
 - name: Create fact for delegate host IP

--- a/roles/sap_vm_provision/tasks/platform_ansible/gcp_ce_vm/execute_provision.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/gcp_ce_vm/execute_provision.yml
@@ -43,6 +43,7 @@
 # The volume creation task requires the above task to define the parameter
 # which contains the calculated unique device names.
 - name: Provision Google Cloud Persistent Disk volumes for Google Cloud VM filesystems
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_provision_host_single_volumes
   google.cloud.gcp_compute_disk:
     state: present
@@ -50,6 +51,8 @@
     zone: "{{ sap_vm_provision_gcp_region_zone }}"
     name: "{{ inventory_hostname + '-vol-' + vol_item.name | replace('_', '-')}}"
     size_gb: "{{ vol_item.size }}"
+    auth_kind: "serviceaccount"
+    service_account_contents: "{{ sap_vm_provision_gcp_credentials_json }}"
   loop: "{{ storage_disks_map }}"
   loop_control:
     loop_var: vol_item
@@ -91,6 +94,7 @@
 
 
 - name: Provision Google Cloud VM
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_provision_host_single
   google.cloud.gcp_compute_instance:
     state: present
@@ -115,6 +119,8 @@
         scopes:
           - "https://www.googleapis.com/auth/cloud-platform" # Allow full access to all Cloud APIs
           # ["compute-rw", "storage-rw", "logging-write", "monitoring-write", "service-control", "service-management"]
+    auth_kind: "serviceaccount"
+    service_account_contents: "{{ sap_vm_provision_gcp_credentials_json }}"
 
 # Required as state: present on Ansible Module gcp_compute_instance does not allow for waiting until VM has booted
 - name: Wait 90 seconds for Google Cloud VM to boot
@@ -124,13 +130,15 @@
   when: __sap_vm_provision_task_provision_host_single.changed
 
 - name: Read Google Cloud VM information
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_provision_host_single_info
   google.cloud.gcp_compute_instance_info:
     project: "{{ sap_vm_provision_gcp_project }}"
     zone: "{{ sap_vm_provision_gcp_region_zone }}"
     filters:
       - name = {{ inventory_hostname }}
-
+    auth_kind: "serviceaccount"
+    service_account_contents: "{{ sap_vm_provision_gcp_credentials_json }}"
 
 - name: Create fact for delegate host IP
   ansible.builtin.set_fact:

--- a/roles/sap_vm_provision/tasks/platform_ansible/gcp_ce_vm/execute_provision.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/gcp_ce_vm/execute_provision.yml
@@ -177,11 +177,11 @@
           {{ lookup('ansible.builtin.file', sap_vm_provision_ssh_host_public_key_file_path ) }}
 
     - name: Permit root login
+      register: __sap_vm_provision_task_os_sshd_config
       ansible.builtin.replace:
         path: /etc/ssh/sshd_config
         regexp: '(^PermitRootLogin no)'
         replace: 'PermitRootLogin yes'
-      register: __sap_vm_provision_task_os_sshd_config
 
     - name: Reload sshd service
       ansible.builtin.service:

--- a/roles/sap_vm_provision/tasks/platform_ansible/gcp_ce_vm/execute_provision.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/gcp_ce_vm/execute_provision.yml
@@ -56,8 +56,8 @@
     label: "{{ vol_item.definition_key }}: {{ vol_item.name }} (size: {{ vol_item.size }})"
   when:
     - vol_item.size > 0
-  register: volume_provisioning
-#  failed_when: "(volume_provisioning.msg is defined) and ('already exists' not in volume_provisioning.msg)"
+  register: __sap_vm_provision_task_provision_host_single_volumes
+#  failed_when: "(__sap_vm_provision_task_provision_host_single_volumes.msg is defined) and ('already exists' not in __sap_vm_provision_task_provision_host_single_volumes.msg)"
 
 
 # Create list of disks to attach to GCP VM
@@ -75,7 +75,7 @@
           }
         }
       ] -%}
-      {% for storage_item in volume_provisioning.results -%}
+      {% for storage_item in __sap_vm_provision_task_provision_host_single_volumes.results -%}
         {% set vol = disks_map.extend([
         {
           'auto_delete': 'true',
@@ -91,7 +91,7 @@
 
 
 - name: Provision Google Cloud VM
-  register: register_provisioned_host_single
+  register: __sap_vm_provision_task_provision_host_single
   google.cloud.gcp_compute_instance:
     state: present
     project: "{{ sap_vm_provision_gcp_project }}"
@@ -121,20 +121,20 @@
   ansible.builtin.pause:
     seconds: 90
     prompt: ""
-  when: register_provisioned_host_single.changed
+  when: __sap_vm_provision_task_provision_host_single.changed
 
 - name: Read Google Cloud VM information
-  google.cloud.gcp_compute_instance_info:
+  google.cloud.gcp_compute___sap_vm_provision_task_provision_host_single_info:
     project: "{{ sap_vm_provision_gcp_project }}"
     zone: "{{ sap_vm_provision_gcp_region_zone }}"
     filters:
       - name = {{ inventory_hostname }}
-  register: instance_info
+  register: __sap_vm_provision_task_provision_host_single_info
 
 
 - name: Create fact for delegate host IP
   ansible.builtin.set_fact:
-    provisioned_private_ip: "{{ register_provisioned_host_single.networkInterfaces[0].networkIP }}"
+    provisioned_private_ip: "{{ __sap_vm_provision_task_provision_host_single.networkInterfaces[0].networkIP }}"
 
 
 - name: Copy facts to delegate host
@@ -146,7 +146,7 @@
     delegate_sap_vm_provision_bastion_ssh_port: "{{ sap_vm_provision_bastion_ssh_port }}"
     delegate_sap_vm_provision_ssh_bastion_private_key_file_path: "{{ sap_vm_provision_ssh_bastion_private_key_file_path }}"
     delegate_sap_vm_provision_ssh_host_private_key_file_path: "{{ sap_vm_provision_ssh_host_private_key_file_path }}"
-    delegate_private_ip: "{{ register_provisioned_host_single.networkInterfaces[0].networkIP }}"
+    delegate_private_ip: "{{ __sap_vm_provision_task_provision_host_single.networkInterfaces[0].networkIP }}"
     delegate_hostname: "{{ inventory_hostname }}"
     delegate_sap_vm_provision_dns_root_domain_name: "{{ sap_vm_provision_dns_root_domain }}"
 
@@ -195,8 +195,8 @@
 
 - name: Append loop value to register
   ansible.builtin.set_fact:
-    register_provisioned_host_single: "{{ register_provisioned_host_single | combine( { 'host_node' : inventory_hostname } , { 'sap_host_type' : lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][scaleout_origin_host_spec | default(inventory_hostname)].sap_host_type } , { 'sap_system_type' : (lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][scaleout_origin_host_spec | default(inventory_hostname)].sap_system_type | default('')) } ) }}"
+    __sap_vm_provision_task_provision_host_single: "{{ __sap_vm_provision_task_provision_host_single | combine( { 'host_node' : inventory_hostname } , { 'sap_host_type' : lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][scaleout_origin_host_spec | default(inventory_hostname)].sap_host_type } , { 'sap_system_type' : (lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][scaleout_origin_host_spec | default(inventory_hostname)].sap_system_type | default('')) } ) }}"
 
 - name: Append output to merged register
   ansible.builtin.set_fact:
-    register_provisioned_host_all: "{{ register_provisioned_host_all + [register_provisioned_host_single] }}"
+    register_provisioned_host_all: "{{ register_provisioned_host_all + [__sap_vm_provision_task_provision_host_single] }}"

--- a/roles/sap_vm_provision/tasks/platform_ansible/gcp_ce_vm/execute_provision.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/gcp_ce_vm/execute_provision.yml
@@ -181,7 +181,7 @@
         path: /etc/ssh/sshd_config
         regexp: '(^PermitRootLogin no)'
         replace: 'PermitRootLogin yes'
-      register: sshd_config
+      register: __sap_vm_provision_task_os_sshd_config
 
     - name: Reload sshd service
       ansible.builtin.service:

--- a/roles/sap_vm_provision/tasks/platform_ansible/gcp_ce_vm/execute_setup_ha.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/gcp_ce_vm/execute_setup_ha.yml
@@ -5,16 +5,16 @@
 
 # - name: GCP append route for SAP HANA HA (route must be outside of existing VPC Subnet Range/s)
 #   no_log: "{{ __sap_vm_provision_no_log }}"
-#   register: gcp_vpc_subnet_rt_route_sap_hana
+#   register: __sap_vm_provision_task_gcp_vpc_subnet_rt_route_sap_hana
 #   google.cloud.gcp_compute_route:
 #     state: present
 #     project: "{{ sap_vm_provision_gcp_project }}"
 #     name: "{{ sap_swpm_db_host }}-vip"
 #     dest_range: "{{ (sap_ha_pacemaker_cluster_vip_hana_primary_ip_address | default('192.168.1.90/32')) | regex_replace('/.*', '') }}"
 #     next_hop_instance:
-#       selfLink: "{{ gcp_vm_info | json_query('results[*].resources[?name==`' + host_node + '`].selfLink') | flatten | join(' ') }}"
+#       selfLink: "{{ __sap_vm_provision_task_provision_host_single_info | json_query('results[*].resources[?name==`' + host_node + '`].selfLink') | flatten | join(' ') }}"
 #     network:
-#       selfLink: "{{ gcp_vpc_info.resources[0].selfLink }}"
+#       selfLink: "{{ __sap_vm_provision_task_gcp_vpc_info.resources[0].selfLink }}"
 #     auth_kind: "serviceaccount"
 #     service_account_contents: "{{ sap_vm_provision_gcp_credentials_json }}"
 #   loop: "{{ (groups['hana_primary'] | default([])) }}"
@@ -29,7 +29,7 @@
     state: present
     project: "{{ sap_vm_provision_gcp_project }}"
     managed_zone:
-      name: "{{ gcp_pdns_info.resources[0].name }}"
+      name: "{{ __sap_vm_provision_task_gcp_pdns_info.resources[0].name }}"
       dnsName: "{{ hostvars[host_node].sap_vm_provision_dns_root_domain }}."
     name: "{{ sap_swpm_db_host }}.{{ hostvars[host_node].sap_vm_provision_dns_root_domain }}."
     target:
@@ -47,16 +47,16 @@
 
 # - name: GCP append route for SAP AnyDB HA (route must be outside of existing VPC Subnet Range/s)
 #   no_log: "{{ __sap_vm_provision_no_log }}"
-#   register: gcp_vpc_subnet_rt_route_sap_hana
+#   register: __sap_vm_provision_task_gcp_vpc_subnet_rt_route_sap_hana
 #   google.cloud.gcp_compute_route:
 #     state: present
 #     project: "{{ sap_vm_provision_gcp_project }}"
 #     name: "{{ sap_swpm_db_host }}-vip"
 #     dest_range: "{{ (sap_vm_temp_vip_anydb_primary | default('192.168.1.90/32')) | regex_replace('/.*', '') }}"
 #     next_hop_instance:
-#       selfLink: "{{ gcp_vm_info | json_query('results[*].resources[?name==`' + host_node + '`].selfLink') | flatten | join(' ') }}"
+#       selfLink: "{{ __sap_vm_provision_task_provision_host_single_info | json_query('results[*].resources[?name==`' + host_node + '`].selfLink') | flatten | join(' ') }}"
 #     network:
-#       selfLink: "{{ gcp_vpc_info.resources[0].selfLink }}"
+#       selfLink: "{{ __sap_vm_provision_task_gcp_vpc_info.resources[0].selfLink }}"
 #     auth_kind: "serviceaccount"
 #     service_account_contents: "{{ sap_vm_provision_gcp_credentials_json }}"
 #   loop: "{{ (groups['anydb_primary'] | default([])) }}"
@@ -71,7 +71,7 @@
     state: present
     project: "{{ sap_vm_provision_gcp_project }}"
     managed_zone:
-      name: "{{ gcp_pdns_info.resources[0].name }}"
+      name: "{{ __sap_vm_provision_task_gcp_pdns_info.resources[0].name }}"
       dnsName: "{{ hostvars[host_node].sap_vm_provision_dns_root_domain }}."
     name: "{{ sap_swpm_db_host }}.{{ hostvars[host_node].sap_vm_provision_dns_root_domain }}."
     target:
@@ -89,16 +89,16 @@
 
 # - name: GCP append route for SAP NetWeaver ASCS HA (route must be outside of existing VPC Subnet Range/s)
 #   no_log: "{{ __sap_vm_provision_no_log }}"
-#   register: gcp_vpc_subnet_rt_route_sap_netweaver_ascs
+#   register: __sap_vm_provision_task_gcp_vpc_subnet_rt_route_sap_netweaver_ascs
 #   google.cloud.gcp_compute_route:
 #     state: present
 #     project: "{{ sap_vm_provision_gcp_project }}"
 #     name: "{{ sap_swpm_ascs_instance_hostname }}-vip"
 #     dest_range: "{{ (sap_ha_pacemaker_cluster_vip_nwas_abap_ascs_ip_address | default('192.168.2.10/32')) | regex_replace('/.*', '') }}"
 #     next_hop_instance:
-#       selfLink: "{{ gcp_vm_info | json_query('results[*].resources[?name==`' + host_node + '`].selfLink') | flatten | join(' ') }}"
+#       selfLink: "{{ __sap_vm_provision_task_provision_host_single_info | json_query('results[*].resources[?name==`' + host_node + '`].selfLink') | flatten | join(' ') }}"
 #     network:
-#       selfLink: "{{ gcp_vpc_info.resources[0].selfLink }}"
+#       selfLink: "{{ __sap_vm_provision_task_gcp_vpc_info.resources[0].selfLink }}"
 #     auth_kind: "serviceaccount"
 #     service_account_contents: "{{ sap_vm_provision_gcp_credentials_json }}"
 #   loop: "{{ (groups['nwas_ascs'] | default([])) }}"
@@ -113,7 +113,7 @@
     state: present
     project: "{{ sap_vm_provision_gcp_project }}"
     managed_zone:
-      name: "{{ gcp_pdns_info.resources[0].name }}"
+      name: "{{ __sap_vm_provision_task_gcp_pdns_info.resources[0].name }}"
       dnsName: "{{ hostvars[host_node].sap_vm_provision_dns_root_domain }}."
     name: "{{ sap_swpm_ascs_instance_hostname }}.{{ hostvars[host_node].sap_vm_provision_dns_root_domain }}."
     target:
@@ -131,16 +131,16 @@
 
 # - name: GCP append route for SAP NetWeaver ERS HA
 #   no_log: "{{ __sap_vm_provision_no_log }}"
-#   register: gcp_vpc_subnet_rt_route_sap_netweaver_ers
+#   register: __sap_vm_provision_task_gcp_vpc_subnet_rt_route_sap_netweaver_ers
 #   google.cloud.gcp_compute_route:
 #     state: present
 #     project: "{{ sap_vm_provision_gcp_project }}"
 #     name: "{{ sap_swpm_ers_instance_hostname }}-vip"
 #     dest_range: "{{ (sap_ha_pacemaker_cluster_vip_nwas_abap_ers_ip_address | default('192.168.2.11/32')) | regex_replace('/.*', '') }}"
 #     next_hop_instance:
-#       selfLink: "{{ gcp_vm_info | json_query('results[*].resources[?name==`' + host_node + '`].selfLink') | flatten | join(' ') }}"
+#       selfLink: "{{ __sap_vm_provision_task_provision_host_single_info | json_query('results[*].resources[?name==`' + host_node + '`].selfLink') | flatten | join(' ') }}"
 #     network:
-#       selfLink: "{{ gcp_vpc_info.resources[0].selfLink }}"
+#       selfLink: "{{ __sap_vm_provision_task_gcp_vpc_info.resources[0].selfLink }}"
 #     auth_kind: "serviceaccount"
 #     service_account_contents: "{{ sap_vm_provision_gcp_credentials_json }}"
 #   loop: "{{ (groups['nwas_ers'] | default([])) }}"
@@ -155,7 +155,7 @@
     state: present
     project: "{{ sap_vm_provision_gcp_project }}"
     managed_zone:
-      name: "{{ gcp_pdns_info.resources[0].name }}"
+      name: "{{ __sap_vm_provision_task_gcp_pdns_info.resources[0].name }}"
       dnsName: "{{ hostvars[host_node].sap_vm_provision_dns_root_domain }}."
     name: "{{ sap_swpm_ers_instance_hostname }}.{{ hostvars[host_node].sap_vm_provision_dns_root_domain }}."
     target:
@@ -175,16 +175,16 @@
 
 # - name: GCP append route for SAP NetWeaver PAS HA
 #   no_log: "{{ __sap_vm_provision_no_log }}"
-#   register: gcp_vpc_subnet_rt_route_sap_netweaver_pas
+#   register: __sap_vm_provision_task_gcp_vpc_subnet_rt_route_sap_netweaver_pas
 #   google.cloud.gcp_compute_route:
 #     state: present
 #     project: "{{ sap_vm_provision_gcp_project }}"
 #     name: "{{ sap_swpm_pas_instance_hostname }}-vip"
 #     dest_range: "{{ (sap_ha_pacemaker_cluster_vip_nwas_abap_pas_ip_address | default('192.168.2.12/32')) | regex_replace('/.*', '') }}"
 #     next_hop_instance:
-#       selfLink: "{{ gcp_vm_info | json_query('results[*].resources[?name==`' + host_node + '`].selfLink') | flatten | join(' ') }}"
+#       selfLink: "{{ __sap_vm_provision_task_provision_host_single_info | json_query('results[*].resources[?name==`' + host_node + '`].selfLink') | flatten | join(' ') }}"
 #     network:
-#       selfLink: "{{ gcp_vpc_info.resources[0].selfLink }}"
+#       selfLink: "{{ __sap_vm_provision_task_gcp_vpc_info.resources[0].selfLink }}"
 #     auth_kind: "serviceaccount"
 #     service_account_contents: "{{ sap_vm_provision_gcp_credentials_json }}"
 #   loop: "{{ (groups['nwas_pas'] | default([])) }}"
@@ -199,7 +199,7 @@
 #     state: present
 #     project: "{{ sap_vm_provision_gcp_project }}"
 #     managed_zone:
-#       name: "{{ gcp_pdns_info.resources[0].name }}"
+#       name: "{{ __sap_vm_provision_task_gcp_pdns_info.resources[0].name }}"
 #       dnsName: "{{ hostvars[host_node].sap_vm_provision_dns_root_domain }}."
 #     name: "{{ sap_swpm_pas_instance_hostname }}.{{ hostvars[host_node].sap_vm_provision_dns_root_domain }}."
 #     target:
@@ -217,16 +217,16 @@
 
 # - name: GCP append route for SAP NetWeaver AAS HA
 #   no_log: "{{ __sap_vm_provision_no_log }}"
-#   register: gcp_vpc_subnet_rt_route_sap_netweaver_aas
+#   register: __sap_vm_provision_task_gcp_vpc_subnet_rt_route_sap_netweaver_aas
 #   google.cloud.gcp_compute_route:
 #     state: present
 #     project: "{{ sap_vm_provision_gcp_project }}"
 #     name: "{{ sap_swpm_aas_instance_hostname }}-vip"
 #     dest_range: "{{ (sap_ha_pacemaker_cluster_vip_nwas_abap_aas_ip_address | default('192.168.2.13/32')) | regex_replace('/.*', '') }}"
 #     next_hop_instance:
-#       selfLink: "{{ gcp_vm_info | json_query('results[*].resources[?name==`' + host_node + '`].selfLink') | flatten | join(' ') }}"
+#       selfLink: "{{ __sap_vm_provision_task_provision_host_single_info | json_query('results[*].resources[?name==`' + host_node + '`].selfLink') | flatten | join(' ') }}"
 #     network:
-#       selfLink: "{{ gcp_vpc_info.resources[0].selfLink }}"
+#       selfLink: "{{ __sap_vm_provision_task_gcp_vpc_info.resources[0].selfLink }}"
 #     auth_kind: "serviceaccount"
 #     service_account_contents: "{{ sap_vm_provision_gcp_credentials_json }}"
 #   loop: "{{ (groups['nwas_aas'] | default([])) }}"
@@ -241,7 +241,7 @@
 #     state: present
 #     project: "{{ sap_vm_provision_gcp_project }}"
 #     managed_zone:
-#       name: "{{ gcp_pdns_info.resources[0].name }}"
+#       name: "{{ __sap_vm_provision_task_gcp_pdns_info.resources[0].name }}"
 #       dnsName: "{{ hostvars[host_node].sap_vm_provision_dns_root_domain }}."
 #     name: "{{ sap_swpm_aas_instance_hostname }}.{{ hostvars[host_node].sap_vm_provision_dns_root_domain }}."
 #     target:
@@ -274,12 +274,12 @@
 
 - name: Create Google Cloud Compute Engine Reserved Static Internal IP Address for the Virtual IP (VIP) of SAP HANA
   no_log: "{{ __sap_vm_provision_no_log }}"
-  register: gcp_lb_reserved_address
+  register: __sap_vm_provision_task_gcp_lb_reserved_address
   google.cloud.gcp_compute_address:
     state: present
     project: "{{ sap_vm_provision_gcp_project }}"
     region: "{{ sap_vm_provision_gcp_region }}"
-    subnetwork: { "selfLink": "{{ gcp_vpc_subnet_info.resources[0].selfLink }}" }
+    subnetwork: { "selfLink": "{{ __sap_vm_provision_task_gcp_vpc_subnet_info.resources[0].selfLink }}" }
     name: "lb-reserved-static-ip-vip-hana-{{ vip_item_nr }}"
     address_type: internal
     address: "{{ vip_item | regex_replace('/.*', '') }}"
@@ -298,7 +298,7 @@
 
 - name: Create Google Cloud Compute Engine Health Check (Global) service instance for SAP HANA
   no_log: "{{ __sap_vm_provision_no_log }}"
-  register: gcp_lb_healthcheck_service
+  register: __sap_vm_provision_task_gcp_lb_healthcheck_service
   google.cloud.gcp_compute_health_check:
     state: present
     project: "{{ sap_vm_provision_gcp_project }}"
@@ -318,7 +318,7 @@
 
 - name: Gather GCP VM information
   no_log: "{{ __sap_vm_provision_no_log }}"
-  register: gcp_vm_info
+  register: __sap_vm_provision_task_provision_host_single_info
   google.cloud.gcp_compute_instance_info:
     project: "{{ sap_vm_provision_gcp_project }}"
     zone: "{{ sap_vm_provision_gcp_region_zone }}"
@@ -334,14 +334,14 @@
 
 - name: Create Google Cloud Compute Engine Instance Group (Self-Managed/Unmanaged) Primary - for SAP HANA
   no_log: "{{ __sap_vm_provision_no_log }}"
-  register: gcp_lb_instance_group1
+  register: __sap_vm_provision_task_gcp_lb_instance_group1
   google.cloud.gcp_compute_instance_group:
     state: present
     project: "{{ sap_vm_provision_gcp_project }}"
     name: "lb-instance-group-hana-primary"
-    zone: "{{ gcp_vm_info | json_query('results[*].resources[?name==`' + host_node + '`].zone') | flatten | join(' ') | basename }}"
+    zone: "{{ __sap_vm_provision_task_provision_host_single_info | json_query('results[*].resources[?name==`' + host_node + '`].zone') | flatten | join(' ') | basename }}"
     instances:
-      - { "selfLink": "{{ gcp_vm_info | json_query('results[*].resources[?name==`' + host_node + '`].selfLink') | flatten | join(' ') }}" }
+      - { "selfLink": "{{ __sap_vm_provision_task_provision_host_single_info | json_query('results[*].resources[?name==`' + host_node + '`].selfLink') | flatten | join(' ') }}" }
     #named_ports:
     #  - name: http # default, not applicable to internal passthrough NLB, only applicable to proxy NLB
     #    port: 80 # default
@@ -355,14 +355,14 @@
 
 - name: Create Google Cloud Compute Engine Instance Group (Self-Managed/Unmanaged) Secondary (Failover) - for SAP HANA
   no_log: "{{ __sap_vm_provision_no_log }}"
-  register: gcp_lb_instance_group2
+  register: __sap_vm_provision_task_gcp_lb_instance_group2
   google.cloud.gcp_compute_instance_group:
     state: present
     project: "{{ sap_vm_provision_gcp_project }}"
     name: "lb-instance-group-hana-secondary"
-    zone: "{{ gcp_vm_info | json_query('results[*].resources[?name==`' + host_node + '`].zone') | flatten | join(' ') | basename }}"
+    zone: "{{ __sap_vm_provision_task_provision_host_single_info | json_query('results[*].resources[?name==`' + host_node + '`].zone') | flatten | join(' ') | basename }}"
     instances:
-      - { "selfLink": "{{ gcp_vm_info | json_query('results[*].resources[?name==`' + host_node + '`].selfLink') | flatten | join(' ') }}" }
+      - { "selfLink": "{{ __sap_vm_provision_task_provision_host_single_info | json_query('results[*].resources[?name==`' + host_node + '`].selfLink') | flatten | join(' ') }}" }
     #named_ports:
     #  - name: http # default, not applicable to internal passthrough NLB, only applicable to proxy NLB
     #    port: 80 # default
@@ -378,21 +378,21 @@
 # No option for --global-health-checks ?
 - name: Create Google Cloud Compute Engine Backend Service (Regional) for the Internal passthrough Network Load Balancer used by SAP HANA
   no_log: "{{ __sap_vm_provision_no_log }}"
-  register: gcp_lb_backend_service_regional
+  register: __sap_vm_provision_task_gcp_lb_backend_service_regional
   google.cloud.gcp_compute_region_backend_service:
     state: present
     project: "{{ sap_vm_provision_gcp_project }}"
     region: "{{ sap_vm_provision_gcp_region }}"
     name: "lb-backend-service-hana"
     backends:
-      - group: "{{ gcp_lb_instance_group1.results[0].selfLink }}"
+      - group: "{{ __sap_vm_provision_task_gcp_lb_instance_group1.results[0].selfLink }}"
         balancing_mode: CONNECTION # UTILIZATION , RATE , CONNECTION
         #failover: false # Should be unset according to GCP for SAP documentation, which is different than set to false
-      - group: "{{ gcp_lb_instance_group2.results[0].selfLink }}"
+      - group: "{{ __sap_vm_provision_task_gcp_lb_instance_group2.results[0].selfLink }}"
         balancing_mode: CONNECTION # UTILIZATION , RATE , CONNECTION
         failover: true
     health_checks:
-      - "{{ gcp_lb_healthcheck_service.selfLink }}"
+      - "{{ __sap_vm_provision_task_gcp_lb_healthcheck_service.selfLink }}"
     load_balancing_scheme: INTERNAL
     failover_policy:
       disable_connection_drain_on_failover: true
@@ -407,7 +407,7 @@
 
 - name: Create Google Cloud Compute Engine Forwarding Rule (aka. Frontend IP and Port) for SAP HANA
   no_log: "{{ __sap_vm_provision_no_log }}"
-  register: gcp_lb_forwarding_rule
+  register: __sap_vm_provision_task_gcp_lb_forwarding_rule
   google.cloud.gcp_compute_forwarding_rule:
     state: present
     project: "{{ sap_vm_provision_gcp_project }}"
@@ -417,9 +417,9 @@
     ip_address: "{{ vip_item | regex_replace('/.*', '') }}"
     all_ports: true # For internal network load balancing, allow any ports to be forwarded to the backend service (can not be set if ports are defined)
     allow_global_access: false # Only for use if access to the SAP HANA Database Server is required from outside of the GCP Region
-    backend_service: { "selfLink": "{{ gcp_lb_backend_service_regional.selfLink }}" } # Mandatory, otherwise error "Invalid value for field 'resource.target'"
+    backend_service: { "selfLink": "{{ __sap_vm_provision_task_gcp_lb_backend_service_regional.selfLink }}" } # Mandatory, otherwise error "Invalid value for field 'resource.target'"
     #backend_service: { "selfLink": "https://www.googleapis.com/compute/v1/projects/{{ sap_vm_provision_gcp_project }}/regions/{{ sap_vm_provision_gcp_region }}/backendServices/lb-backend-service-hana" }
-    subnetwork: { "selfLink": "{{ gcp_vpc_subnet_info.resources[0].selfLink }}" }
+    subnetwork: { "selfLink": "{{ __sap_vm_provision_task_gcp_vpc_subnet_info.resources[0].selfLink }}" }
     load_balancing_scheme: INTERNAL
     network_tier: PREMIUM
     auth_kind: "serviceaccount"
@@ -435,7 +435,7 @@
 
 - name: Get information on Google Cloud Compute Engine (Regional) Backend Service
   no_log: "{{ __sap_vm_provision_no_log }}"
-  register: gcp_info_lb_backend_service_regional
+  register: __sap_vm_provision_task_gcp_lb_backend_service_regional
   google.cloud.gcp_compute_region_backend_service_info:
     project: "{{ sap_vm_provision_gcp_project }}"
     region: "{{ sap_vm_provision_gcp_region }}"
@@ -449,12 +449,12 @@
 
 - name: Create Google Cloud Compute Engine Reserved Static Internal IP Address for the Virtual IP (VIP) of SAP AnyDB
   no_log: "{{ __sap_vm_provision_no_log }}"
-  register: gcp_lb_reserved_address
+  register: __sap_vm_provision_task_gcp_lb_reserved_address
   google.cloud.gcp_compute_address:
     state: present
     project: "{{ sap_vm_provision_gcp_project }}"
     region: "{{ sap_vm_provision_gcp_region }}"
-    subnetwork: { "selfLink": "{{ gcp_vpc_subnet_info.resources[0].selfLink }}" }
+    subnetwork: { "selfLink": "{{ __sap_vm_provision_task_gcp_vpc_subnet_info.resources[0].selfLink }}" }
     name: "lb-reserved-static-ip-vip-anydb-{{ vip_item_nr }}"
     address_type: internal
     address: "{{ vip_item | regex_replace('/.*', '') }}"
@@ -473,7 +473,7 @@
 
 - name: Create Google Cloud Compute Engine Health Check (Global) service instance for SAP AnyDB
   no_log: "{{ __sap_vm_provision_no_log }}"
-  register: gcp_lb_healthcheck_service
+  register: __sap_vm_provision_task_gcp_lb_healthcheck_service
   google.cloud.gcp_compute_health_check:
     state: present
     project: "{{ sap_vm_provision_gcp_project }}"
@@ -493,7 +493,7 @@
 
 - name: Gather GCP VM information
   no_log: "{{ __sap_vm_provision_no_log }}"
-  register: gcp_vm_info
+  register: __sap_vm_provision_task_provision_host_single_info
   google.cloud.gcp_compute_instance_info:
     project: "{{ sap_vm_provision_gcp_project }}"
     zone: "{{ sap_vm_provision_gcp_region_zone }}"
@@ -509,14 +509,14 @@
 
 - name: Create Google Cloud Compute Engine Instance Group (Self-Managed/Unmanaged) Primary - for SAP AnyDB
   no_log: "{{ __sap_vm_provision_no_log }}"
-  register: gcp_lb_instance_group1
+  register: __sap_vm_provision_task_gcp_lb_instance_group1
   google.cloud.gcp_compute_instance_group:
     state: present
     project: "{{ sap_vm_provision_gcp_project }}"
     name: "lb-instance-group-anydb-primary"
-    zone: "{{ gcp_vm_info | json_query('results[*].resources[?name==`' + host_node + '`].zone') | flatten | join(' ') | basename }}"
+    zone: "{{ __sap_vm_provision_task_provision_host_single_info | json_query('results[*].resources[?name==`' + host_node + '`].zone') | flatten | join(' ') | basename }}"
     instances:
-      - { "selfLink": "{{ gcp_vm_info | json_query('results[*].resources[?name==`' + host_node + '`].selfLink') | flatten | join(' ') }}" }
+      - { "selfLink": "{{ __sap_vm_provision_task_provision_host_single_info | json_query('results[*].resources[?name==`' + host_node + '`].selfLink') | flatten | join(' ') }}" }
     #named_ports:
     #  - name: http # default, not applicable to internal passthrough NLB, only applicable to proxy NLB
     #    port: 80 # default
@@ -530,14 +530,14 @@
 
 - name: Create Google Cloud Compute Engine Instance Group (Self-Managed/Unmanaged) Secondary (Failover) - for SAP AnyDB
   no_log: "{{ __sap_vm_provision_no_log }}"
-  register: gcp_lb_instance_group2
+  register: __sap_vm_provision_task_gcp_lb_instance_group2
   google.cloud.gcp_compute_instance_group:
     state: present
     project: "{{ sap_vm_provision_gcp_project }}"
     name: "lb-instance-group-anydb-secondary"
-    zone: "{{ gcp_vm_info | json_query('results[*].resources[?name==`' + host_node + '`].zone') | flatten | join(' ') | basename }}"
+    zone: "{{ __sap_vm_provision_task_provision_host_single_info | json_query('results[*].resources[?name==`' + host_node + '`].zone') | flatten | join(' ') | basename }}"
     instances:
-      - { "selfLink": "{{ gcp_vm_info | json_query('results[*].resources[?name==`' + host_node + '`].selfLink') | flatten | join(' ') }}" }
+      - { "selfLink": "{{ __sap_vm_provision_task_provision_host_single_info | json_query('results[*].resources[?name==`' + host_node + '`].selfLink') | flatten | join(' ') }}" }
     #named_ports:
     #  - name: http # default, not applicable to internal passthrough NLB, only applicable to proxy NLB
     #    port: 80 # default
@@ -553,21 +553,21 @@
 # No option for --global-health-checks ?
 - name: Create Google Cloud Compute Engine Backend Service (Regional) for the Internal passthrough Network Load Balancer used by SAP AnyDB
   no_log: "{{ __sap_vm_provision_no_log }}"
-  register: gcp_lb_backend_service_regional
+  register: __sap_vm_provision_task_gcp_lb_backend_service_regional
   google.cloud.gcp_compute_region_backend_service:
     state: present
     project: "{{ sap_vm_provision_gcp_project }}"
     region: "{{ sap_vm_provision_gcp_region }}"
     name: "lb-backend-service-anydb"
     backends:
-      - group: "{{ gcp_lb_instance_group1.results[0].selfLink }}"
+      - group: "{{ __sap_vm_provision_task_gcp_lb_instance_group1.results[0].selfLink }}"
         balancing_mode: CONNECTION # UTILIZATION , RATE , CONNECTION
         #failover: false # Should be unset according to GCP for SAP documentation, which is different than set to false
-      - group: "{{ gcp_lb_instance_group2.results[0].selfLink }}"
+      - group: "{{ __sap_vm_provision_task_gcp_lb_instance_group2.results[0].selfLink }}"
         balancing_mode: CONNECTION # UTILIZATION , RATE , CONNECTION
         failover: true
     health_checks:
-      - "{{ gcp_lb_healthcheck_service.selfLink }}"
+      - "{{ __sap_vm_provision_task_gcp_lb_healthcheck_service.selfLink }}"
     load_balancing_scheme: INTERNAL
     failover_policy:
       disable_connection_drain_on_failover: true
@@ -582,7 +582,7 @@
 
 - name: Create Google Cloud Compute Engine Forwarding Rule (aka. Frontend IP and Port) for SAP AnyDB
   no_log: "{{ __sap_vm_provision_no_log }}"
-  register: gcp_lb_forwarding_rule
+  register: __sap_vm_provision_task_gcp_lb_forwarding_rule
   google.cloud.gcp_compute_forwarding_rule:
     state: present
     project: "{{ sap_vm_provision_gcp_project }}"
@@ -592,9 +592,9 @@
     ip_address: "{{ vip_item | regex_replace('/.*', '') }}"
     all_ports: true # For internal network load balancing, allow any ports to be forwarded to the backend service (can not be set if ports are defined)
     allow_global_access: false # Only for use if access to the SAP AnyDB Database Server is required from outside of the GCP Region
-    backend_service: { "selfLink": "{{ gcp_lb_backend_service_regional.selfLink }}" } # Mandatory, otherwise error "Invalid value for field 'resource.target'"
+    backend_service: { "selfLink": "{{ __sap_vm_provision_task_gcp_lb_backend_service_regional.selfLink }}" } # Mandatory, otherwise error "Invalid value for field 'resource.target'"
     #backend_service: { "selfLink": "https://www.googleapis.com/compute/v1/projects/{{ sap_vm_provision_gcp_project }}/regions/{{ sap_vm_provision_gcp_region }}/backendServices/lb-backend-service-anydb" }
-    subnetwork: { "selfLink": "{{ gcp_vpc_subnet_info.resources[0].selfLink }}" }
+    subnetwork: { "selfLink": "{{ __sap_vm_provision_task_gcp_vpc_subnet_info.resources[0].selfLink }}" }
     load_balancing_scheme: INTERNAL
     network_tier: PREMIUM
     auth_kind: "serviceaccount"
@@ -610,7 +610,7 @@
 
 - name: Get information on Google Cloud Compute Engine (Regional) Backend Service
   no_log: "{{ __sap_vm_provision_no_log }}"
-  register: gcp_info_lb_backend_service_regional
+  register: __sap_vm_provision_task_gcp_lb_backend_service_regional
   google.cloud.gcp_compute_region_backend_service_info:
     project: "{{ sap_vm_provision_gcp_project }}"
     region: "{{ sap_vm_provision_gcp_region }}"
@@ -624,12 +624,12 @@
 
 - name: Create Google Cloud Compute Engine Reserved Static Internal IP Address for the Virtual IP (VIP) of SAP NetWeaver ASCS
   no_log: "{{ __sap_vm_provision_no_log }}"
-  register: gcp_lb_reserved_address
+  register: __sap_vm_provision_task_gcp_lb_reserved_address
   google.cloud.gcp_compute_address:
     state: present
     project: "{{ sap_vm_provision_gcp_project }}"
     region: "{{ sap_vm_provision_gcp_region }}"
-    subnetwork: { "selfLink": "{{ gcp_vpc_subnet_info.resources[0].selfLink }}" }
+    subnetwork: { "selfLink": "{{ __sap_vm_provision_task_gcp_vpc_subnet_info.resources[0].selfLink }}" }
     name: "lb-reserved-static-ip-vip-nwas-ascs"
     address_type: internal
     address: "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_ascs_ip_address | regex_replace('/.*', '') }}"
@@ -642,12 +642,12 @@
 
 - name: Create Google Cloud Compute Engine Reserved Static Internal IP Address for the Virtual IP (VIP) of SAP NetWeaver ERS
   no_log: "{{ __sap_vm_provision_no_log }}"
-  register: gcp_lb_reserved_address
+  register: __sap_vm_provision_task_gcp_lb_reserved_address
   google.cloud.gcp_compute_address:
     state: present
     project: "{{ sap_vm_provision_gcp_project }}"
     region: "{{ sap_vm_provision_gcp_region }}"
-    subnetwork: { "selfLink": "{{ gcp_vpc_subnet_info.resources[0].selfLink }}" }
+    subnetwork: { "selfLink": "{{ __sap_vm_provision_task_gcp_vpc_subnet_info.resources[0].selfLink }}" }
     name: "lb-reserved-static-ip-vip-nwas-ers"
     address_type: internal
     address: "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_ers_ip_address | regex_replace('/.*', '') }}"
@@ -660,7 +660,7 @@
 
 - name: Create Google Cloud Compute Engine Health Check (Global) service instance for SAP NetWeaver ASCS
   no_log: "{{ __sap_vm_provision_no_log }}"
-  register: gcp_lb_healthcheck_service_ascs
+  register: __sap_vm_provision_task_gcp_lb_healthcheck_service_ascs
   google.cloud.gcp_compute_health_check:
     state: present
     project: "{{ sap_vm_provision_gcp_project }}"
@@ -680,7 +680,7 @@
 
 - name: Create Google Cloud Compute Engine Health Check (Global) service instance for SAP NetWeaver ERS
   no_log: "{{ __sap_vm_provision_no_log }}"
-  register: gcp_lb_healthcheck_service_ers
+  register: __sap_vm_provision_task_gcp_lb_healthcheck_service_ers
   google.cloud.gcp_compute_health_check:
     state: present
     project: "{{ sap_vm_provision_gcp_project }}"
@@ -700,7 +700,7 @@
 
 - name: Gather GCP VM information
   no_log: "{{ __sap_vm_provision_no_log }}"
-  register: gcp_vm_info
+  register: __sap_vm_provision_task_provision_host_single_info
   google.cloud.gcp_compute_instance_info:
     project: "{{ sap_vm_provision_gcp_project }}"
     zone: "{{ sap_vm_provision_gcp_region_zone }}"
@@ -716,14 +716,14 @@
 
 - name: Create Google Cloud Compute Engine Instance Group (Self-Managed/Unmanaged) Primary - for SAP NetWeaver ASCS
   no_log: "{{ __sap_vm_provision_no_log }}"
-  register: gcp_lb_instance_group1
+  register: __sap_vm_provision_task_gcp_lb_instance_group1
   google.cloud.gcp_compute_instance_group:
     state: present
     project: "{{ sap_vm_provision_gcp_project }}"
     name: "lb-instance-group-nwas-ascs"
-    zone: "{{ gcp_vm_info | json_query('results[*].resources[?name==`' + host_node + '`].zone') | flatten | join(' ') | basename }}"
+    zone: "{{ __sap_vm_provision_task_provision_host_single_info | json_query('results[*].resources[?name==`' + host_node + '`].zone') | flatten | join(' ') | basename }}"
     instances:
-      - { "selfLink": "{{ gcp_vm_info | json_query('results[*].resources[?name==`' + host_node + '`].selfLink') | flatten | join(' ') }}" }
+      - { "selfLink": "{{ __sap_vm_provision_task_provision_host_single_info | json_query('results[*].resources[?name==`' + host_node + '`].selfLink') | flatten | join(' ') }}" }
     #named_ports:
     #  - name: http # default, not applicable to internal passthrough NLB, only applicable to proxy NLB
     #    port: 80 # default
@@ -737,14 +737,14 @@
 
 - name: Create Google Cloud Compute Engine Instance Group (Self-Managed/Unmanaged) Secondary (Failover) - for SAP NetWeaver ERS
   no_log: "{{ __sap_vm_provision_no_log }}"
-  register: gcp_lb_instance_group2
+  register: __sap_vm_provision_task_gcp_lb_instance_group2
   google.cloud.gcp_compute_instance_group:
     state: present
     project: "{{ sap_vm_provision_gcp_project }}"
     name: "lb-instance-group-nwas-ers"
-    zone: "{{ gcp_vm_info | json_query('results[*].resources[?name==`' + host_node + '`].zone') | flatten | join(' ') | basename }}"
+    zone: "{{ __sap_vm_provision_task_provision_host_single_info | json_query('results[*].resources[?name==`' + host_node + '`].zone') | flatten | join(' ') | basename }}"
     instances:
-      - { "selfLink": "{{ gcp_vm_info | json_query('results[*].resources[?name==`' + host_node + '`].selfLink') | flatten | join(' ') }}" }
+      - { "selfLink": "{{ __sap_vm_provision_task_provision_host_single_info | json_query('results[*].resources[?name==`' + host_node + '`].selfLink') | flatten | join(' ') }}" }
     #named_ports:
     #  - name: http # default, not applicable to internal passthrough NLB, only applicable to proxy NLB
     #    port: 80 # default
@@ -760,21 +760,21 @@
 # No option for --global-health-checks ?
 - name: Create Google Cloud Compute Engine Backend Service (Regional) for the Internal passthrough Network Load Balancer used by SAP NetWeaver ASCS
   no_log: "{{ __sap_vm_provision_no_log }}"
-  register: gcp_lb_backend_service_regional_ascs
+  register: __sap_vm_provision_task_gcp_lb_backend_service_regional_ascs
   google.cloud.gcp_compute_region_backend_service:
     state: present
     project: "{{ sap_vm_provision_gcp_project }}"
     region: "{{ sap_vm_provision_gcp_region }}"
     name: "lb-backend-service-nwas-ascs"
     backends:
-      - group: "{{ gcp_lb_instance_group1.results[0].selfLink }}"
+      - group: "{{ __sap_vm_provision_task_gcp_lb_instance_group1.results[0].selfLink }}"
         balancing_mode: CONNECTION # UTILIZATION , RATE , CONNECTION
         #failover: false # Should be unset according to GCP for SAP documentation, which is different than set to false
-      - group: "{{ gcp_lb_instance_group2.results[0].selfLink }}"
+      - group: "{{ __sap_vm_provision_task_gcp_lb_instance_group2.results[0].selfLink }}"
         balancing_mode: CONNECTION # UTILIZATION , RATE , CONNECTION
         failover: true
     health_checks:
-      - "{{ gcp_lb_healthcheck_service_ascs.selfLink }}"
+      - "{{ __sap_vm_provision_task_gcp_lb_healthcheck_service_ascs.selfLink }}"
     load_balancing_scheme: INTERNAL
     failover_policy:
       disable_connection_drain_on_failover: true
@@ -791,21 +791,21 @@
 # No option for --global-health-checks ?
 - name: Create Google Cloud Compute Engine Backend Service (Regional) for the Internal passthrough Network Load Balancer used by SAP NetWeaver ERS
   no_log: "{{ __sap_vm_provision_no_log }}"
-  register: gcp_lb_backend_service_regional_ers
+  register: __sap_vm_provision_task_gcp_lb_backend_service_regional_ers
   google.cloud.gcp_compute_region_backend_service:
     state: present
     project: "{{ sap_vm_provision_gcp_project }}"
     region: "{{ sap_vm_provision_gcp_region }}"
     name: "lb-backend-service-nwas-ers"
     backends:
-      - group: "{{ gcp_lb_instance_group2.results[0].selfLink }}"
+      - group: "{{ __sap_vm_provision_task_gcp_lb_instance_group2.results[0].selfLink }}"
         balancing_mode: CONNECTION # UTILIZATION , RATE , CONNECTION
         #failover: false # Should be unset according to GCP for SAP documentation, which is different than set to false
-      - group: "{{ gcp_lb_instance_group1.results[0].selfLink }}"
+      - group: "{{ __sap_vm_provision_task_gcp_lb_instance_group1.results[0].selfLink }}"
         balancing_mode: CONNECTION # UTILIZATION , RATE , CONNECTION
         failover: true
     health_checks:
-      - "{{ gcp_lb_healthcheck_service_ers.selfLink }}"
+      - "{{ __sap_vm_provision_task_gcp_lb_healthcheck_service_ers.selfLink }}"
     load_balancing_scheme: INTERNAL
     failover_policy:
       disable_connection_drain_on_failover: true
@@ -820,7 +820,7 @@
 
 - name: Create Google Cloud Compute Engine Forwarding Rule (aka. Frontend IP and Port) for SAP NetWeaver ASCS
   no_log: "{{ __sap_vm_provision_no_log }}"
-  register: gcp_lb_forwarding_rule
+  register: __sap_vm_provision_task_gcp_lb_forwarding_rule
   google.cloud.gcp_compute_forwarding_rule:
     state: present
     project: "{{ sap_vm_provision_gcp_project }}"
@@ -830,9 +830,9 @@
     ip_address: "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_ascs_ip_address | regex_replace('/.*', '') }}"
     all_ports: true # For internal network load balancing, allow any ports to be forwarded to the backend service (can not be set if ports are defined)
     allow_global_access: false # Only for use if access to the SAP NetWeaver Database Server is required from outside of the GCP Region
-    backend_service: { "selfLink": "{{ gcp_lb_backend_service_regional_ascs.selfLink }}" } # Mandatory, otherwise error "Invalid value for field 'resource.target'"
+    backend_service: { "selfLink": "{{ __sap_vm_provision_task_gcp_lb_backend_service_regional_ascs.selfLink }}" } # Mandatory, otherwise error "Invalid value for field 'resource.target'"
     #backend_service: { "selfLink": "https://www.googleapis.com/compute/v1/projects/{{ sap_vm_provision_gcp_project }}/regions/{{ sap_vm_provision_gcp_region }}/backendServices/lb-backend-service-nwas-ascs" }
-    subnetwork: { "selfLink": "{{ gcp_vpc_subnet_info.resources[0].selfLink }}" }
+    subnetwork: { "selfLink": "{{ __sap_vm_provision_task_gcp_vpc_subnet_info.resources[0].selfLink }}" }
     load_balancing_scheme: INTERNAL
     network_tier: PREMIUM
     auth_kind: "serviceaccount"
@@ -842,7 +842,7 @@
 
 - name: Create Google Cloud Compute Engine Forwarding Rule (aka. Frontend IP and Port) for SAP NetWeaver ERS
   no_log: "{{ __sap_vm_provision_no_log }}"
-  register: gcp_lb_forwarding_rule
+  register: __sap_vm_provision_task_gcp_lb_forwarding_rule
   google.cloud.gcp_compute_forwarding_rule:
     state: present
     project: "{{ sap_vm_provision_gcp_project }}"
@@ -852,9 +852,9 @@
     ip_address: "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_ers_ip_address | regex_replace('/.*', '') }}"
     all_ports: true # For internal network load balancing, allow any ports to be forwarded to the backend service (can not be set if ports are defined)
     allow_global_access: false # Only for use if access to the SAP NetWeaver Database Server is required from outside of the GCP Region
-    backend_service: { "selfLink": "{{ gcp_lb_backend_service_regional_ascs.selfLink }}" } # Mandatory, otherwise error "Invalid value for field 'resource.target'"
+    backend_service: { "selfLink": "{{ __sap_vm_provision_task_gcp_lb_backend_service_regional_ascs.selfLink }}" } # Mandatory, otherwise error "Invalid value for field 'resource.target'"
     #backend_service: { "selfLink": "https://www.googleapis.com/compute/v1/projects/{{ sap_vm_provision_gcp_project }}/regions/{{ sap_vm_provision_gcp_region }}/backendServices/lb-backend-service-nwas-ascs" }
-    subnetwork: { "selfLink": "{{ gcp_vpc_subnet_info.resources[0].selfLink }}" }
+    subnetwork: { "selfLink": "{{ __sap_vm_provision_task_gcp_vpc_subnet_info.resources[0].selfLink }}" }
     load_balancing_scheme: INTERNAL
     network_tier: PREMIUM
     auth_kind: "serviceaccount"
@@ -865,7 +865,7 @@
 
 - name: Get information on Google Cloud Compute Engine (Regional) Backend Service for SAP NetWeaver ASCS
   no_log: "{{ __sap_vm_provision_no_log }}"
-  register: gcp_info_lb_backend_service_regional
+  register: __sap_vm_provision_task_gcp_lb_backend_service_regional
   google.cloud.gcp_compute_region_backend_service_info:
     project: "{{ sap_vm_provision_gcp_project }}"
     region: "{{ sap_vm_provision_gcp_region }}"
@@ -878,7 +878,7 @@
 
 - name: Get information on Google Cloud Compute Engine (Regional) Backend Service for SAP NetWeaver ERS
   no_log: "{{ __sap_vm_provision_no_log }}"
-  register: gcp_info_lb_backend_service_regional
+  register: __sap_vm_provision_task_gcp_lb_backend_service_regional
   google.cloud.gcp_compute_region_backend_service_info:
     project: "{{ sap_vm_provision_gcp_project }}"
     region: "{{ sap_vm_provision_gcp_region }}"

--- a/roles/sap_vm_provision/tasks/platform_ansible/gcp_ce_vm/execute_setup_ha.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/gcp_ce_vm/execute_setup_ha.yml
@@ -4,6 +4,7 @@
 # Virtual IP Address also uses subnet netmask /32 CIDR, otherwise subnet traffic attempts to route through the Load Balancer Backend Service
 
 # - name: GCP append route for SAP HANA HA (route must be outside of existing VPC Subnet Range/s)
+#   register: gcp_vpc_subnet_rt_route_sap_hana
 #   google.cloud.gcp_compute_route:
 #     state: present
 #     project: "{{ sap_vm_provision_gcp_project }}"
@@ -16,7 +17,6 @@
 #   loop: "{{ (groups['hana_primary'] | default([])) }}"
 #   loop_control:
 #     loop_var: host_node
-#   register: gcp_vpc_subnet_rt_route_sap_hana
 #   when:
 #     - groups["hana_secondary"] is defined and (groups["hana_secondary"] | length>0)
 
@@ -40,6 +40,7 @@
 
 
 # - name: GCP append route for SAP AnyDB HA (route must be outside of existing VPC Subnet Range/s)
+#   register: gcp_vpc_subnet_rt_route_sap_hana
 #   google.cloud.gcp_compute_route:
 #     state: present
 #     project: "{{ sap_vm_provision_gcp_project }}"
@@ -52,7 +53,6 @@
 #   loop: "{{ (groups['anydb_primary'] | default([])) }}"
 #   loop_control:
 #     loop_var: host_node
-#   register: gcp_vpc_subnet_rt_route_sap_hana
 #   when:
 #     - groups["hana_secondary"] is defined and (groups["hana_secondary"] | length>0)
 
@@ -76,6 +76,7 @@
 
 
 # - name: GCP append route for SAP NetWeaver ASCS HA (route must be outside of existing VPC Subnet Range/s)
+#   register: gcp_vpc_subnet_rt_route_sap_netweaver_ascs
 #   google.cloud.gcp_compute_route:
 #     state: present
 #     project: "{{ sap_vm_provision_gcp_project }}"
@@ -88,7 +89,6 @@
 #   loop: "{{ (groups['nwas_ascs'] | default([])) }}"
 #   loop_control:
 #     loop_var: host_node
-#   register: gcp_vpc_subnet_rt_route_sap_netweaver_ascs
 #   when:
 #     - groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0)
 
@@ -112,6 +112,7 @@
 
 
 # - name: GCP append route for SAP NetWeaver ERS HA
+#   register: gcp_vpc_subnet_rt_route_sap_netweaver_ers
 #   google.cloud.gcp_compute_route:
 #     state: present
 #     project: "{{ sap_vm_provision_gcp_project }}"
@@ -124,7 +125,6 @@
 #   loop: "{{ (groups['nwas_ers'] | default([])) }}"
 #   loop_control:
 #     loop_var: host_node
-#   register: gcp_vpc_subnet_rt_route_sap_netweaver_ers
 #   when:
 #     - groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0)
 
@@ -150,6 +150,7 @@
 ## For HA of PAS and AAS, if required
 
 # - name: GCP append route for SAP NetWeaver PAS HA
+#   register: gcp_vpc_subnet_rt_route_sap_netweaver_pas
 #   google.cloud.gcp_compute_route:
 #     state: present
 #     project: "{{ sap_vm_provision_gcp_project }}"
@@ -162,7 +163,6 @@
 #   loop: "{{ (groups['nwas_pas'] | default([])) }}"
 #   loop_control:
 #     loop_var: host_node
-#   register: gcp_vpc_subnet_rt_route_sap_netweaver_pas
 #   when:
 #     - groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0)
 
@@ -186,6 +186,7 @@
 
 
 # - name: GCP append route for SAP NetWeaver AAS HA
+#   register: gcp_vpc_subnet_rt_route_sap_netweaver_aas
 #   google.cloud.gcp_compute_route:
 #     state: present
 #     project: "{{ sap_vm_provision_gcp_project }}"
@@ -198,7 +199,6 @@
 #   loop: "{{ (groups['nwas_aas'] | default([])) }}"
 #   loop_control:
 #     loop_var: host_node
-#   register: gcp_vpc_subnet_rt_route_sap_netweaver_aas
 #   when:
 #     - groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0)
 
@@ -237,6 +237,7 @@
 # tcpdump -i eth0 net 130.211.0.0/22 and dst port 55550/55551/55552
 
 - name: Create Google Cloud Compute Engine Reserved Static Internal IP Address for the Virtual IP (VIP) of SAP HANA
+  register: gcp_lb_reserved_address
   google.cloud.gcp_compute_address:
     state: present
     project: "{{ sap_vm_provision_gcp_project }}"
@@ -247,7 +248,6 @@
     address: "{{ vip_item | regex_replace('/.*', '') }}"
     #network_tier: PREMIUM # An address with type INTERNAL cannot have a network tier
     purpose: GCE_ENDPOINT # GCE_ENDPOINT is for addresses used by VMs, alias IP ranges, and internal load balancers
-  register: gcp_lb_reserved_address
   when:
     - vip_item | length > 0
     - groups["hana_secondary"] is defined and (groups["hana_secondary"]|length>0)
@@ -258,6 +258,7 @@
     loop_var: vip_item
 
 - name: Create Google Cloud Compute Engine Health Check (Global) service instance for SAP HANA
+  register: gcp_lb_healthcheck_service
   google.cloud.gcp_compute_health_check:
     state: present
     project: "{{ sap_vm_provision_gcp_project }}"
@@ -270,17 +271,16 @@
     timeout_sec: 10
     unhealthy_threshold: 2
     healthy_threshold: 2
-  register: gcp_lb_healthcheck_service
   when:
     - groups["hana_secondary"] is defined and (groups["hana_secondary"]|length>0)
 
 - name: Gather GCP VM information
+  register: gcp_vm_info
   google.cloud.gcp_compute_instance_info:
     project: "{{ sap_vm_provision_gcp_project }}"
     zone: "{{ sap_vm_provision_gcp_region_zone }}"
     filters:
       - name = {{ host_node }}
-  register: gcp_vm_info
   loop: "{{ groups_merged_list }}"
   loop_control:
     loop_var: host_node
@@ -288,6 +288,7 @@
     - groups["hana_secondary"] is defined and (groups["hana_secondary"]|length>0)
 
 - name: Create Google Cloud Compute Engine Instance Group (Self-Managed/Unmanaged) Primary - for SAP HANA
+  register: gcp_lb_instance_group1
   google.cloud.gcp_compute_instance_group:
     state: present
     project: "{{ sap_vm_provision_gcp_project }}"
@@ -298,7 +299,6 @@
     #named_ports:
     #  - name: http # default, not applicable to internal passthrough NLB, only applicable to proxy NLB
     #    port: 80 # default
-  register: gcp_lb_instance_group1
   loop: "{{ (groups['hana_primary'] | default([])) }}"
   loop_control:
     loop_var: host_node
@@ -306,6 +306,7 @@
     - groups["hana_secondary"] is defined and (groups["hana_secondary"]|length>0)
 
 - name: Create Google Cloud Compute Engine Instance Group (Self-Managed/Unmanaged) Secondary (Failover) - for SAP HANA
+  register: gcp_lb_instance_group2
   google.cloud.gcp_compute_instance_group:
     state: present
     project: "{{ sap_vm_provision_gcp_project }}"
@@ -316,7 +317,6 @@
     #named_ports:
     #  - name: http # default, not applicable to internal passthrough NLB, only applicable to proxy NLB
     #    port: 80 # default
-  register: gcp_lb_instance_group2
   loop: "{{ (groups['hana_secondary'] | default([])) }}"
   loop_control:
     loop_var: host_node
@@ -326,6 +326,7 @@
 # Note: Failover Ratio must be 1.0, which enforces failover to Secondary/Failover Instance Group if any VM the Backend Service's Primary Instance Group
 # No option for --global-health-checks ?
 - name: Create Google Cloud Compute Engine Backend Service (Regional) for the Internal passthrough Network Load Balancer used by SAP HANA
+  register: gcp_lb_backend_service_regional
   google.cloud.gcp_compute_region_backend_service:
     state: present
     project: "{{ sap_vm_provision_gcp_project }}"
@@ -347,11 +348,11 @@
       failover_ratio: 1 # 1.0
     session_affinity: NONE
     #timeout_sec: 30 # value ignored for internal passthrough NLB, default 30s to wait for backend before failure - see https://cloud.google.com/load-balancing/docs/backend-service#timeout-setting
-  register: gcp_lb_backend_service_regional
   when:
     - groups["hana_secondary"] is defined and (groups["hana_secondary"]|length>0)
 
 - name: Create Google Cloud Compute Engine Forwarding Rule (aka. Frontend IP and Port) for SAP HANA
+  register: gcp_lb_forwarding_rule
   google.cloud.gcp_compute_forwarding_rule:
     state: present
     project: "{{ sap_vm_provision_gcp_project }}"
@@ -366,7 +367,6 @@
     subnetwork: { "selfLink": "{{ gcp_vpc_subnet_info.resources[0].selfLink }}" }
     load_balancing_scheme: INTERNAL
     network_tier: PREMIUM
-  register: gcp_lb_forwarding_rule
   when:
     - vip_item | length > 0
     - groups["hana_secondary"] is defined and (groups["hana_secondary"]|length>0)
@@ -377,17 +377,18 @@
     loop_var: vip_item
 
 - name: Get information on Google Cloud Compute Engine (Regional) Backend Service
+  register: gcp_info_lb_backend_service_regional
   google.cloud.gcp_compute_region_backend_service_info:
     project: "{{ sap_vm_provision_gcp_project }}"
     region: "{{ sap_vm_provision_gcp_region }}"
     filters:
       - name = "lb-backend-service-hana"
-  register: gcp_info_lb_backend_service_regional
   when:
     - groups["hana_secondary"] is defined and (groups["hana_secondary"]|length>0)
 
 
 - name: Create Google Cloud Compute Engine Reserved Static Internal IP Address for the Virtual IP (VIP) of SAP AnyDB
+  register: gcp_lb_reserved_address
   google.cloud.gcp_compute_address:
     state: present
     project: "{{ sap_vm_provision_gcp_project }}"
@@ -398,7 +399,6 @@
     address: "{{ vip_item | regex_replace('/.*', '') }}"
     #network_tier: PREMIUM # An address with type INTERNAL cannot have a network tier
     purpose: GCE_ENDPOINT # GCE_ENDPOINT is for addresses used by VMs, alias IP ranges, and internal load balancers
-  register: gcp_lb_reserved_address
   when:
     - vip_item | length > 0
     - groups["anydb_secondary"] is defined and (groups["anydb_secondary"]|length>0)
@@ -409,6 +409,7 @@
     loop_var: vip_item
 
 - name: Create Google Cloud Compute Engine Health Check (Global) service instance for SAP AnyDB
+  register: gcp_lb_healthcheck_service
   google.cloud.gcp_compute_health_check:
     state: present
     project: "{{ sap_vm_provision_gcp_project }}"
@@ -421,17 +422,16 @@
     timeout_sec: 10
     unhealthy_threshold: 2
     healthy_threshold: 2
-  register: gcp_lb_healthcheck_service
   when:
     - groups["anydb_secondary"] is defined and (groups["anydb_secondary"]|length>0)
 
 - name: Gather GCP VM information
+  register: gcp_vm_info
   google.cloud.gcp_compute_instance_info:
     project: "{{ sap_vm_provision_gcp_project }}"
     zone: "{{ sap_vm_provision_gcp_region_zone }}"
     filters:
       - name = {{ host_node }}
-  register: gcp_vm_info
   loop: "{{ groups_merged_list }}"
   loop_control:
     loop_var: host_node
@@ -439,6 +439,7 @@
     - groups["anydb_secondary"] is defined and (groups["anydb_secondary"]|length>0)
 
 - name: Create Google Cloud Compute Engine Instance Group (Self-Managed/Unmanaged) Primary - for SAP AnyDB
+  register: gcp_lb_instance_group1
   google.cloud.gcp_compute_instance_group:
     state: present
     project: "{{ sap_vm_provision_gcp_project }}"
@@ -449,7 +450,6 @@
     #named_ports:
     #  - name: http # default, not applicable to internal passthrough NLB, only applicable to proxy NLB
     #    port: 80 # default
-  register: gcp_lb_instance_group1
   loop: "{{ (groups['anydb_primary'] | default([])) }}"
   loop_control:
     loop_var: host_node
@@ -457,6 +457,7 @@
     - groups["anydb_secondary"] is defined and (groups["anydb_secondary"]|length>0)
 
 - name: Create Google Cloud Compute Engine Instance Group (Self-Managed/Unmanaged) Secondary (Failover) - for SAP AnyDB
+  register: gcp_lb_instance_group2
   google.cloud.gcp_compute_instance_group:
     state: present
     project: "{{ sap_vm_provision_gcp_project }}"
@@ -467,7 +468,6 @@
     #named_ports:
     #  - name: http # default, not applicable to internal passthrough NLB, only applicable to proxy NLB
     #    port: 80 # default
-  register: gcp_lb_instance_group2
   loop: "{{ (groups['anydb_secondary'] | default([])) }}"
   loop_control:
     loop_var: host_node
@@ -477,6 +477,7 @@
 # Note: Failover Ratio must be 1.0, which enforces failover to Secondary/Failover Instance Group if any VM the Backend Service's Primary Instance Group
 # No option for --global-health-checks ?
 - name: Create Google Cloud Compute Engine Backend Service (Regional) for the Internal passthrough Network Load Balancer used by SAP AnyDB
+  register: gcp_lb_backend_service_regional
   google.cloud.gcp_compute_region_backend_service:
     state: present
     project: "{{ sap_vm_provision_gcp_project }}"
@@ -498,11 +499,11 @@
       failover_ratio: 1 # 1.0
     session_affinity: NONE
     #timeout_sec: 30 # value ignored for internal passthrough NLB, default 30s to wait for backend before failure - see https://cloud.google.com/load-balancing/docs/backend-service#timeout-setting
-  register: gcp_lb_backend_service_regional
   when:
     - groups["anydb_secondary"] is defined and (groups["anydb_secondary"]|length>0)
 
 - name: Create Google Cloud Compute Engine Forwarding Rule (aka. Frontend IP and Port) for SAP AnyDB
+  register: gcp_lb_forwarding_rule
   google.cloud.gcp_compute_forwarding_rule:
     state: present
     project: "{{ sap_vm_provision_gcp_project }}"
@@ -517,7 +518,6 @@
     subnetwork: { "selfLink": "{{ gcp_vpc_subnet_info.resources[0].selfLink }}" }
     load_balancing_scheme: INTERNAL
     network_tier: PREMIUM
-  register: gcp_lb_forwarding_rule
   when:
     - vip_item | length > 0
     - groups["anydb_secondary"] is defined and (groups["anydb_secondary"]|length>0)
@@ -528,17 +528,18 @@
     loop_var: vip_item
 
 - name: Get information on Google Cloud Compute Engine (Regional) Backend Service
+  register: gcp_info_lb_backend_service_regional
   google.cloud.gcp_compute_region_backend_service_info:
     project: "{{ sap_vm_provision_gcp_project }}"
     region: "{{ sap_vm_provision_gcp_region }}"
     filters:
       - name = "lb-backend-service-anydb"
-  register: gcp_info_lb_backend_service_regional
   when:
     - groups["anydb_secondary"] is defined and (groups["anydb_secondary"]|length>0)
 
 
 - name: Create Google Cloud Compute Engine Reserved Static Internal IP Address for the Virtual IP (VIP) of SAP NetWeaver ASCS
+  register: gcp_lb_reserved_address
   google.cloud.gcp_compute_address:
     state: present
     project: "{{ sap_vm_provision_gcp_project }}"
@@ -549,11 +550,11 @@
     address: "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_ascs_ip_address | regex_replace('/.*', '') }}"
     #network_tier: PREMIUM # An address with type INTERNAL cannot have a network tier
     purpose: GCE_ENDPOINT # GCE_ENDPOINT is for addresses used by VMs, alias IP ranges, and internal load balancers
-  register: gcp_lb_reserved_address
   when:
     - groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
 
 - name: Create Google Cloud Compute Engine Reserved Static Internal IP Address for the Virtual IP (VIP) of SAP NetWeaver ERS
+  register: gcp_lb_reserved_address
   google.cloud.gcp_compute_address:
     state: present
     project: "{{ sap_vm_provision_gcp_project }}"
@@ -564,11 +565,11 @@
     address: "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_ers_ip_address | regex_replace('/.*', '') }}"
     #network_tier: PREMIUM # An address with type INTERNAL cannot have a network tier
     purpose: GCE_ENDPOINT # GCE_ENDPOINT is for addresses used by VMs, alias IP ranges, and internal load balancers
-  register: gcp_lb_reserved_address
   when:
     - groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
 
 - name: Create Google Cloud Compute Engine Health Check (Global) service instance for SAP NetWeaver ASCS
+  register: gcp_lb_healthcheck_service_ascs
   google.cloud.gcp_compute_health_check:
     state: present
     project: "{{ sap_vm_provision_gcp_project }}"
@@ -581,11 +582,11 @@
     timeout_sec: 10
     unhealthy_threshold: 2
     healthy_threshold: 2
-  register: gcp_lb_healthcheck_service_ascs
   when:
     - groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
 
 - name: Create Google Cloud Compute Engine Health Check (Global) service instance for SAP NetWeaver ERS
+  register: gcp_lb_healthcheck_service_ers
   google.cloud.gcp_compute_health_check:
     state: present
     project: "{{ sap_vm_provision_gcp_project }}"
@@ -598,17 +599,16 @@
     timeout_sec: 10
     unhealthy_threshold: 2
     healthy_threshold: 2
-  register: gcp_lb_healthcheck_service_ers
   when:
     - groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
 
 - name: Gather GCP VM information
+  register: gcp_vm_info
   google.cloud.gcp_compute_instance_info:
     project: "{{ sap_vm_provision_gcp_project }}"
     zone: "{{ sap_vm_provision_gcp_region_zone }}"
     filters:
       - name = {{ host_node }}
-  register: gcp_vm_info
   loop: "{{ groups_merged_list }}"
   loop_control:
     loop_var: host_node
@@ -616,6 +616,7 @@
     - groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
 
 - name: Create Google Cloud Compute Engine Instance Group (Self-Managed/Unmanaged) Primary - for SAP NetWeaver ASCS
+  register: gcp_lb_instance_group1
   google.cloud.gcp_compute_instance_group:
     state: present
     project: "{{ sap_vm_provision_gcp_project }}"
@@ -626,7 +627,6 @@
     #named_ports:
     #  - name: http # default, not applicable to internal passthrough NLB, only applicable to proxy NLB
     #    port: 80 # default
-  register: gcp_lb_instance_group1
   loop: "{{ (groups['nwas_ascs'] | default([])) }}"
   loop_control:
     loop_var: host_node
@@ -634,6 +634,7 @@
     - groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
 
 - name: Create Google Cloud Compute Engine Instance Group (Self-Managed/Unmanaged) Secondary (Failover) - for SAP NetWeaver ERS
+  register: gcp_lb_instance_group2
   google.cloud.gcp_compute_instance_group:
     state: present
     project: "{{ sap_vm_provision_gcp_project }}"
@@ -644,7 +645,6 @@
     #named_ports:
     #  - name: http # default, not applicable to internal passthrough NLB, only applicable to proxy NLB
     #    port: 80 # default
-  register: gcp_lb_instance_group2
   loop: "{{ (groups['nwas_ers'] | default([])) }}"
   loop_control:
     loop_var: host_node
@@ -654,6 +654,7 @@
 # Note: Failover Ratio must be 1.0, which enforces failover to Secondary/Failover Instance Group if any VM the Backend Service's Primary Instance Group
 # No option for --global-health-checks ?
 - name: Create Google Cloud Compute Engine Backend Service (Regional) for the Internal passthrough Network Load Balancer used by SAP NetWeaver ASCS
+  register: gcp_lb_backend_service_regional_ascs
   google.cloud.gcp_compute_region_backend_service:
     state: present
     project: "{{ sap_vm_provision_gcp_project }}"
@@ -675,13 +676,13 @@
       failover_ratio: 1 # 1.0
     session_affinity: NONE
     #timeout_sec: 30 # value ignored for internal passthrough NLB, default 30s to wait for backend before failure - see https://cloud.google.com/load-balancing/docs/backend-service#timeout-setting
-  register: gcp_lb_backend_service_regional_ascs
   when:
     - groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
 
 # Note: Failover Ratio must be 1.0, which enforces failover to Secondary/Failover Instance Group if any VM the Backend Service's Primary Instance Group
 # No option for --global-health-checks ?
 - name: Create Google Cloud Compute Engine Backend Service (Regional) for the Internal passthrough Network Load Balancer used by SAP NetWeaver ERS
+  register: gcp_lb_backend_service_regional_ers
   google.cloud.gcp_compute_region_backend_service:
     state: present
     project: "{{ sap_vm_provision_gcp_project }}"
@@ -703,11 +704,11 @@
       failover_ratio: 1 # 1.0
     session_affinity: NONE
     #timeout_sec: 30 # value ignored for internal passthrough NLB, default 30s to wait for backend before failure - see https://cloud.google.com/load-balancing/docs/backend-service#timeout-setting
-  register: gcp_lb_backend_service_regional_ers
   when:
     - groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
 
 - name: Create Google Cloud Compute Engine Forwarding Rule (aka. Frontend IP and Port) for SAP NetWeaver ASCS
+  register: gcp_lb_forwarding_rule
   google.cloud.gcp_compute_forwarding_rule:
     state: present
     project: "{{ sap_vm_provision_gcp_project }}"
@@ -722,11 +723,11 @@
     subnetwork: { "selfLink": "{{ gcp_vpc_subnet_info.resources[0].selfLink }}" }
     load_balancing_scheme: INTERNAL
     network_tier: PREMIUM
-  register: gcp_lb_forwarding_rule
   when:
     - groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
 
 - name: Create Google Cloud Compute Engine Forwarding Rule (aka. Frontend IP and Port) for SAP NetWeaver ERS
+  register: gcp_lb_forwarding_rule
   google.cloud.gcp_compute_forwarding_rule:
     state: present
     project: "{{ sap_vm_provision_gcp_project }}"
@@ -741,27 +742,26 @@
     subnetwork: { "selfLink": "{{ gcp_vpc_subnet_info.resources[0].selfLink }}" }
     load_balancing_scheme: INTERNAL
     network_tier: PREMIUM
-  register: gcp_lb_forwarding_rule
   when:
     - groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
 
 
 - name: Get information on Google Cloud Compute Engine (Regional) Backend Service for SAP NetWeaver ASCS
+  register: gcp_info_lb_backend_service_regional
   google.cloud.gcp_compute_region_backend_service_info:
     project: "{{ sap_vm_provision_gcp_project }}"
     region: "{{ sap_vm_provision_gcp_region }}"
     filters:
       - name = "lb-backend-service-nwas-ascs"
-  register: gcp_info_lb_backend_service_regional
   when:
     - groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
 
 - name: Get information on Google Cloud Compute Engine (Regional) Backend Service for SAP NetWeaver ERS
+  register: gcp_info_lb_backend_service_regional
   google.cloud.gcp_compute_region_backend_service_info:
     project: "{{ sap_vm_provision_gcp_project }}"
     region: "{{ sap_vm_provision_gcp_region }}"
     filters:
       - name = "lb-backend-service-nwas-ers"
-  register: gcp_info_lb_backend_service_regional
   when:
     - groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)

--- a/roles/sap_vm_provision/tasks/platform_ansible/gcp_ce_vm/execute_setup_ha.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/gcp_ce_vm/execute_setup_ha.yml
@@ -4,6 +4,7 @@
 # Virtual IP Address also uses subnet netmask /32 CIDR, otherwise subnet traffic attempts to route through the Load Balancer Backend Service
 
 # - name: GCP append route for SAP HANA HA (route must be outside of existing VPC Subnet Range/s)
+#   no_log: "{{ __sap_vm_provision_no_log }}"
 #   register: gcp_vpc_subnet_rt_route_sap_hana
 #   google.cloud.gcp_compute_route:
 #     state: present
@@ -14,6 +15,8 @@
 #       selfLink: "{{ gcp_vm_info | json_query('results[*].resources[?name==`' + host_node + '`].selfLink') | flatten | join(' ') }}"
 #     network:
 #       selfLink: "{{ gcp_vpc_info.resources[0].selfLink }}"
+#     auth_kind: "serviceaccount"
+#     service_account_contents: "{{ sap_vm_provision_gcp_credentials_json }}"
 #   loop: "{{ (groups['hana_primary'] | default([])) }}"
 #   loop_control:
 #     loop_var: host_node
@@ -21,6 +24,7 @@
 #     - groups["hana_secondary"] is defined and (groups["hana_secondary"] | length>0)
 
 - name: GCP Private DNS Record for SAP HANA HA Virtual Hostname
+  no_log: "{{ __sap_vm_provision_no_log }}"
   google.cloud.gcp_dns_resource_record_set:
     state: present
     project: "{{ sap_vm_provision_gcp_project }}"
@@ -32,6 +36,8 @@
       - "{{ (sap_ha_pacemaker_cluster_vip_hana_primary_ip_address | default('192.168.1.90/32')) | regex_replace('/.*', '') }}"
     type: A
     ttl: 7200
+    auth_kind: "serviceaccount"
+    service_account_contents: "{{ sap_vm_provision_gcp_credentials_json }}"
   loop: "{{ (groups['hana_primary'] | default([])) }}"
   loop_control:
     loop_var: host_node
@@ -40,6 +46,7 @@
 
 
 # - name: GCP append route for SAP AnyDB HA (route must be outside of existing VPC Subnet Range/s)
+#   no_log: "{{ __sap_vm_provision_no_log }}"
 #   register: gcp_vpc_subnet_rt_route_sap_hana
 #   google.cloud.gcp_compute_route:
 #     state: present
@@ -50,6 +57,8 @@
 #       selfLink: "{{ gcp_vm_info | json_query('results[*].resources[?name==`' + host_node + '`].selfLink') | flatten | join(' ') }}"
 #     network:
 #       selfLink: "{{ gcp_vpc_info.resources[0].selfLink }}"
+#     auth_kind: "serviceaccount"
+#     service_account_contents: "{{ sap_vm_provision_gcp_credentials_json }}"
 #   loop: "{{ (groups['anydb_primary'] | default([])) }}"
 #   loop_control:
 #     loop_var: host_node
@@ -57,6 +66,7 @@
 #     - groups["hana_secondary"] is defined and (groups["hana_secondary"] | length>0)
 
 - name: GCP Private DNS Record for SAP AnyDB HA Virtual Hostname
+  no_log: "{{ __sap_vm_provision_no_log }}"
   google.cloud.gcp_dns_resource_record_set:
     state: present
     project: "{{ sap_vm_provision_gcp_project }}"
@@ -68,6 +78,8 @@
       - "{{ (sap_vm_temp_vip_anydb_primary | default('192.168.1.90/32')) | regex_replace('/.*', '') }}"
     type: A
     ttl: 7200
+    auth_kind: "serviceaccount"
+    service_account_contents: "{{ sap_vm_provision_gcp_credentials_json }}"
   loop: "{{ (groups['anydb_primary'] | default([])) }}"
   loop_control:
     loop_var: host_node
@@ -76,6 +88,7 @@
 
 
 # - name: GCP append route for SAP NetWeaver ASCS HA (route must be outside of existing VPC Subnet Range/s)
+#   no_log: "{{ __sap_vm_provision_no_log }}"
 #   register: gcp_vpc_subnet_rt_route_sap_netweaver_ascs
 #   google.cloud.gcp_compute_route:
 #     state: present
@@ -86,6 +99,8 @@
 #       selfLink: "{{ gcp_vm_info | json_query('results[*].resources[?name==`' + host_node + '`].selfLink') | flatten | join(' ') }}"
 #     network:
 #       selfLink: "{{ gcp_vpc_info.resources[0].selfLink }}"
+#     auth_kind: "serviceaccount"
+#     service_account_contents: "{{ sap_vm_provision_gcp_credentials_json }}"
 #   loop: "{{ (groups['nwas_ascs'] | default([])) }}"
 #   loop_control:
 #     loop_var: host_node
@@ -93,6 +108,7 @@
 #     - groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0)
 
 - name: GCP Private DNS Record for SAP NetWeaver ASCS HA Virtual Hostname
+  no_log: "{{ __sap_vm_provision_no_log }}"
   google.cloud.gcp_dns_resource_record_set:
     state: present
     project: "{{ sap_vm_provision_gcp_project }}"
@@ -104,6 +120,8 @@
       - "{{ (sap_ha_pacemaker_cluster_vip_nwas_abap_ascs_ip_address | default('192.168.2.10/32')) | regex_replace('/.*', '') }}"
     type: A
     ttl: 7200
+    auth_kind: "serviceaccount"
+    service_account_contents: "{{ sap_vm_provision_gcp_credentials_json }}"
   loop: "{{ (groups['nwas_ascs'] | default([])) }}"
   loop_control:
     loop_var: host_node
@@ -112,6 +130,7 @@
 
 
 # - name: GCP append route for SAP NetWeaver ERS HA
+#   no_log: "{{ __sap_vm_provision_no_log }}"
 #   register: gcp_vpc_subnet_rt_route_sap_netweaver_ers
 #   google.cloud.gcp_compute_route:
 #     state: present
@@ -122,6 +141,8 @@
 #       selfLink: "{{ gcp_vm_info | json_query('results[*].resources[?name==`' + host_node + '`].selfLink') | flatten | join(' ') }}"
 #     network:
 #       selfLink: "{{ gcp_vpc_info.resources[0].selfLink }}"
+#     auth_kind: "serviceaccount"
+#     service_account_contents: "{{ sap_vm_provision_gcp_credentials_json }}"
 #   loop: "{{ (groups['nwas_ers'] | default([])) }}"
 #   loop_control:
 #     loop_var: host_node
@@ -129,6 +150,7 @@
 #     - groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0)
 
 - name: GCP Private DNS Record for SAP NetWeaver ERS HA Virtual Hostname
+  no_log: "{{ __sap_vm_provision_no_log }}"
   google.cloud.gcp_dns_resource_record_set:
     state: present
     project: "{{ sap_vm_provision_gcp_project }}"
@@ -140,6 +162,8 @@
       - "{{ (sap_ha_pacemaker_cluster_vip_nwas_abap_ers_ip_address | default('192.168.2.11/32')) | regex_replace('/.*', '') }}"
     type: A
     ttl: 7200
+    auth_kind: "serviceaccount"
+    service_account_contents: "{{ sap_vm_provision_gcp_credentials_json }}"
   loop: "{{ (groups['nwas_ers'] | default([])) }}"
   loop_control:
     loop_var: host_node
@@ -150,6 +174,7 @@
 ## For HA of PAS and AAS, if required
 
 # - name: GCP append route for SAP NetWeaver PAS HA
+#   no_log: "{{ __sap_vm_provision_no_log }}"
 #   register: gcp_vpc_subnet_rt_route_sap_netweaver_pas
 #   google.cloud.gcp_compute_route:
 #     state: present
@@ -160,6 +185,8 @@
 #       selfLink: "{{ gcp_vm_info | json_query('results[*].resources[?name==`' + host_node + '`].selfLink') | flatten | join(' ') }}"
 #     network:
 #       selfLink: "{{ gcp_vpc_info.resources[0].selfLink }}"
+#     auth_kind: "serviceaccount"
+#     service_account_contents: "{{ sap_vm_provision_gcp_credentials_json }}"
 #   loop: "{{ (groups['nwas_pas'] | default([])) }}"
 #   loop_control:
 #     loop_var: host_node
@@ -167,6 +194,7 @@
 #     - groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0)
 
 # - name: GCP Private DNS Record for SAP NetWeaver PAS HA Virtual Hostname
+#   no_log: "{{ __sap_vm_provision_no_log }}"
 #   google.cloud.gcp_dns_resource_record_set:
 #     state: present
 #     project: "{{ sap_vm_provision_gcp_project }}"
@@ -178,6 +206,8 @@
 #       - "{{ (sap_ha_pacemaker_cluster_vip_nwas_abap_pas_ip_address | default('192.168.2.12/32')) | regex_replace('/.*', '') }}"
 #     type: A
 #     ttl: 7200
+#     auth_kind: "serviceaccount"
+#     service_account_contents: "{{ sap_vm_provision_gcp_credentials_json }}"
 #   loop: "{{ (groups['nwas_pas'] | default([])) }}"
 #   loop_control:
 #     loop_var: host_node
@@ -186,6 +216,7 @@
 
 
 # - name: GCP append route for SAP NetWeaver AAS HA
+#   no_log: "{{ __sap_vm_provision_no_log }}"
 #   register: gcp_vpc_subnet_rt_route_sap_netweaver_aas
 #   google.cloud.gcp_compute_route:
 #     state: present
@@ -196,6 +227,8 @@
 #       selfLink: "{{ gcp_vm_info | json_query('results[*].resources[?name==`' + host_node + '`].selfLink') | flatten | join(' ') }}"
 #     network:
 #       selfLink: "{{ gcp_vpc_info.resources[0].selfLink }}"
+#     auth_kind: "serviceaccount"
+#     service_account_contents: "{{ sap_vm_provision_gcp_credentials_json }}"
 #   loop: "{{ (groups['nwas_aas'] | default([])) }}"
 #   loop_control:
 #     loop_var: host_node
@@ -203,6 +236,7 @@
 #     - groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0)
 
 # - name: GCP Private DNS Record for SAP NetWeaver AAS HA Virtual Hostname
+#   no_log: "{{ __sap_vm_provision_no_log }}"
 #   google.cloud.gcp_dns_resource_record_set:
 #     state: present
 #     project: "{{ sap_vm_provision_gcp_project }}"
@@ -214,6 +248,8 @@
 #       - "{{ (sap_ha_pacemaker_cluster_vip_nwas_abap_aas_ip_address | default('192.168.2.13/32')) | regex_replace('/.*', '') }}"
 #     type: A
 #     ttl: 7200
+#     auth_kind: "serviceaccount"
+#     service_account_contents: "{{ sap_vm_provision_gcp_credentials_json }}"
 #   loop: "{{ (groups['nwas_aas'] | default([])) }}"
 #   loop_control:
 #     loop_var: host_node
@@ -237,6 +273,7 @@
 # tcpdump -i eth0 net 130.211.0.0/22 and dst port 55550/55551/55552
 
 - name: Create Google Cloud Compute Engine Reserved Static Internal IP Address for the Virtual IP (VIP) of SAP HANA
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: gcp_lb_reserved_address
   google.cloud.gcp_compute_address:
     state: present
@@ -248,6 +285,8 @@
     address: "{{ vip_item | regex_replace('/.*', '') }}"
     #network_tier: PREMIUM # An address with type INTERNAL cannot have a network tier
     purpose: GCE_ENDPOINT # GCE_ENDPOINT is for addresses used by VMs, alias IP ranges, and internal load balancers
+    auth_kind: "serviceaccount"
+    service_account_contents: "{{ sap_vm_provision_gcp_credentials_json }}"
   when:
     - vip_item | length > 0
     - groups["hana_secondary"] is defined and (groups["hana_secondary"]|length>0)
@@ -258,6 +297,7 @@
     loop_var: vip_item
 
 - name: Create Google Cloud Compute Engine Health Check (Global) service instance for SAP HANA
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: gcp_lb_healthcheck_service
   google.cloud.gcp_compute_health_check:
     state: present
@@ -271,16 +311,21 @@
     timeout_sec: 10
     unhealthy_threshold: 2
     healthy_threshold: 2
+    auth_kind: "serviceaccount"
+    service_account_contents: "{{ sap_vm_provision_gcp_credentials_json }}"
   when:
     - groups["hana_secondary"] is defined and (groups["hana_secondary"]|length>0)
 
 - name: Gather GCP VM information
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: gcp_vm_info
   google.cloud.gcp_compute_instance_info:
     project: "{{ sap_vm_provision_gcp_project }}"
     zone: "{{ sap_vm_provision_gcp_region_zone }}"
     filters:
       - name = {{ host_node }}
+    auth_kind: "serviceaccount"
+    service_account_contents: "{{ sap_vm_provision_gcp_credentials_json }}"
   loop: "{{ groups_merged_list }}"
   loop_control:
     loop_var: host_node
@@ -288,6 +333,7 @@
     - groups["hana_secondary"] is defined and (groups["hana_secondary"]|length>0)
 
 - name: Create Google Cloud Compute Engine Instance Group (Self-Managed/Unmanaged) Primary - for SAP HANA
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: gcp_lb_instance_group1
   google.cloud.gcp_compute_instance_group:
     state: present
@@ -299,6 +345,8 @@
     #named_ports:
     #  - name: http # default, not applicable to internal passthrough NLB, only applicable to proxy NLB
     #    port: 80 # default
+    auth_kind: "serviceaccount"
+    service_account_contents: "{{ sap_vm_provision_gcp_credentials_json }}"
   loop: "{{ (groups['hana_primary'] | default([])) }}"
   loop_control:
     loop_var: host_node
@@ -306,6 +354,7 @@
     - groups["hana_secondary"] is defined and (groups["hana_secondary"]|length>0)
 
 - name: Create Google Cloud Compute Engine Instance Group (Self-Managed/Unmanaged) Secondary (Failover) - for SAP HANA
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: gcp_lb_instance_group2
   google.cloud.gcp_compute_instance_group:
     state: present
@@ -317,6 +366,8 @@
     #named_ports:
     #  - name: http # default, not applicable to internal passthrough NLB, only applicable to proxy NLB
     #    port: 80 # default
+    auth_kind: "serviceaccount"
+    service_account_contents: "{{ sap_vm_provision_gcp_credentials_json }}"
   loop: "{{ (groups['hana_secondary'] | default([])) }}"
   loop_control:
     loop_var: host_node
@@ -326,6 +377,7 @@
 # Note: Failover Ratio must be 1.0, which enforces failover to Secondary/Failover Instance Group if any VM the Backend Service's Primary Instance Group
 # No option for --global-health-checks ?
 - name: Create Google Cloud Compute Engine Backend Service (Regional) for the Internal passthrough Network Load Balancer used by SAP HANA
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: gcp_lb_backend_service_regional
   google.cloud.gcp_compute_region_backend_service:
     state: present
@@ -348,10 +400,13 @@
       failover_ratio: 1 # 1.0
     session_affinity: NONE
     #timeout_sec: 30 # value ignored for internal passthrough NLB, default 30s to wait for backend before failure - see https://cloud.google.com/load-balancing/docs/backend-service#timeout-setting
+    auth_kind: "serviceaccount"
+    service_account_contents: "{{ sap_vm_provision_gcp_credentials_json }}"
   when:
     - groups["hana_secondary"] is defined and (groups["hana_secondary"]|length>0)
 
 - name: Create Google Cloud Compute Engine Forwarding Rule (aka. Frontend IP and Port) for SAP HANA
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: gcp_lb_forwarding_rule
   google.cloud.gcp_compute_forwarding_rule:
     state: present
@@ -367,6 +422,8 @@
     subnetwork: { "selfLink": "{{ gcp_vpc_subnet_info.resources[0].selfLink }}" }
     load_balancing_scheme: INTERNAL
     network_tier: PREMIUM
+    auth_kind: "serviceaccount"
+    service_account_contents: "{{ sap_vm_provision_gcp_credentials_json }}"
   when:
     - vip_item | length > 0
     - groups["hana_secondary"] is defined and (groups["hana_secondary"]|length>0)
@@ -377,17 +434,21 @@
     loop_var: vip_item
 
 - name: Get information on Google Cloud Compute Engine (Regional) Backend Service
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: gcp_info_lb_backend_service_regional
   google.cloud.gcp_compute_region_backend_service_info:
     project: "{{ sap_vm_provision_gcp_project }}"
     region: "{{ sap_vm_provision_gcp_region }}"
     filters:
       - name = "lb-backend-service-hana"
+    auth_kind: "serviceaccount"
+    service_account_contents: "{{ sap_vm_provision_gcp_credentials_json }}"
   when:
     - groups["hana_secondary"] is defined and (groups["hana_secondary"]|length>0)
 
 
 - name: Create Google Cloud Compute Engine Reserved Static Internal IP Address for the Virtual IP (VIP) of SAP AnyDB
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: gcp_lb_reserved_address
   google.cloud.gcp_compute_address:
     state: present
@@ -399,6 +460,8 @@
     address: "{{ vip_item | regex_replace('/.*', '') }}"
     #network_tier: PREMIUM # An address with type INTERNAL cannot have a network tier
     purpose: GCE_ENDPOINT # GCE_ENDPOINT is for addresses used by VMs, alias IP ranges, and internal load balancers
+    auth_kind: "serviceaccount"
+    service_account_contents: "{{ sap_vm_provision_gcp_credentials_json }}"
   when:
     - vip_item | length > 0
     - groups["anydb_secondary"] is defined and (groups["anydb_secondary"]|length>0)
@@ -409,6 +472,7 @@
     loop_var: vip_item
 
 - name: Create Google Cloud Compute Engine Health Check (Global) service instance for SAP AnyDB
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: gcp_lb_healthcheck_service
   google.cloud.gcp_compute_health_check:
     state: present
@@ -422,16 +486,21 @@
     timeout_sec: 10
     unhealthy_threshold: 2
     healthy_threshold: 2
+    auth_kind: "serviceaccount"
+    service_account_contents: "{{ sap_vm_provision_gcp_credentials_json }}"
   when:
     - groups["anydb_secondary"] is defined and (groups["anydb_secondary"]|length>0)
 
 - name: Gather GCP VM information
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: gcp_vm_info
   google.cloud.gcp_compute_instance_info:
     project: "{{ sap_vm_provision_gcp_project }}"
     zone: "{{ sap_vm_provision_gcp_region_zone }}"
     filters:
       - name = {{ host_node }}
+    auth_kind: "serviceaccount"
+    service_account_contents: "{{ sap_vm_provision_gcp_credentials_json }}"
   loop: "{{ groups_merged_list }}"
   loop_control:
     loop_var: host_node
@@ -439,6 +508,7 @@
     - groups["anydb_secondary"] is defined and (groups["anydb_secondary"]|length>0)
 
 - name: Create Google Cloud Compute Engine Instance Group (Self-Managed/Unmanaged) Primary - for SAP AnyDB
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: gcp_lb_instance_group1
   google.cloud.gcp_compute_instance_group:
     state: present
@@ -450,6 +520,8 @@
     #named_ports:
     #  - name: http # default, not applicable to internal passthrough NLB, only applicable to proxy NLB
     #    port: 80 # default
+    auth_kind: "serviceaccount"
+    service_account_contents: "{{ sap_vm_provision_gcp_credentials_json }}"
   loop: "{{ (groups['anydb_primary'] | default([])) }}"
   loop_control:
     loop_var: host_node
@@ -457,6 +529,7 @@
     - groups["anydb_secondary"] is defined and (groups["anydb_secondary"]|length>0)
 
 - name: Create Google Cloud Compute Engine Instance Group (Self-Managed/Unmanaged) Secondary (Failover) - for SAP AnyDB
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: gcp_lb_instance_group2
   google.cloud.gcp_compute_instance_group:
     state: present
@@ -468,6 +541,8 @@
     #named_ports:
     #  - name: http # default, not applicable to internal passthrough NLB, only applicable to proxy NLB
     #    port: 80 # default
+    auth_kind: "serviceaccount"
+    service_account_contents: "{{ sap_vm_provision_gcp_credentials_json }}"
   loop: "{{ (groups['anydb_secondary'] | default([])) }}"
   loop_control:
     loop_var: host_node
@@ -477,6 +552,7 @@
 # Note: Failover Ratio must be 1.0, which enforces failover to Secondary/Failover Instance Group if any VM the Backend Service's Primary Instance Group
 # No option for --global-health-checks ?
 - name: Create Google Cloud Compute Engine Backend Service (Regional) for the Internal passthrough Network Load Balancer used by SAP AnyDB
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: gcp_lb_backend_service_regional
   google.cloud.gcp_compute_region_backend_service:
     state: present
@@ -499,10 +575,13 @@
       failover_ratio: 1 # 1.0
     session_affinity: NONE
     #timeout_sec: 30 # value ignored for internal passthrough NLB, default 30s to wait for backend before failure - see https://cloud.google.com/load-balancing/docs/backend-service#timeout-setting
+    auth_kind: "serviceaccount"
+    service_account_contents: "{{ sap_vm_provision_gcp_credentials_json }}"
   when:
     - groups["anydb_secondary"] is defined and (groups["anydb_secondary"]|length>0)
 
 - name: Create Google Cloud Compute Engine Forwarding Rule (aka. Frontend IP and Port) for SAP AnyDB
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: gcp_lb_forwarding_rule
   google.cloud.gcp_compute_forwarding_rule:
     state: present
@@ -518,6 +597,8 @@
     subnetwork: { "selfLink": "{{ gcp_vpc_subnet_info.resources[0].selfLink }}" }
     load_balancing_scheme: INTERNAL
     network_tier: PREMIUM
+    auth_kind: "serviceaccount"
+    service_account_contents: "{{ sap_vm_provision_gcp_credentials_json }}"
   when:
     - vip_item | length > 0
     - groups["anydb_secondary"] is defined and (groups["anydb_secondary"]|length>0)
@@ -528,17 +609,21 @@
     loop_var: vip_item
 
 - name: Get information on Google Cloud Compute Engine (Regional) Backend Service
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: gcp_info_lb_backend_service_regional
   google.cloud.gcp_compute_region_backend_service_info:
     project: "{{ sap_vm_provision_gcp_project }}"
     region: "{{ sap_vm_provision_gcp_region }}"
     filters:
       - name = "lb-backend-service-anydb"
+    auth_kind: "serviceaccount"
+    service_account_contents: "{{ sap_vm_provision_gcp_credentials_json }}"
   when:
     - groups["anydb_secondary"] is defined and (groups["anydb_secondary"]|length>0)
 
 
 - name: Create Google Cloud Compute Engine Reserved Static Internal IP Address for the Virtual IP (VIP) of SAP NetWeaver ASCS
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: gcp_lb_reserved_address
   google.cloud.gcp_compute_address:
     state: present
@@ -550,10 +635,13 @@
     address: "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_ascs_ip_address | regex_replace('/.*', '') }}"
     #network_tier: PREMIUM # An address with type INTERNAL cannot have a network tier
     purpose: GCE_ENDPOINT # GCE_ENDPOINT is for addresses used by VMs, alias IP ranges, and internal load balancers
+    auth_kind: "serviceaccount"
+    service_account_contents: "{{ sap_vm_provision_gcp_credentials_json }}"
   when:
     - groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
 
 - name: Create Google Cloud Compute Engine Reserved Static Internal IP Address for the Virtual IP (VIP) of SAP NetWeaver ERS
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: gcp_lb_reserved_address
   google.cloud.gcp_compute_address:
     state: present
@@ -565,10 +653,13 @@
     address: "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_ers_ip_address | regex_replace('/.*', '') }}"
     #network_tier: PREMIUM # An address with type INTERNAL cannot have a network tier
     purpose: GCE_ENDPOINT # GCE_ENDPOINT is for addresses used by VMs, alias IP ranges, and internal load balancers
+    auth_kind: "serviceaccount"
+    service_account_contents: "{{ sap_vm_provision_gcp_credentials_json }}"
   when:
     - groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
 
 - name: Create Google Cloud Compute Engine Health Check (Global) service instance for SAP NetWeaver ASCS
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: gcp_lb_healthcheck_service_ascs
   google.cloud.gcp_compute_health_check:
     state: present
@@ -582,10 +673,13 @@
     timeout_sec: 10
     unhealthy_threshold: 2
     healthy_threshold: 2
+    auth_kind: "serviceaccount"
+    service_account_contents: "{{ sap_vm_provision_gcp_credentials_json }}"
   when:
     - groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
 
 - name: Create Google Cloud Compute Engine Health Check (Global) service instance for SAP NetWeaver ERS
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: gcp_lb_healthcheck_service_ers
   google.cloud.gcp_compute_health_check:
     state: present
@@ -599,16 +693,21 @@
     timeout_sec: 10
     unhealthy_threshold: 2
     healthy_threshold: 2
+    auth_kind: "serviceaccount"
+    service_account_contents: "{{ sap_vm_provision_gcp_credentials_json }}"
   when:
     - groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
 
 - name: Gather GCP VM information
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: gcp_vm_info
   google.cloud.gcp_compute_instance_info:
     project: "{{ sap_vm_provision_gcp_project }}"
     zone: "{{ sap_vm_provision_gcp_region_zone }}"
     filters:
       - name = {{ host_node }}
+    auth_kind: "serviceaccount"
+    service_account_contents: "{{ sap_vm_provision_gcp_credentials_json }}"
   loop: "{{ groups_merged_list }}"
   loop_control:
     loop_var: host_node
@@ -616,6 +715,7 @@
     - groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
 
 - name: Create Google Cloud Compute Engine Instance Group (Self-Managed/Unmanaged) Primary - for SAP NetWeaver ASCS
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: gcp_lb_instance_group1
   google.cloud.gcp_compute_instance_group:
     state: present
@@ -627,6 +727,8 @@
     #named_ports:
     #  - name: http # default, not applicable to internal passthrough NLB, only applicable to proxy NLB
     #    port: 80 # default
+    auth_kind: "serviceaccount"
+    service_account_contents: "{{ sap_vm_provision_gcp_credentials_json }}"
   loop: "{{ (groups['nwas_ascs'] | default([])) }}"
   loop_control:
     loop_var: host_node
@@ -634,6 +736,7 @@
     - groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
 
 - name: Create Google Cloud Compute Engine Instance Group (Self-Managed/Unmanaged) Secondary (Failover) - for SAP NetWeaver ERS
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: gcp_lb_instance_group2
   google.cloud.gcp_compute_instance_group:
     state: present
@@ -645,6 +748,8 @@
     #named_ports:
     #  - name: http # default, not applicable to internal passthrough NLB, only applicable to proxy NLB
     #    port: 80 # default
+    auth_kind: "serviceaccount"
+    service_account_contents: "{{ sap_vm_provision_gcp_credentials_json }}"
   loop: "{{ (groups['nwas_ers'] | default([])) }}"
   loop_control:
     loop_var: host_node
@@ -654,6 +759,7 @@
 # Note: Failover Ratio must be 1.0, which enforces failover to Secondary/Failover Instance Group if any VM the Backend Service's Primary Instance Group
 # No option for --global-health-checks ?
 - name: Create Google Cloud Compute Engine Backend Service (Regional) for the Internal passthrough Network Load Balancer used by SAP NetWeaver ASCS
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: gcp_lb_backend_service_regional_ascs
   google.cloud.gcp_compute_region_backend_service:
     state: present
@@ -676,12 +782,15 @@
       failover_ratio: 1 # 1.0
     session_affinity: NONE
     #timeout_sec: 30 # value ignored for internal passthrough NLB, default 30s to wait for backend before failure - see https://cloud.google.com/load-balancing/docs/backend-service#timeout-setting
+    auth_kind: "serviceaccount"
+    service_account_contents: "{{ sap_vm_provision_gcp_credentials_json }}"
   when:
     - groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
 
 # Note: Failover Ratio must be 1.0, which enforces failover to Secondary/Failover Instance Group if any VM the Backend Service's Primary Instance Group
 # No option for --global-health-checks ?
 - name: Create Google Cloud Compute Engine Backend Service (Regional) for the Internal passthrough Network Load Balancer used by SAP NetWeaver ERS
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: gcp_lb_backend_service_regional_ers
   google.cloud.gcp_compute_region_backend_service:
     state: present
@@ -704,10 +813,13 @@
       failover_ratio: 1 # 1.0
     session_affinity: NONE
     #timeout_sec: 30 # value ignored for internal passthrough NLB, default 30s to wait for backend before failure - see https://cloud.google.com/load-balancing/docs/backend-service#timeout-setting
+    auth_kind: "serviceaccount"
+    service_account_contents: "{{ sap_vm_provision_gcp_credentials_json }}"
   when:
     - groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
 
 - name: Create Google Cloud Compute Engine Forwarding Rule (aka. Frontend IP and Port) for SAP NetWeaver ASCS
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: gcp_lb_forwarding_rule
   google.cloud.gcp_compute_forwarding_rule:
     state: present
@@ -723,10 +835,13 @@
     subnetwork: { "selfLink": "{{ gcp_vpc_subnet_info.resources[0].selfLink }}" }
     load_balancing_scheme: INTERNAL
     network_tier: PREMIUM
+    auth_kind: "serviceaccount"
+    service_account_contents: "{{ sap_vm_provision_gcp_credentials_json }}"
   when:
     - groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
 
 - name: Create Google Cloud Compute Engine Forwarding Rule (aka. Frontend IP and Port) for SAP NetWeaver ERS
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: gcp_lb_forwarding_rule
   google.cloud.gcp_compute_forwarding_rule:
     state: present
@@ -742,26 +857,34 @@
     subnetwork: { "selfLink": "{{ gcp_vpc_subnet_info.resources[0].selfLink }}" }
     load_balancing_scheme: INTERNAL
     network_tier: PREMIUM
+    auth_kind: "serviceaccount"
+    service_account_contents: "{{ sap_vm_provision_gcp_credentials_json }}"
   when:
     - groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
 
 
 - name: Get information on Google Cloud Compute Engine (Regional) Backend Service for SAP NetWeaver ASCS
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: gcp_info_lb_backend_service_regional
   google.cloud.gcp_compute_region_backend_service_info:
     project: "{{ sap_vm_provision_gcp_project }}"
     region: "{{ sap_vm_provision_gcp_region }}"
     filters:
       - name = "lb-backend-service-nwas-ascs"
+    auth_kind: "serviceaccount"
+    service_account_contents: "{{ sap_vm_provision_gcp_credentials_json }}"
   when:
     - groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
 
 - name: Get information on Google Cloud Compute Engine (Regional) Backend Service for SAP NetWeaver ERS
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: gcp_info_lb_backend_service_regional
   google.cloud.gcp_compute_region_backend_service_info:
     project: "{{ sap_vm_provision_gcp_project }}"
     region: "{{ sap_vm_provision_gcp_region }}"
     filters:
       - name = "lb-backend-service-nwas-ers"
+    auth_kind: "serviceaccount"
+    service_account_contents: "{{ sap_vm_provision_gcp_credentials_json }}"
   when:
     - groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)

--- a/roles/sap_vm_provision/tasks/platform_ansible/gcp_ce_vm/execute_setup_ha.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/gcp_ce_vm/execute_setup_ha.yml
@@ -275,7 +275,7 @@
     - groups["hana_secondary"] is defined and (groups["hana_secondary"]|length>0)
 
 - name: Gather GCP VM information
-  google.cloud.gcp_compute___sap_vm_provision_task_provision_host_single_info:
+  google.cloud.gcp_compute_instance_info:
     project: "{{ sap_vm_provision_gcp_project }}"
     zone: "{{ sap_vm_provision_gcp_region_zone }}"
     filters:
@@ -426,7 +426,7 @@
     - groups["anydb_secondary"] is defined and (groups["anydb_secondary"]|length>0)
 
 - name: Gather GCP VM information
-  google.cloud.gcp_compute___sap_vm_provision_task_provision_host_single_info:
+  google.cloud.gcp_compute_instance_info:
     project: "{{ sap_vm_provision_gcp_project }}"
     zone: "{{ sap_vm_provision_gcp_region_zone }}"
     filters:
@@ -603,7 +603,7 @@
     - groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
 
 - name: Gather GCP VM information
-  google.cloud.gcp_compute___sap_vm_provision_task_provision_host_single_info:
+  google.cloud.gcp_compute_instance_info:
     project: "{{ sap_vm_provision_gcp_project }}"
     zone: "{{ sap_vm_provision_gcp_region_zone }}"
     filters:

--- a/roles/sap_vm_provision/tasks/platform_ansible/gcp_ce_vm/execute_setup_ha.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/gcp_ce_vm/execute_setup_ha.yml
@@ -275,7 +275,7 @@
     - groups["hana_secondary"] is defined and (groups["hana_secondary"]|length>0)
 
 - name: Gather GCP VM information
-  google.cloud.gcp_compute_instance_info:
+  google.cloud.gcp_compute___sap_vm_provision_task_provision_host_single_info:
     project: "{{ sap_vm_provision_gcp_project }}"
     zone: "{{ sap_vm_provision_gcp_region_zone }}"
     filters:
@@ -426,7 +426,7 @@
     - groups["anydb_secondary"] is defined and (groups["anydb_secondary"]|length>0)
 
 - name: Gather GCP VM information
-  google.cloud.gcp_compute_instance_info:
+  google.cloud.gcp_compute___sap_vm_provision_task_provision_host_single_info:
     project: "{{ sap_vm_provision_gcp_project }}"
     zone: "{{ sap_vm_provision_gcp_region_zone }}"
     filters:
@@ -603,7 +603,7 @@
     - groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
 
 - name: Gather GCP VM information
-  google.cloud.gcp_compute_instance_info:
+  google.cloud.gcp_compute___sap_vm_provision_task_provision_host_single_info:
     project: "{{ sap_vm_provision_gcp_project }}"
     zone: "{{ sap_vm_provision_gcp_region_zone }}"
     filters:

--- a/roles/sap_vm_provision/tasks/platform_ansible/gcp_ce_vm/post_deployment_execute.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/gcp_ce_vm/post_deployment_execute.yml
@@ -42,6 +42,7 @@
       when: not sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ers_port is defined
 
     - name: Create Google Cloud Compute Engine Health Check (Global) service instance for SAP HANA
+      register: gcp_lb_healthcheck_service
       google.cloud.gcp_compute_health_check:
         state: present
         project: "{{ sap_vm_provision_gcp_project }}"
@@ -54,11 +55,11 @@
         timeout_sec: 10
         unhealthy_threshold: 2
         healthy_threshold: 2
-      register: gcp_lb_healthcheck_service
       when:
         - groups["hana_secondary"] is defined and (groups["hana_secondary"]|length>0)
 
     - name: Create Google Cloud Compute Engine Health Check (Global) service instance for SAP AnyDB
+      register: gcp_lb_healthcheck_service
       google.cloud.gcp_compute_health_check:
         state: present
         project: "{{ sap_vm_provision_gcp_project }}"
@@ -71,11 +72,11 @@
         timeout_sec: 10
         unhealthy_threshold: 2
         healthy_threshold: 2
-      register: gcp_lb_healthcheck_service
       when:
         - groups["anydb_secondary"] is defined and (groups["anydb_secondary"]|length>0)
 
     - name: Create Google Cloud Compute Engine Health Check (Global) service instance for SAP NetWeaver ASCS
+      register: gcp_lb_healthcheck_service_ascs
       google.cloud.gcp_compute_health_check:
         state: present
         project: "{{ sap_vm_provision_gcp_project }}"
@@ -88,11 +89,11 @@
         timeout_sec: 10
         unhealthy_threshold: 2
         healthy_threshold: 2
-      register: gcp_lb_healthcheck_service_ascs
       when:
         - groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
 
     - name: Create Google Cloud Compute Engine Health Check (Global) service instance for SAP NetWeaver ERS
+      register: gcp_lb_healthcheck_service_ers
       google.cloud.gcp_compute_health_check:
         state: present
         project: "{{ sap_vm_provision_gcp_project }}"
@@ -105,6 +106,5 @@
         timeout_sec: 10
         unhealthy_threshold: 2
         healthy_threshold: 2
-      register: gcp_lb_healthcheck_service_ers
       when:
         - groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)

--- a/roles/sap_vm_provision/tasks/platform_ansible/gcp_ce_vm/post_deployment_execute.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/gcp_ce_vm/post_deployment_execute.yml
@@ -3,9 +3,12 @@
 - name: Ansible Task block for amending Load Balancer ports for High Availability - after provisioning GCP CE VMs
   delegate_to: localhost
   run_once: true
-  environment:
-    GCP_AUTH_KIND: "serviceaccount"
-    GCP_SERVICE_ACCOUNT_FILE: "{{ sap_vm_provision_gcp_credentials_json }}"
+  any_errors_fatal: true
+  # Using environment, no_log is ineffective and log will show 'EXEC /bin/sh -c 'ENV_VAR=value python3 /AnsiballZ_ansible_module_name.py && sleep 0'
+  # Therefore do not use environment for secrets, use only for non-sensitive values as this will reduce Ansible Task parameters.
+  # environment:
+  #   GCP_AUTH_KIND: "serviceaccount"
+  #   GCP_SERVICE_ACCOUNT_FILE: "{{ sap_vm_provision_gcp_credentials_json }}"
   when:
     - sap_ha_pacemaker_cluster_msazure_resource_group is defined
     - (groups["hana_secondary"] is defined and (groups["hana_secondary"] | length>0)) or (groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0)) or (groups["anydb_secondary"] is defined and (groups["anydb_secondary"] | length>0))
@@ -42,6 +45,7 @@
       when: not sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ers_port is defined
 
     - name: Create Google Cloud Compute Engine Health Check (Global) service instance for SAP HANA
+      no_log: "{{ __sap_vm_provision_no_log }}"
       register: gcp_lb_healthcheck_service
       google.cloud.gcp_compute_health_check:
         state: present
@@ -55,10 +59,13 @@
         timeout_sec: 10
         unhealthy_threshold: 2
         healthy_threshold: 2
+        auth_kind: "serviceaccount"
+        service_account_contents: "{{ sap_vm_provision_gcp_credentials_json }}"
       when:
         - groups["hana_secondary"] is defined and (groups["hana_secondary"]|length>0)
 
     - name: Create Google Cloud Compute Engine Health Check (Global) service instance for SAP AnyDB
+      no_log: "{{ __sap_vm_provision_no_log }}"
       register: gcp_lb_healthcheck_service
       google.cloud.gcp_compute_health_check:
         state: present
@@ -72,10 +79,13 @@
         timeout_sec: 10
         unhealthy_threshold: 2
         healthy_threshold: 2
+        auth_kind: "serviceaccount"
+        service_account_contents: "{{ sap_vm_provision_gcp_credentials_json }}"
       when:
         - groups["anydb_secondary"] is defined and (groups["anydb_secondary"]|length>0)
 
     - name: Create Google Cloud Compute Engine Health Check (Global) service instance for SAP NetWeaver ASCS
+      no_log: "{{ __sap_vm_provision_no_log }}"
       register: gcp_lb_healthcheck_service_ascs
       google.cloud.gcp_compute_health_check:
         state: present
@@ -89,10 +99,13 @@
         timeout_sec: 10
         unhealthy_threshold: 2
         healthy_threshold: 2
+        auth_kind: "serviceaccount"
+        service_account_contents: "{{ sap_vm_provision_gcp_credentials_json }}"
       when:
         - groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
 
     - name: Create Google Cloud Compute Engine Health Check (Global) service instance for SAP NetWeaver ERS
+      no_log: "{{ __sap_vm_provision_no_log }}"
       register: gcp_lb_healthcheck_service_ers
       google.cloud.gcp_compute_health_check:
         state: present
@@ -106,5 +119,7 @@
         timeout_sec: 10
         unhealthy_threshold: 2
         healthy_threshold: 2
+        auth_kind: "serviceaccount"
+        service_account_contents: "{{ sap_vm_provision_gcp_credentials_json }}"
       when:
         - groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)

--- a/roles/sap_vm_provision/tasks/platform_ansible/gcp_ce_vm/post_deployment_execute.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/gcp_ce_vm/post_deployment_execute.yml
@@ -16,44 +16,44 @@
 
     - name: Inherit variable - set fact for Google Cloud Compute Engine Health Check (Global) - SAP HANA
       ansible.builtin.set_fact:
-        gcp_lb_healthcheck_hana: "{{ sap_ha_pacemaker_cluster_healthcheck_hana_primary_port | default('') }}"
+        __sap_vm_provision_task_gcp_lb_healthcheck_hana: "{{ sap_ha_pacemaker_cluster_healthcheck_hana_primary_port | default('') }}"
       when: sap_ha_pacemaker_cluster_healthcheck_hana_primary_port is defined
 
     - name: Inherit variable - set fact for Google Cloud Compute Engine Health Check (Global) - SAP NWAS ASCS
       ansible.builtin.set_fact:
-        gcp_lb_healthcheck_nwas_ascs: "{{ sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ascs_port | default('') }}"
+        __sap_vm_provision_task_gcp_lb_healthcheck_nwas_ascs: "{{ sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ascs_port | default('') }}"
       when: sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ascs_port is defined
 
     - name: Inherit variable - set fact for Google Cloud Compute Engine Health Check (Global) - SAP NWAS ERS
       ansible.builtin.set_fact:
-        gcp_lb_healthcheck_nwas_ers: "{{ sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ers_port | default('') }}"
+        __sap_vm_provision_task_gcp_lb_healthcheck_nwas_ers: "{{ sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ers_port | default('') }}"
       when: sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ers_port is defined
 
     - name: Default variable - Set fact for Google Cloud Compute Engine Health Check (Global) - SAP HANA
       ansible.builtin.set_fact:
-        gcp_lb_healthcheck_hana: "{{ ('620' + (sap_system_hana_db_instance_nr | default('')) | string) | int }}"
+        __sap_vm_provision_task_gcp_lb_healthcheck_hana: "{{ ('620' + (sap_system_hana_db_instance_nr | default('')) | string) | int }}"
       when: not sap_ha_pacemaker_cluster_healthcheck_hana_primary_port is defined
 
     - name: Default variable - Set fact for Google Cloud Compute Engine Health Check (Global) - SAP NWAS ASCS
       ansible.builtin.set_fact:
-        gcp_lb_healthcheck_nwas_ascs: "{{ ('620' + (sap_system_nwas_abap_ascs_instance_nr | default('')) | string) | int }}"
+        __sap_vm_provision_task_gcp_lb_healthcheck_nwas_ascs: "{{ ('620' + (sap_system_nwas_abap_ascs_instance_nr | default('')) | string) | int }}"
       when: not sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ascs_port is defined
 
     - name: Default variable - Set fact for Google Cloud Compute Engine Health Check (Global) - SAP NWAS ERS
       ansible.builtin.set_fact:
-        gcp_lb_healthcheck_nwas_ers: "{{ ('620' + (sap_system_nwas_abap_ers_instance_nr | default('')) | string) | int }}"
+        __sap_vm_provision_task_gcp_lb_healthcheck_nwas_ers: "{{ ('620' + (sap_system_nwas_abap_ers_instance_nr | default('')) | string) | int }}"
       when: not sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ers_port is defined
 
     - name: Create Google Cloud Compute Engine Health Check (Global) service instance for SAP HANA
       no_log: "{{ __sap_vm_provision_no_log }}"
-      register: gcp_lb_healthcheck_service
+      register: __sap_vm_provision_task_gcp_lb_healthcheck_service
       google.cloud.gcp_compute_health_check:
         state: present
         project: "{{ sap_vm_provision_gcp_project }}"
         name: "lb-probe-hc-vip-hana"
         type: TCP
         tcp_health_check:
-          port: "{{ gcp_lb_healthcheck_hana }}"
+          port: "{{ __sap_vm_provision_task_gcp_lb_healthcheck_hana }}"
           proxy_header: NONE
         check_interval_sec: 10
         timeout_sec: 10
@@ -66,7 +66,7 @@
 
     - name: Create Google Cloud Compute Engine Health Check (Global) service instance for SAP AnyDB
       no_log: "{{ __sap_vm_provision_no_log }}"
-      register: gcp_lb_healthcheck_service
+      register: __sap_vm_provision_task_gcp_lb_healthcheck_service
       google.cloud.gcp_compute_health_check:
         state: present
         project: "{{ sap_vm_provision_gcp_project }}"
@@ -86,14 +86,14 @@
 
     - name: Create Google Cloud Compute Engine Health Check (Global) service instance for SAP NetWeaver ASCS
       no_log: "{{ __sap_vm_provision_no_log }}"
-      register: gcp_lb_healthcheck_service_ascs
+      register: __sap_vm_provision_task_gcp_lb_healthcheck_service_ascs
       google.cloud.gcp_compute_health_check:
         state: present
         project: "{{ sap_vm_provision_gcp_project }}"
         name: "lb-probe-hc-vip-nwas-ascs"
         type: TCP
         tcp_health_check:
-          port: "{{ gcp_lb_healthcheck_nwas_ascs }}"
+          port: "{{ __sap_vm_provision_task_gcp_lb_healthcheck_nwas_ascs }}"
           proxy_header: NONE
         check_interval_sec: 10
         timeout_sec: 10
@@ -106,14 +106,14 @@
 
     - name: Create Google Cloud Compute Engine Health Check (Global) service instance for SAP NetWeaver ERS
       no_log: "{{ __sap_vm_provision_no_log }}"
-      register: gcp_lb_healthcheck_service_ers
+      register: __sap_vm_provision_task_gcp_lb_healthcheck_service_ers
       google.cloud.gcp_compute_health_check:
         state: present
         project: "{{ sap_vm_provision_gcp_project }}"
         name: "lb-probe-hc-vip-nwas-ers"
         type: TCP
         tcp_health_check:
-          port: "{{ gcp_lb_healthcheck_nwas_ers }}"
+          port: "{{ __sap_vm_provision_task_gcp_lb_healthcheck_nwas_ers }}"
           proxy_header: NONE
         check_interval_sec: 10
         timeout_sec: 10

--- a/roles/sap_vm_provision/tasks/platform_ansible/ibmcloud_powervs/execute_main.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/ibmcloud_powervs/execute_main.yml
@@ -44,94 +44,117 @@
     sap_vm_provision_ibmcloud_powervs_region: "{{ list_ibmcloud_powervs_location_to_powervs_region[sap_vm_provision_ibmcloud_powervs_location] }}"
 
 - name: Ansible Task block for looped provisioning of IBM Power Virtual Servers on IBM Cloud
+  any_errors_fatal: true
+  # Using environment, no_log is ineffective and log will show 'EXEC /bin/sh -c 'ENV_VAR=value python3 /AnsiballZ_ansible_module_name.py && sleep 0'
+  # Therefore do not use environment for secrets, use only for non-sensitive values as this will reduce Ansible Task parameters.
   environment:
-    IC_API_KEY: "{{ sap_vm_provision_ibmcloud_api_key }}"
+    # IC_API_KEY: "{{ sap_vm_provision_ibmcloud_api_key }}"
     IC_REGION: "{{ sap_vm_provision_ibmcloud_region }}"
     IC_ZONE: "{{ sap_vm_provision_ibmcloud_powervs_location }}" # Required only for IBM Power VS, to set IBM Power VS location
   block:
 
     - name: Identify Resource Group info
-      register: register_ibmcloud_resource_group
+      no_log: "{{ __sap_vm_provision_no_log }}"
+      register: __sap_vm_provision_task_ibmcloud_resource_group
       ibm.cloudcollection.ibm_resource_group_info:
         name: "{{ sap_vm_provision_ibmcloud_resource_group_name }}"
+        ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
 
     # DNS may exist in separate Resource Group
     # Use empty string var (or default false if undefined) to evaluate to false boolean
     - name: Identify Resource Group info for Private DNS
-      register: register_ibmcloud_resource_group_dns
+      no_log: "{{ __sap_vm_provision_no_log }}"
+      register: __sap_vm_provision_task_ibmcloud_resource_group_dns
       ibm.cloudcollection.ibm_resource_group_info:
         name: "{{ sap_vm_provision_ibmcloud_private_dns_resource_group_name }}"
+        ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
       when: (sap_vm_provision_ibmcloud_private_dns_resource_group_name | default(false))
 
     - name: Identify IBM Power Infrastructure Workspace
-      register: register_ibmcloud_power_iaas_workspace_service_instance
+      no_log: "{{ __sap_vm_provision_no_log }}"
+      register: __sap_vm_provision_task_ibmcloud_pi_workspace_service_instance
       ibm.cloudcollection.ibm_resource_instance_info:
-        resource_group_id: "{{ register_ibmcloud_resource_group.resource.id }}"
+        resource_group_id: "{{ __sap_vm_provision_task_ibmcloud_resource_group.resource.id }}"
         location: "{{ sap_vm_provision_ibmcloud_powervs_location }}"
         service: power-iaas
         name: "{{ sap_vm_provision_ibmcloud_powervs_workspace_name }}"
+        ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
 
     - name: Identify pre-loaded Power Infrastructure SSH Public Key info
-      register: register_ibmcloud_pi_ssh_public_key
+      no_log: "{{ __sap_vm_provision_no_log }}"
+      register: __sap_vm_provision_task_ibmcloud_pi_ssh_public_key
       environment:
         IC_REGION: "{{ sap_vm_provision_ibmcloud_powervs_region }}"
       ibm.cloudcollection.ibm_pi_key_info:
-        pi_cloud_instance_id: "{{ register_ibmcloud_power_iaas_workspace_service_instance.resource.guid }}" # must be GUID, not CRN
+        pi_cloud_instance_id: "{{ __sap_vm_provision_task_ibmcloud_pi_workspace_service_instance.resource.guid }}" # must be GUID, not CRN
         pi_key_name: "{{ sap_vm_provision_ibmcloud_powervs_key_pair_name_ssh_host_public_key }}"
+        ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
 
     - name: Identify Power Infrastructure VLAN Subnet info
-      register: register_ibmcloud_pi_subnet
+      no_log: "{{ __sap_vm_provision_no_log }}"
+      register: __sap_vm_provision_task_ibmcloud_pi_subnet
       environment:
         IC_REGION: "{{ sap_vm_provision_ibmcloud_powervs_region }}"
       ibm.cloudcollection.ibm_pi_network_info:
-        pi_cloud_instance_id: "{{ register_ibmcloud_power_iaas_workspace_service_instance.resource.guid }}" # must be GUID, not CRN
+        pi_cloud_instance_id: "{{ __sap_vm_provision_task_ibmcloud_pi_workspace_service_instance.resource.guid }}" # must be GUID, not CRN
         pi_network_name: "{{ sap_vm_provision_ibmcloud_powervs_vlan_subnet_name }}"
+        ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
 
     - name: Identify Power Infrastructure OS Image list
-      register: register_ibmcloud_pi_os_image_list
+      no_log: "{{ __sap_vm_provision_no_log }}"
+      register: __sap_vm_provision_task_ibmcloud_pi_os_image_list
       environment:
         IC_REGION: "{{ sap_vm_provision_ibmcloud_powervs_region }}"
       ibm.cloudcollection.ibm_pi_catalog_images_info:
-        pi_cloud_instance_id: "{{ register_ibmcloud_power_iaas_workspace_service_instance.resource.guid }}" # must be GUID, not CRN
+        pi_cloud_instance_id: "{{ __sap_vm_provision_task_ibmcloud_pi_workspace_service_instance.resource.guid }}" # must be GUID, not CRN
+        ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
 
     # DNS may exist in separate Resource Group
     # If previous identification task is skipped, use resource group else use the resource group defined for the Private DNS
     - name: Identify Private DNS instance
-      register: register_ibmcloud_pdns_service_instance
+      no_log: "{{ __sap_vm_provision_no_log }}"
+      register: __sap_vm_provision_task_ibmcloud_pdns_service_instance
       ibm.cloudcollection.ibm_resource_instance_info:
-        resource_group_id: "{{ register_ibmcloud_resource_group.resource.id if register_ibmcloud_resource_group_dns is skipped else register_ibmcloud_resource_group_dns.resource.id }}"
+        resource_group_id: "{{ __sap_vm_provision_task_ibmcloud_resource_group.resource.id if __sap_vm_provision_task_ibmcloud_resource_group_dns is skipped else __sap_vm_provision_task_ibmcloud_resource_group_dns.resource.id }}"
         location: global
         service: dns-svcs
         name: "{{ sap_vm_provision_ibmcloud_private_dns_instance_name }}"
+        ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
 
     - name: Identify Private DNS Zone info
-      register: register_ibmcloud_pdns
+      no_log: "{{ __sap_vm_provision_no_log }}"
+      register: __sap_vm_provision_task_ibmcloud_pdns
       ibm.cloudcollection.ibm_dns_zones_info:
-        instance_id: "{{ register_ibmcloud_pdns_service_instance.resource.guid }}"
+        instance_id: "{{ __sap_vm_provision_task_ibmcloud_pdns_service_instance.resource.guid }}"
+        ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
 
     - name: Set fact for latest IBM Power Infrastructure OS Catalog Stock Image
       ansible.builtin.set_fact:
-        register_ibmcloud_pi_os_image_selected: "{{ register_ibmcloud_pi_os_image_list.resource.images | selectattr('name', 'search', lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_os_image_dictionary')[sap_vm_provision_ibmcloud_powervs_host_os_image]) | sort(reverse=True,case_sensitive=False,attribute='name') | first }}"
+        register_ibmcloud_pi_os_image_selected: "{{ __sap_vm_provision_task_ibmcloud_pi_os_image_list.resource.images | selectattr('name', 'search', lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_os_image_dictionary')[sap_vm_provision_ibmcloud_powervs_host_os_image]) | sort(reverse=True,case_sensitive=False,attribute='name') | first }}"
 
     - name: Create Boot Image from IBM Power Infrastructure OS Catalog Stock Image
-      register: register_provisioned_os_image
+      no_log: "{{ __sap_vm_provision_no_log }}"
+      register: __sap_vm_provision_task_ibmcloud_pi_os_image_provisioned
       environment:
         IC_REGION: "{{ sap_vm_provision_ibmcloud_powervs_region }}"
       ibm.cloudcollection.ibm_pi_image:
-        pi_cloud_instance_id: "{{ register_ibmcloud_power_iaas_workspace_service_instance.resource.guid }}" # must be GUID, not CRN
+        pi_cloud_instance_id: "{{ __sap_vm_provision_task_ibmcloud_pi_workspace_service_instance.resource.guid }}" # must be GUID, not CRN
         pi_image_id: "{{ register_ibmcloud_pi_os_image_selected.image_id }}"
         pi_image_name: "{{ sap_vm_provision_ibmcloud_powervs_host_os_image }}-boot"
-      failed_when: not register_provisioned_os_image.rc == 0 and not 'already exists' in register_provisioned_os_image.stderr
+        ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
+      failed_when: not __sap_vm_provision_task_ibmcloud_pi_os_image_provisioned.rc == 0 and not 'already exists' in __sap_vm_provision_task_ibmcloud_pi_os_image_provisioned.stderr
       run_once: true
 
     # Use check to avoid idempotency issues with legacy ibm.cloudcollection Ansible Collection (until ibm.cloud Ansible Collection is ready)
     - name: Check for existing Boot Image imported already from IBM Power Infrastructure OS Catalog Stock Image
-      register: register_existing_os_image
+      no_log: "{{ __sap_vm_provision_no_log }}"
+      register: __sap_vm_provision_task_ibmcloud_pi_os_image_existing
       environment:
         IC_REGION: "{{ sap_vm_provision_ibmcloud_powervs_region }}"
       ibm.cloudcollection.ibm_pi_image_info:
-        pi_cloud_instance_id: "{{ register_ibmcloud_power_iaas_workspace_service_instance.resource.guid }}" # must be GUID, not CRN
+        pi_cloud_instance_id: "{{ __sap_vm_provision_task_ibmcloud_pi_workspace_service_instance.resource.guid }}" # must be GUID, not CRN
         pi_image_name: "{{ register_ibmcloud_pi_os_image_selected.name }}"
+        ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
       run_once: true
 
     - name: Set fact to hold loop variables from include_tasks
@@ -144,7 +167,7 @@
         file: "{{ 'platform_' + sap_vm_provision_iac_type }}/{{ sap_vm_provision_iac_platform }}/execute_provision.yml"
         apply:
           environment:
-            IC_API_KEY: "{{ sap_vm_provision_ibmcloud_api_key }}"
+            # IC_API_KEY: "{{ sap_vm_provision_ibmcloud_api_key }}"
             IC_REGION: "{{ sap_vm_provision_ibmcloud_powervs_region }}"
             IC_ZONE: "{{ sap_vm_provision_ibmcloud_powervs_location }}" # Required only for IBM Power VS, to set IBM Power VS location
 
@@ -176,18 +199,56 @@
         file: common/set_ansible_vars.yml
 
     - name: IBM Cloud Private DNS Record for hosts
-      register: register_ibmcloud_pdns_record
+      no_log: "{{ __sap_vm_provision_no_log }}"
+      register: __sap_vm_provision_task_ibmcloud_pdns_record
       ibm.cloudcollection.ibm_dns_resource_record:
-        instance_id: "{{ register_ibmcloud_pdns_service_instance.resource.guid }}"
-        zone_id: "{{ (register_ibmcloud_pdns.resource.dns_zones | selectattr('name', '==', sap_vm_provision_dns_root_domain) | first).zone_id }}"
+        instance_id: "{{ __sap_vm_provision_task_ibmcloud_pdns_service_instance.resource.guid }}"
+        zone_id: "{{ (__sap_vm_provision_task_ibmcloud_pdns.resource.dns_zones | selectattr('name', '==', sap_vm_provision_dns_root_domain) | first).zone_id }}"
         name: "{{ inventory_hostname }}.{{ hostvars[inventory_hostname].sap_vm_provision_dns_root_domain }}" # Host FQDN
         rdata: "{{ hostvars[inventory_hostname].ansible_host }}" # IP Address
         type: A
         ttl: 7200
-      failed_when: not register_ibmcloud_pdns_record.rc == 0 and not 'The record already exists' in register_ibmcloud_pdns_record.stderr
+        ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
+      failed_when: not __sap_vm_provision_task_ibmcloud_pdns_record.rc == 0 and not 'The record already exists' in __sap_vm_provision_task_ibmcloud_pdns_record.stderr
 
   #  - ansible.builtin.debug:
   #      var: __sap_vm_provision_task_provision_host_all_add.results
+
+  rescue:
+    # This requires no_log set on each Ansible Task, and not set on the Ansible Task Block
+    # This requires an Ansible Task Block containing the Ansible Tasks for calling
+    # Infrastructure Platform APIs (via Ansible Modules)
+    - name: Show errors in task outputs
+      ansible.builtin.fail:
+        msg: "{{ lookup('ansible.builtin.vars', loop_item) }}"
+      loop:
+        - __sap_vm_provision_task_ibmcloud_resource_group
+        - __sap_vm_provision_task_ibmcloud_resource_group_dns
+        - __sap_vm_provision_task_ibmcloud_pi_workspace_service_instance
+        - __sap_vm_provision_task_ibmcloud_pi_ssh_public_key
+        - __sap_vm_provision_task_ibmcloud_pi_subnet
+        - __sap_vm_provision_task_ibmcloud_pi_os_image_list
+        - __sap_vm_provision_task_ibmcloud_pdns_service_instance
+        - __sap_vm_provision_task_ibmcloud_pdns
+        - __sap_vm_provision_task_ibmcloud_pi_os_image_provisioned
+        - __sap_vm_provision_task_ibmcloud_pi_os_image_existing
+        - __sap_vm_provision_task_provision_host_all_run
+        - __sap_vm_provision_task_provision_host_single
+        - __sap_vm_provision_task_provision_host_single_volumes
+        - __sap_vm_provision_task_provision_host_single_volumes_info
+        - __sap_vm_provision_task_provision_host_single_volume_attachments
+        - __sap_vm_provision_task_provision_host_single_info
+        - __sap_vm_provision_task_provision_host_all_add
+        - __sap_vm_provision_task_ibmcloud_pdns_record
+      loop_control:
+        loop_var: loop_item
+        index_var: loop_item_index
+        label: "{{ 'Variable No. ' + (loop_item_index | string) }}"
+      when:
+        - lookup('ansible.builtin.vars', loop_item, default='') | length > 0
+        - not lookup('ansible.builtin.vars', loop_item, default='') is skipped
+        - lookup('ansible.builtin.vars', loop_item, default='') is failed
+
 
 - name: Ansible Task block to execute on target inventory hosts
   delegate_to: "{{ inventory_hostname }}"

--- a/roles/sap_vm_provision/tasks/platform_ansible/ibmcloud_powervs/execute_main.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/ibmcloud_powervs/execute_main.yml
@@ -65,7 +65,7 @@
 
     - name: Identify IBM Power Infrastructure Workspace
       register: register_ibmcloud_power_iaas_workspace_service_instance
-      ibm.cloudcollection.ibm_resource___sap_vm_provision_task_provision_host_single_info:
+      ibm.cloudcollection.ibm_resource_instance_info:
         resource_group_id: "{{ register_ibmcloud_resource_group.resource.id }}"
         location: "{{ sap_vm_provision_ibmcloud_powervs_location }}"
         service: power-iaas
@@ -98,7 +98,7 @@
     # If previous identification task is skipped, use resource group else use the resource group defined for the Private DNS
     - name: Identify Private DNS instance
       register: register_ibmcloud_pdns_service_instance
-      ibm.cloudcollection.ibm_resource___sap_vm_provision_task_provision_host_single_info:
+      ibm.cloudcollection.ibm_resource_instance_info:
         resource_group_id: "{{ register_ibmcloud_resource_group.resource.id if register_ibmcloud_resource_group_dns is skipped else register_ibmcloud_resource_group_dns.resource.id }}"
         location: global
         service: dns-svcs

--- a/roles/sap_vm_provision/tasks/platform_ansible/ibmcloud_powervs/execute_main.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/ibmcloud_powervs/execute_main.yml
@@ -171,7 +171,7 @@
         groups_merged_list: "{{ [ [ groups['hana_primary'] | default([]) ] , [ groups['hana_secondary'] | default([]) ] , [ groups['nwas_ascs'] | default([]) ] , [ groups['nwas_ers'] | default([]) ] , [ groups['nwas_pas'] | default([]) ] , [ groups['nwas_aas'] | default([]) ] ] | flatten | select() }}"
 
     - name: Set Ansible Vars
-      register: register_set_ansible_vars
+      register: __sap_vm_provision_task_ansible_vars_set
       ansible.builtin.include_tasks:
         file: common/set_ansible_vars.yml
 
@@ -206,26 +206,26 @@
         name: "{{ inventory_hostname_short }}"
 
     - name: Set /etc/hosts
-      register: register_etc_hosts_file
+      register: __sap_vm_provision_task_os_etc_hosts
       ansible.builtin.include_tasks:
         file: common/set_etc_hosts.yml
 
     - name: Set /etc/hosts for HA
-      register: register_etc_hosts_file_ha
+      register: __sap_vm_provision_task_os_etc_hosts_ha
       ansible.builtin.include_tasks:
         file: common/set_etc_hosts_ha.yml
       when:
         - (groups["hana_secondary"] is defined and (groups["hana_secondary"] | length>0)) or (groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0)) or (groups["anydb_secondary"] is defined and (groups["anydb_secondary"] | length>0))
 
     - name: Set /etc/hosts for Scale-Out
-      register: register_etc_hosts_file_scaleout
+      register: __sap_vm_provision_task_os_etc_hosts_scaleout
       ansible.builtin.include_tasks:
         file: common/set_etc_hosts_scaleout.yml
       when:
         - (groups["hana_primary"] is defined and (groups["hana_primary"] | length>0)) and (sap_hana_scaleout_active_coordinator is defined or sap_hana_scaleout_active_worker is defined or sap_hana_scaleout_standby is defined)
 
     - name: Set vars for sap_storage_setup Ansible Role
-      register: register_ansible_vars_storage
+      register: __sap_vm_provision_task_ansible_vars_storage
       ansible.builtin.include_tasks:
         file: common/set_ansible_vars_storage.yml
 

--- a/roles/sap_vm_provision/tasks/platform_ansible/ibmcloud_powervs/execute_main.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/ibmcloud_powervs/execute_main.yml
@@ -65,7 +65,7 @@
 
     - name: Identify IBM Power Infrastructure Workspace
       register: register_ibmcloud_power_iaas_workspace_service_instance
-      ibm.cloudcollection.ibm_resource_instance_info:
+      ibm.cloudcollection.ibm_resource___sap_vm_provision_task_provision_host_single_info:
         resource_group_id: "{{ register_ibmcloud_resource_group.resource.id }}"
         location: "{{ sap_vm_provision_ibmcloud_powervs_location }}"
         service: power-iaas
@@ -98,7 +98,7 @@
     # If previous identification task is skipped, use resource group else use the resource group defined for the Private DNS
     - name: Identify Private DNS instance
       register: register_ibmcloud_pdns_service_instance
-      ibm.cloudcollection.ibm_resource_instance_info:
+      ibm.cloudcollection.ibm_resource___sap_vm_provision_task_provision_host_single_info:
         resource_group_id: "{{ register_ibmcloud_resource_group.resource.id if register_ibmcloud_resource_group_dns is skipped else register_ibmcloud_resource_group_dns.resource.id }}"
         location: global
         service: dns-svcs
@@ -139,7 +139,7 @@
         register_provisioned_host_all: []
 
     - name: Provision IBM Power Virtual Server hosts on IBM Cloud
-      register: register_provisioned_hosts
+      register: __sap_vm_provision_task_provision_host_all_run
       ansible.builtin.include_tasks:
         file: "{{ 'platform_' + sap_vm_provision_iac_type }}/{{ sap_vm_provision_iac_platform }}/execute_provision.yml"
         apply:
@@ -149,7 +149,7 @@
             IC_ZONE: "{{ sap_vm_provision_ibmcloud_powervs_location }}" # Required only for IBM Power VS, to set IBM Power VS location
 
     - name: Add hosts provisioned to the Ansible Inventory
-      register: register_add_hosts
+      register: __sap_vm_provision_task_provision_host_all_add
       ansible.builtin.add_host:
         name: "{{ add_item[0].host_node }}"
         groups: "{{ add_item[0].sap_system_type + '_' if (add_item[0].sap_system_type != '') }}{{ add_item[0].sap_host_type }}"
@@ -187,7 +187,7 @@
       failed_when: not register_ibmcloud_pdns_record.rc == 0 and not 'The record already exists' in register_ibmcloud_pdns_record.stderr
 
   #  - ansible.builtin.debug:
-  #      var: register_add_hosts.results
+  #      var: __sap_vm_provision_task_provision_host_all_add.results
 
 - name: Ansible Task block to execute on target inventory hosts
   delegate_to: "{{ inventory_hostname }}"

--- a/roles/sap_vm_provision/tasks/platform_ansible/ibmcloud_powervs/execute_provision.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/ibmcloud_powervs/execute_provision.yml
@@ -17,19 +17,20 @@
 
 # Status will change from Building > Warning (VM = Active, Health = Warning) > Active. The Ansible Task will continue once the Active status has been reached.
 - name: Provision IBM Power Virtual Server instance on IBM Cloud
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_provision_host_single
   ibm.cloudcollection.ibm_pi_instance:
-    pi_cloud_instance_id: "{{ register_ibmcloud_power_iaas_workspace_service_instance.resource.guid }}" # must be GUID, not CRN
+    pi_cloud_instance_id: "{{ __sap_vm_provision_task_ibmcloud_pi_workspace_service_instance.resource.guid }}" # must be GUID, not CRN
 
     pi_instance_name: "{{ inventory_hostname }}"
-    pi_image_id: "{{ register_provisioned_os_image.resource.id if register_provisioned_os_image.rc == 0 else register_existing_os_image.resource.id }}"
+    pi_image_id: "{{ __sap_vm_provision_task_ibmcloud_pi_os_image_provisioned.resource.id if __sap_vm_provision_task_ibmcloud_pi_os_image_provisioned.rc == 0 else __sap_vm_provision_task_ibmcloud_pi_os_image_existing.resource.id }}"
 
     pi_sys_type: e980
     pi_sap_profile_id: "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][scaleout_origin_host_spec | default(inventory_hostname)].virtual_machine_profile }}"
     pi_key_pair_name: "{{ sap_vm_provision_ibmcloud_powervs_key_pair_name_ssh_host_public_key }}"
 
     pi_network:
-      - network_id: "{{ register_ibmcloud_pi_subnet.resource.id }}"
+      - network_id: "{{ __sap_vm_provision_task_ibmcloud_pi_subnet.resource.id }}"
 
     pi_storage_type: tier1
     #pi_volume_ids: []
@@ -37,12 +38,16 @@
     pi_pin_policy: none
     pi_health_status: OK
 
+    ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
+
 # Use check to avoid idempotency issues with legacy ibm.cloudcollection Ansible Collection (until ibm.cloud Ansible Collection is out of beta)
 - name: Check IBM Power Virtual Server instance on IBM Cloud
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_provision_host_single
   ibm.cloudcollection.ibm_pi_instance_info:
-    pi_cloud_instance_id: "{{ register_ibmcloud_power_iaas_workspace_service_instance.resource.guid }}" # must be GUID, not CRN
+    pi_cloud_instance_id: "{{ __sap_vm_provision_task_ibmcloud_pi_workspace_service_instance.resource.guid }}" # must be GUID, not CRN
     pi_instance_name: "{{ inventory_hostname }}"
+    ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
 
 
 # Create flat list with names for each volume to be created.
@@ -71,15 +76,17 @@
 
 
 - name: Provision IBM Power Infrastructure Block Storage volumes for IBM Power VS instance filesystems
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_provision_host_single_volumes
   ibm.cloudcollection.ibm_pi_volume:
-    pi_cloud_instance_id: "{{ register_ibmcloud_power_iaas_workspace_service_instance.resource.guid }}" # must be GUID, not CRN
+    pi_cloud_instance_id: "{{ __sap_vm_provision_task_ibmcloud_pi_workspace_service_instance.resource.guid }}" # must be GUID, not CRN
     pi_volume_name: "{{ inventory_hostname + '-vol-' + vol_item.name | replace('_', '-')}}"
     pi_volume_type: "{{ vol_item.type }}"
     pi_volume_size: "{{ vol_item.size }}"
     pi_volume_shareable: false
     pi_replication_enabled: false
     #delete_on_termination: true
+    ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
   loop: "{{ storage_disks_map }}"
   loop_control:
     loop_var: vol_item
@@ -93,10 +100,12 @@
 
 # Use check to avoid idempotency issues with legacy ibm.cloudcollection Ansible Collection (until ibm.cloud Ansible Collection is out of beta)
 - name: Check status of IBM Power Infrastructure Block Storage volumes
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_provision_host_single_volumes_info
   ibm.cloudcollection.ibm_pi_volume_info:
-    pi_cloud_instance_id: "{{ register_ibmcloud_power_iaas_workspace_service_instance.resource.guid }}" # must be GUID, not CRN
+    pi_cloud_instance_id: "{{ __sap_vm_provision_task_ibmcloud_pi_workspace_service_instance.resource.guid }}" # must be GUID, not CRN
     pi_volume_name: "{{ inventory_hostname + '-vol-' + vol_item.name | replace('_', '-')}}"
+    ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
   loop: "{{ storage_disks_map }}"
   loop_control:
     loop_var: vol_item
@@ -109,11 +118,13 @@
   delay: 20
 
 - name: Attach IBM Power Infrastructure Block Storage volumes as filesystem for IBM Power VS instance
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_provision_host_single_volume_attachments
   ibm.cloudcollection.ibm_pi_volume_attach:
-    pi_cloud_instance_id: "{{ register_ibmcloud_power_iaas_workspace_service_instance.resource.guid }}" # must be GUID, not CRN
+    pi_cloud_instance_id: "{{ __sap_vm_provision_task_ibmcloud_pi_workspace_service_instance.resource.guid }}" # must be GUID, not CRN
     pi_volume_id: "{{ vol_item.resource.id }}"
     pi_instance_id: "{{ __sap_vm_provision_task_provision_host_single.resource.id }}"
+    ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
   loop: "{{ __sap_vm_provision_task_provision_host_single_volumes_info.results }}"
   loop_control:
     loop_var: vol_item
@@ -127,10 +138,12 @@
   delay: 10
 
 - name: Read IBM Power Virtual Server information
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_provision_host_single_info
   ibm.cloudcollection.ibm_pi_instance_info:
-    pi_cloud_instance_id: "{{ register_ibmcloud_power_iaas_workspace_service_instance.resource.guid }}" # must be GUID, not CRN
+    pi_cloud_instance_id: "{{ __sap_vm_provision_task_ibmcloud_pi_workspace_service_instance.resource.guid }}" # must be GUID, not CRN
     pi_instance_name: "{{ __sap_vm_provision_task_provision_host_single.resource.pi_instance_name }}"
+    ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
 
 - name: Add host facts
   ansible.builtin.set_fact:
@@ -182,7 +195,7 @@
         dest: /root/.ssh/authorized_keys
         mode: '0600'
         content: |
-          {{ register_ibmcloud_pi_ssh_public_key.resource.ssh_key }}
+          {{ __sap_vm_provision_task_ibmcloud_pi_ssh_public_key.resource.ssh_key }}
 
     - name: Permit root login
       register: __sap_vm_provision_task_os_sshd_config

--- a/roles/sap_vm_provision/tasks/platform_ansible/ibmcloud_powervs/execute_provision.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/ibmcloud_powervs/execute_provision.yml
@@ -39,8 +39,8 @@
 
 # Use check to avoid idempotency issues with legacy ibm.cloudcollection Ansible Collection (until ibm.cloud Ansible Collection is out of beta)
 - name: Check IBM Power Virtual Server instance on IBM Cloud
-  register: register_provisioned_host_single
-  ibm.cloudcollection.ibm_pi_instance_info:
+  register: __sap_vm_provision_task_provision_host_single
+  ibm.cloudcollection.ibm_pi___sap_vm_provision_task_provision_host_single_info:
     pi_cloud_instance_id: "{{ register_ibmcloud_power_iaas_workspace_service_instance.resource.guid }}" # must be GUID, not CRN
     pi_instance_name: "{{ inventory_hostname }}"
 
@@ -113,7 +113,7 @@
   ibm.cloudcollection.ibm_pi_volume_attach:
     pi_cloud_instance_id: "{{ register_ibmcloud_power_iaas_workspace_service_instance.resource.guid }}" # must be GUID, not CRN
     pi_volume_id: "{{ vol_item.resource.id }}"
-    pi_instance_id: "{{ register_provisioned_host_single.resource.id }}"
+    pi_instance_id: "{{ __sap_vm_provision_task_provision_host_single.resource.id }}"
   loop: "{{ register_volumes.results }}"
   loop_control:
     loop_var: vol_item
@@ -127,22 +127,22 @@
   delay: 10
 
 - name: Read IBM Power Virtual Server information
-  register: instance_info
-  ibm.cloudcollection.ibm_pi_instance_info:
+  register: __sap_vm_provision_task_provision_host_single_info
+  ibm.cloudcollection.ibm_pi___sap_vm_provision_task_provision_host_single_info:
     pi_cloud_instance_id: "{{ register_ibmcloud_power_iaas_workspace_service_instance.resource.guid }}" # must be GUID, not CRN
-    pi_instance_name: "{{ register_provisioned_host_single.resource.pi_instance_name }}"
+    pi_instance_name: "{{ __sap_vm_provision_task_provision_host_single.resource.pi_instance_name }}"
 
 - name: Add host facts
   ansible.builtin.set_fact:
-    volume_provisioning: "{{ register_volumes }}"
-    instance_info: "{{ instance_info }}"
+    __sap_vm_provision_task_provision_host_single_volumes: "{{ register_volumes }}"
+    __sap_vm_provision_task_provision_host_single_info: "{{ __sap_vm_provision_task_provision_host_single_info }}"
   delegate_to: "{{ inventory_hostname }}"
   delegate_facts: true
 
 
 - name: Create fact for delegate host IP
   ansible.builtin.set_fact:
-    provisioned_private_ip: "{{ register_provisioned_host_single.resource.addresses[0].ip }}"
+    provisioned_private_ip: "{{ __sap_vm_provision_task_provision_host_single.resource.addresses[0].ip }}"
 
 
 - name: Copy facts to delegate host
@@ -154,7 +154,7 @@
     delegate_sap_vm_provision_bastion_ssh_port: "{{ sap_vm_provision_bastion_ssh_port }}"
     delegate_sap_vm_provision_ssh_bastion_private_key_file_path: "{{ sap_vm_provision_ssh_bastion_private_key_file_path }}"
     delegate_sap_vm_provision_ssh_host_private_key_file_path: "{{ sap_vm_provision_ssh_host_private_key_file_path }}"
-    delegate_private_ip: "{{ register_provisioned_host_single.resource.addresses[0].ip }}"
+    delegate_private_ip: "{{ __sap_vm_provision_task_provision_host_single.resource.addresses[0].ip }}"
     delegate_hostname: "{{ inventory_hostname }}"
     delegate_sap_vm_provision_dns_root_domain_name: "{{ sap_vm_provision_dns_root_domain }}"
 
@@ -203,8 +203,8 @@
 
 - name: Append loop value to register
   ansible.builtin.set_fact:
-    register_provisioned_host_single: "{{ register_provisioned_host_single | combine( { 'host_node' : inventory_hostname } , { 'sap_host_type' : lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][scaleout_origin_host_spec | default(inventory_hostname)].sap_host_type } , { 'sap_system_type' : (lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][scaleout_origin_host_spec | default(inventory_hostname)].sap_system_type | default('')) } ) }}"
+    __sap_vm_provision_task_provision_host_single: "{{ __sap_vm_provision_task_provision_host_single | combine( { 'host_node' : inventory_hostname } , { 'sap_host_type' : lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][scaleout_origin_host_spec | default(inventory_hostname)].sap_host_type } , { 'sap_system_type' : (lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][scaleout_origin_host_spec | default(inventory_hostname)].sap_system_type | default('')) } ) }}"
 
 - name: Append output to merged register
   ansible.builtin.set_fact:
-    register_provisioned_host_all: "{{ register_provisioned_host_all + [register_provisioned_host_single] }}"
+    register_provisioned_host_all: "{{ register_provisioned_host_all + [__sap_vm_provision_task_provision_host_single] }}"

--- a/roles/sap_vm_provision/tasks/platform_ansible/ibmcloud_powervs/execute_provision.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/ibmcloud_powervs/execute_provision.yml
@@ -17,7 +17,7 @@
 
 # Status will change from Building > Warning (VM = Active, Health = Warning) > Active. The Ansible Task will continue once the Active status has been reached.
 - name: Provision IBM Power Virtual Server instance on IBM Cloud
-  register: register_provision_host_single
+  register: __sap_vm_provision_task_provision_host_single
   ibm.cloudcollection.ibm_pi_instance:
     pi_cloud_instance_id: "{{ register_ibmcloud_power_iaas_workspace_service_instance.resource.guid }}" # must be GUID, not CRN
 
@@ -71,7 +71,7 @@
 
 
 - name: Provision IBM Power Infrastructure Block Storage volumes for IBM Power VS instance filesystems
-  register: register_provisioned_volumes
+  register: __sap_vm_provision_task_provision_host_single_volumes
   ibm.cloudcollection.ibm_pi_volume:
     pi_cloud_instance_id: "{{ register_ibmcloud_power_iaas_workspace_service_instance.resource.guid }}" # must be GUID, not CRN
     pi_volume_name: "{{ inventory_hostname + '-vol-' + vol_item.name | replace('_', '-')}}"
@@ -88,12 +88,12 @@
   when:
     - vol_item.size > 0
   failed_when:
-    - not register_provisioned_volumes.rc == 0
-    - not 'already exists' in register_provisioned_volumes.stderr
+    - not __sap_vm_provision_task_provision_host_single_volumes.rc == 0
+    - not 'already exists' in __sap_vm_provision_task_provision_host_single_volumes.stderr
 
 # Use check to avoid idempotency issues with legacy ibm.cloudcollection Ansible Collection (until ibm.cloud Ansible Collection is out of beta)
 - name: Check status of IBM Power Infrastructure Block Storage volumes
-  register: register_volumes
+  register: __sap_vm_provision_task_provision_host_single_volumes_info
   ibm.cloudcollection.ibm_pi_volume_info:
     pi_cloud_instance_id: "{{ register_ibmcloud_power_iaas_workspace_service_instance.resource.guid }}" # must be GUID, not CRN
     pi_volume_name: "{{ inventory_hostname + '-vol-' + vol_item.name | replace('_', '-')}}"
@@ -105,25 +105,25 @@
   when:
     - vol_item.size > 0
   retries: 5
-  until: register_volumes.rc == 0 and (register_volumes.resource is defined and register_volumes.resource.state == "available", "in-use")
+  until: __sap_vm_provision_task_provision_host_single_volumes_info.rc == 0 and (__sap_vm_provision_task_provision_host_single_volumes_info.resource is defined and __sap_vm_provision_task_provision_host_single_volumes_info.resource.state == "available", "in-use")
   delay: 20
 
 - name: Attach IBM Power Infrastructure Block Storage volumes as filesystem for IBM Power VS instance
-  register: register_attached_volumes
+  register: __sap_vm_provision_task_provision_host_single_volume_attachments
   ibm.cloudcollection.ibm_pi_volume_attach:
     pi_cloud_instance_id: "{{ register_ibmcloud_power_iaas_workspace_service_instance.resource.guid }}" # must be GUID, not CRN
     pi_volume_id: "{{ vol_item.resource.id }}"
     pi_instance_id: "{{ __sap_vm_provision_task_provision_host_single.resource.id }}"
-  loop: "{{ register_volumes.results }}"
+  loop: "{{ __sap_vm_provision_task_provision_host_single_volumes_info.results }}"
   loop_control:
     loop_var: vol_item
     index_var: vol_item_index
     label: "{{ vol_item.resource.pi_volume_name }}"
   failed_when:
-    - not register_attached_volumes.rc == 0
-    - not 'volume cannot be attached in the current state' in register_attached_volumes.stderr # when already attached message
+    - not __sap_vm_provision_task_provision_host_single_volume_attachments.rc == 0
+    - not 'volume cannot be attached in the current state' in __sap_vm_provision_task_provision_host_single_volume_attachments.stderr # when already attached message
   retries: 1
-  until: register_attached_volumes is success
+  until: __sap_vm_provision_task_provision_host_single_volume_attachments is success
   delay: 10
 
 - name: Read IBM Power Virtual Server information
@@ -134,7 +134,7 @@
 
 - name: Add host facts
   ansible.builtin.set_fact:
-    __sap_vm_provision_task_provision_host_single_volumes: "{{ register_volumes }}"
+    __sap_vm_provision_task_provision_host_single_volumes: "{{ __sap_vm_provision_task_provision_host_single_volumes_info }}"
     __sap_vm_provision_task_provision_host_single_info: "{{ __sap_vm_provision_task_provision_host_single_info }}"
   delegate_to: "{{ inventory_hostname }}"
   delegate_facts: true
@@ -185,11 +185,11 @@
           {{ register_ibmcloud_pi_ssh_public_key.resource.ssh_key }}
 
     - name: Permit root login
+      register: __sap_vm_provision_task_os_sshd_config
       ansible.builtin.replace:
         path: /etc/ssh/sshd_config
         regexp: '(^PermitRootLogin no)'
         replace: 'PermitRootLogin yes'
-      register: sshd_config
 
     - name: Reload sshd service
       ansible.builtin.service:

--- a/roles/sap_vm_provision/tasks/platform_ansible/ibmcloud_powervs/execute_provision.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/ibmcloud_powervs/execute_provision.yml
@@ -40,7 +40,7 @@
 # Use check to avoid idempotency issues with legacy ibm.cloudcollection Ansible Collection (until ibm.cloud Ansible Collection is out of beta)
 - name: Check IBM Power Virtual Server instance on IBM Cloud
   register: __sap_vm_provision_task_provision_host_single
-  ibm.cloudcollection.ibm_pi___sap_vm_provision_task_provision_host_single_info:
+  ibm.cloudcollection.ibm_pi_instance_info:
     pi_cloud_instance_id: "{{ register_ibmcloud_power_iaas_workspace_service_instance.resource.guid }}" # must be GUID, not CRN
     pi_instance_name: "{{ inventory_hostname }}"
 
@@ -128,7 +128,7 @@
 
 - name: Read IBM Power Virtual Server information
   register: __sap_vm_provision_task_provision_host_single_info
-  ibm.cloudcollection.ibm_pi___sap_vm_provision_task_provision_host_single_info:
+  ibm.cloudcollection.ibm_pi_instance_info:
     pi_cloud_instance_id: "{{ register_ibmcloud_power_iaas_workspace_service_instance.resource.guid }}" # must be GUID, not CRN
     pi_instance_name: "{{ __sap_vm_provision_task_provision_host_single.resource.pi_instance_name }}"
 

--- a/roles/sap_vm_provision/tasks/platform_ansible/ibmcloud_vs/execute_main.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/ibmcloud_vs/execute_main.yml
@@ -10,7 +10,7 @@
   block:
 
     - name: Identify Resource Group info
-      no_log: true
+      no_log: "{{ __sap_vm_provision_no_log }}"
       register: __sap_vm_provision_task_ibmcloud_resource_group
       ibm.cloudcollection.ibm_resource_group_info:
         name: "{{ sap_vm_provision_ibmcloud_resource_group_name }}"
@@ -19,7 +19,7 @@
     # DNS may exist in separate Resource Group
     # Use empty string var (or default false if undefined) to evaluate to false boolean
     - name: Identify Resource Group info for Private DNS
-      no_log: true
+      no_log: "{{ __sap_vm_provision_no_log }}"
       register: __sap_vm_provision_task_ibmcloud_resource_group_dns
       ibm.cloudcollection.ibm_resource_group_info:
         name: "{{ sap_vm_provision_ibmcloud_private_dns_resource_group_name }}"
@@ -27,21 +27,21 @@
       when: (sap_vm_provision_ibmcloud_private_dns_resource_group_name | default(false))
 
     - name: Identify pre-loaded SSH Public Key info
-      no_log: true
+      no_log: "{{ __sap_vm_provision_no_log }}"
       register: __sap_vm_provision_task_ibmcloud_ssh_public_key
       ibm.cloudcollection.ibm_is_ssh_key_info:
         name: "{{ sap_vm_provision_ibmcloud_key_pair_name_ssh_host_public_key }}"
         ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
 
     - name: Identify VPC Subnet info
-      no_log: true
+      no_log: "{{ __sap_vm_provision_no_log }}"
       register: __sap_vm_provision_task_ibmcloud_vpc_subnet
       ibm.cloudcollection.ibm_is_subnet_info:
         name: "{{ sap_vm_provision_ibmcloud_vpc_subnet_name }}"
         ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
 
     - name: Identify VPC Security Group info
-      no_log: true
+      no_log: "{{ __sap_vm_provision_no_log }}"
       register: __sap_vm_provision_task_ibmcloud_vpc_sg
       ibm.cloudcollection.ibm_is_security_group_info:
         name: "{{ item }}"
@@ -49,7 +49,7 @@
       loop: "{{ sap_vm_provision_ibmcloud_vpc_sg_names | split(',') }}"
 
     - name: Identify Private DNS instance
-      no_log: true
+      no_log: "{{ __sap_vm_provision_no_log }}"
       register: __sap_vm_provision_task_ibmcloud_pdns_service_instance
       ibm.cloudcollection.ibm_resource_instance_info:
         resource_group_id: "{{ __sap_vm_provision_task_ibmcloud_resource_group.resource.id }}"
@@ -59,14 +59,14 @@
         ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
 
     - name: Identify Private DNS Zone info
-      no_log: true
+      no_log: "{{ __sap_vm_provision_no_log }}"
       register: __sap_vm_provision_task_ibmcloud_pdns
       ibm.cloudcollection.ibm_dns_zones_info:
         instance_id: "{{ __sap_vm_provision_task_ibmcloud_pdns_service_instance.resource.guid }}"
         ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
 
     - name: Identify OS Image list
-      no_log: true
+      no_log: "{{ __sap_vm_provision_no_log }}"
       register: __sap_vm_provision_task_ibmcloud_os_image_list
       ibm.cloudcollection.ibm_is_images_info:
         status: available
@@ -113,7 +113,7 @@
         file: common/set_ansible_vars.yml
 
     - name: IBM Cloud Private DNS Record for hosts
-      no_log: true
+      no_log: "{{ __sap_vm_provision_no_log }}"
       register: __sap_vm_provision_task_ibmcloud_pdns_record
       ibm.cloudcollection.ibm_dns_resource_record:
         instance_id: "{{ __sap_vm_provision_task_ibmcloud_pdns_service_instance.resource.guid }}"

--- a/roles/sap_vm_provision/tasks/platform_ansible/ibmcloud_vs/execute_main.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/ibmcloud_vs/execute_main.yml
@@ -145,11 +145,11 @@
         - __sap_vm_provision_task_ibmcloud_pdns
         - __sap_vm_provision_task_ibmcloud_os_image_list
         - __sap_vm_provision_task_provision_host_all_run
-        - __sap_vm_provision_task_provision_host_all_add
         - __sap_vm_provision_task_provision_host_single
         - __sap_vm_provision_task_provision_host_single_volumes
         - __sap_vm_provision_task_provision_host_single_volume_attachments
         - __sap_vm_provision_task_provision_host_single_info
+        - __sap_vm_provision_task_provision_host_all_add
         - __sap_vm_provision_task_ibmcloud_pdns_record
       loop_control:
         loop_var: loop_item

--- a/roles/sap_vm_provision/tasks/platform_ansible/ibmcloud_vs/execute_main.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/ibmcloud_vs/execute_main.yml
@@ -51,7 +51,7 @@
     - name: Identify Private DNS instance
       no_log: true
       register: __sap_vm_provision_task_ibmcloud_pdns_service_instance
-      ibm.cloudcollection.ibm_resource___sap_vm_provision_task_provision_host_single_info:
+      ibm.cloudcollection.ibm_resource_instance_info:
         resource_group_id: "{{ __sap_vm_provision_task_ibmcloud_resource_group.resource.id }}"
         location: global
         service: dns-svcs
@@ -148,7 +148,7 @@
         - __sap_vm_provision_task_provision_host_all_add
         - __sap_vm_provision_task_provision_host_single
         - __sap_vm_provision_task_provision_host_single_volumes
-        - __sap_vm_provision_task_provision_host_single___sap_vm_provision_task_provision_host_single_volume_attachments
+        - __sap_vm_provision_task_provision_host_single_volume_attachments
         - __sap_vm_provision_task_provision_host_single_info
         - __sap_vm_provision_task_ibmcloud_pdns_record
       loop_control:

--- a/roles/sap_vm_provision/tasks/platform_ansible/ibmcloud_vs/execute_main.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/ibmcloud_vs/execute_main.yml
@@ -108,7 +108,7 @@
         groups_merged_list: "{{ [ [ groups['hana_primary'] | default([]) ] , [ groups['hana_secondary'] | default([]) ] , [ groups['nwas_ascs'] | default([]) ] , [ groups['nwas_ers'] | default([]) ] , [ groups['nwas_pas'] | default([]) ] , [ groups['nwas_aas'] | default([]) ] ] | flatten | select() }}"
 
     - name: Set Ansible Vars
-      register: register_set_ansible_vars
+      register: __sap_vm_provision_task_ansible_vars_set
       ansible.builtin.include_tasks:
         file: common/set_ansible_vars.yml
 
@@ -178,19 +178,19 @@
         name: "{{ inventory_hostname_short }}"
 
     - name: Set /etc/hosts
-      register: register_etc_hosts_file
+      register: __sap_vm_provision_task_os_etc_hosts
       ansible.builtin.include_tasks:
         file: common/set_etc_hosts.yml
 
     - name: Set /etc/hosts for Scale-Out
-      register: register_etc_hosts_file_scaleout
+      register: __sap_vm_provision_task_os_etc_hosts_scaleout
       ansible.builtin.include_tasks:
         file: common/set_etc_hosts_scaleout.yml
       when:
         - (groups["hana_primary"] is defined and (groups["hana_primary"] | length>0)) and (sap_hana_scaleout_active_coordinator is defined or sap_hana_scaleout_active_worker is defined or sap_hana_scaleout_standby is defined)
 
     - name: Set vars for sap_storage_setup Ansible Role
-      register: register_ansible_vars_storage
+      register: __sap_vm_provision_task_ansible_vars_storage
       ansible.builtin.include_tasks:
         file: common/set_ansible_vars_storage.yml
 
@@ -323,6 +323,6 @@
   block:
 
     - name: Set /etc/hosts for HA
-      register: register_etc_hosts_file_ha
+      register: __sap_vm_provision_task_os_etc_hosts_ha
       ansible.builtin.include_tasks:
         file: common/set_etc_hosts_ha.yml

--- a/roles/sap_vm_provision/tasks/platform_ansible/ibmcloud_vs/execute_main.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/ibmcloud_vs/execute_main.yml
@@ -1,75 +1,92 @@
 ---
 
 - name: Ansible Task block for looped provisioning of IBM Cloud Virtual Servers
+  any_errors_fatal: true
+  # Using environment, no_log is ineffective and log will show 'EXEC /bin/sh -c 'ENV_VAR=value python3 /AnsiballZ_ansible_module_name.py && sleep 0'
+  # Therefore do not use environment for secrets, use only for non-sensitive values as this will reduce Ansible Task parameters.
   environment:
-    IC_API_KEY: "{{ sap_vm_provision_ibmcloud_api_key }}"
+    # IC_API_KEY: "{{ sap_vm_provision_ibmcloud_api_key }}"
     IC_REGION: "{{ sap_vm_provision_ibmcloud_region }}"
   block:
 
     - name: Identify Resource Group info
-      register: register_ibmcloud_resource_group
+      no_log: true
+      register: __sap_vm_provision_task_ibmcloud_resource_group
       ibm.cloudcollection.ibm_resource_group_info:
         name: "{{ sap_vm_provision_ibmcloud_resource_group_name }}"
+        ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
 
     # DNS may exist in separate Resource Group
     # Use empty string var (or default false if undefined) to evaluate to false boolean
     - name: Identify Resource Group info for Private DNS
-      register: register_ibmcloud_resource_group_dns
+      no_log: true
+      register: __sap_vm_provision_task_ibmcloud_resource_group_dns
       ibm.cloudcollection.ibm_resource_group_info:
         name: "{{ sap_vm_provision_ibmcloud_private_dns_resource_group_name }}"
+        ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
       when: (sap_vm_provision_ibmcloud_private_dns_resource_group_name | default(false))
 
     - name: Identify pre-loaded SSH Public Key info
-      register: register_ibmcloud_ssh_public_key
+      no_log: true
+      register: __sap_vm_provision_task_ibmcloud_ssh_public_key
       ibm.cloudcollection.ibm_is_ssh_key_info:
         name: "{{ sap_vm_provision_ibmcloud_key_pair_name_ssh_host_public_key }}"
+        ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
 
     - name: Identify VPC Subnet info
-      register: register_ibmcloud_vpc_subnet
+      no_log: true
+      register: __sap_vm_provision_task_ibmcloud_vpc_subnet
       ibm.cloudcollection.ibm_is_subnet_info:
         name: "{{ sap_vm_provision_ibmcloud_vpc_subnet_name }}"
+        ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
 
     - name: Identify VPC Security Group info
-      register: register_ibmcloud_vpc_sg
+      no_log: true
+      register: __sap_vm_provision_task_ibmcloud_vpc_sg
       ibm.cloudcollection.ibm_is_security_group_info:
         name: "{{ item }}"
+        ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
       loop: "{{ sap_vm_provision_ibmcloud_vpc_sg_names | split(',') }}"
 
-    # DNS may exist in separate Resource Group
-    # If previous identification task is skipped, use resource group else use the resource group defined for the Private DNS
     - name: Identify Private DNS instance
-      register: register_ibmcloud_pdns_service_instance
-      ibm.cloudcollection.ibm_resource_instance_info:
-        resource_group_id: "{{ register_ibmcloud_resource_group.resource.id if register_ibmcloud_resource_group_dns is skipped else register_ibmcloud_resource_group_dns.resource.id }}"
+      no_log: true
+      register: __sap_vm_provision_task_ibmcloud_pdns_service_instance
+      ibm.cloudcollection.ibm_resource___sap_vm_provision_task_provision_host_single_info:
+        resource_group_id: "{{ __sap_vm_provision_task_ibmcloud_resource_group.resource.id }}"
         location: global
         service: dns-svcs
         name: "{{ sap_vm_provision_ibmcloud_private_dns_instance_name }}"
+        ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
 
     - name: Identify Private DNS Zone info
-      register: register_ibmcloud_pdns
+      no_log: true
+      register: __sap_vm_provision_task_ibmcloud_pdns
       ibm.cloudcollection.ibm_dns_zones_info:
-        instance_id: "{{ register_ibmcloud_pdns_service_instance.resource.guid }}"
+        instance_id: "{{ __sap_vm_provision_task_ibmcloud_pdns_service_instance.resource.guid }}"
+        ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
 
     - name: Identify OS Image list
-      register: register_ibmcloud_os_image_list
+      no_log: true
+      register: __sap_vm_provision_task_ibmcloud_os_image_list
       ibm.cloudcollection.ibm_is_images_info:
         status: available
+        ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
 
     - name: Set fact to hold loop variables from include_tasks
       ansible.builtin.set_fact:
         register_provisioned_host_all: []
 
     - name: Provision hosts to IBM Cloud
-      register: register_provisioned_hosts
+      register: __sap_vm_provision_task_provision_host_all_run
       ansible.builtin.include_tasks:
         file: "{{ 'platform_' + sap_vm_provision_iac_type }}/{{ sap_vm_provision_iac_platform }}/execute_provision.yml"
         apply:
           environment:
-            IC_API_KEY: "{{ sap_vm_provision_ibmcloud_api_key }}"
+            # IC_API_KEY: "{{ sap_vm_provision_ibmcloud_api_key }}"
             IC_REGION: "{{ sap_vm_provision_ibmcloud_region }}"
 
     - name: Add hosts provisioned to the Ansible Inventory
-      register: register_add_hosts
+      register: __sap_vm_provision_task_provision_host_all_add
       ansible.builtin.add_host:
         name: "{{ add_item[0].host_node }}"
         groups: "{{ add_item[0].sap_system_type + '_' if (add_item[0].sap_system_type != '') }}{{ add_item[0].sap_host_type }}"
@@ -96,18 +113,53 @@
         file: common/set_ansible_vars.yml
 
     - name: IBM Cloud Private DNS Record for hosts
-      register: register_ibmcloud_pdns_record
+      no_log: true
+      register: __sap_vm_provision_task_ibmcloud_pdns_record
       ibm.cloudcollection.ibm_dns_resource_record:
-        instance_id: "{{ register_ibmcloud_pdns_service_instance.resource.guid }}"
-        zone_id: "{{ (register_ibmcloud_pdns.resource.dns_zones | selectattr('name', '==', sap_vm_provision_dns_root_domain) | first).zone_id }}"
+        instance_id: "{{ __sap_vm_provision_task_ibmcloud_pdns_service_instance.resource.guid }}"
+        zone_id: "{{ (__sap_vm_provision_task_ibmcloud_pdns.resource.dns_zones | selectattr('name', '==', sap_vm_provision_dns_root_domain) | first).zone_id }}"
         name: "{{ inventory_hostname }}.{{ hostvars[inventory_hostname].sap_vm_provision_dns_root_domain }}" # Host FQDN
         rdata: "{{ hostvars[inventory_hostname].ansible_host }}" # IP Address
         type: A
         ttl: 7200
-      failed_when: not register_ibmcloud_pdns_record.rc == 0 and not 'The record already exists' in register_ibmcloud_pdns_record.stderr
+        ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
+      failed_when: not __sap_vm_provision_task_ibmcloud_pdns_record.rc == 0 and not 'The record already exists' in __sap_vm_provision_task_ibmcloud_pdns_record.stderr
 
   #  - ansible.builtin.debug:
-  #      var: register_add_hosts.results
+  #      var: __sap_vm_provision_task_provision_host_all_add.results
+
+  rescue:
+    # This requires no_log set on each Ansible Task, and not set on the Ansible Task Block
+    # This requires an Ansible Task Block containing the Ansible Tasks for calling
+    # Infrastructure Platform APIs (via Ansible Modules)
+    - name: Show errors in task outputs
+      ansible.builtin.fail:
+        msg: "{{ lookup('ansible.builtin.vars', loop_item) }}"
+      loop:
+        - __sap_vm_provision_task_ibmcloud_resource_group
+        - __sap_vm_provision_task_ibmcloud_resource_group_dns
+        - __sap_vm_provision_task_ibmcloud_ssh_public_key
+        - __sap_vm_provision_task_ibmcloud_vpc_subnet
+        - __sap_vm_provision_task_ibmcloud_vpc_sg
+        - __sap_vm_provision_task_ibmcloud_pdns_service_instance
+        - __sap_vm_provision_task_ibmcloud_pdns
+        - __sap_vm_provision_task_ibmcloud_os_image_list
+        - __sap_vm_provision_task_provision_host_all_run
+        - __sap_vm_provision_task_provision_host_all_add
+        - __sap_vm_provision_task_provision_host_single
+        - __sap_vm_provision_task_provision_host_single_volumes
+        - __sap_vm_provision_task_provision_host_single___sap_vm_provision_task_provision_host_single_volume_attachments
+        - __sap_vm_provision_task_provision_host_single_info
+        - __sap_vm_provision_task_ibmcloud_pdns_record
+      loop_control:
+        loop_var: loop_item
+        index_var: loop_item_index
+        label: "{{ 'Variable No. ' + (loop_item_index | string) }}"
+      when:
+        - lookup('ansible.builtin.vars', loop_item, default='') | length > 0
+        - not lookup('ansible.builtin.vars', loop_item, default='') is skipped
+        - lookup('ansible.builtin.vars', loop_item, default='') is failed
+
 
 - name: Ansible Task block to execute on target inventory hosts
   delegate_to: "{{ inventory_hostname }}"
@@ -153,10 +205,13 @@
 
 - name: Ansible Task block for looped provisioning of High Availability resources for IBM Cloud VS instances
   delegate_to: localhost
+  any_errors_fatal: true
   run_once: true
+  # Using environment, no_log is ineffective and log will show 'EXEC /bin/sh -c 'ENV_VAR=value python3 /AnsiballZ_ansible_module_name.py && sleep 0'
+  # Therefore do not use environment for secrets, use only for non-sensitive values as this will reduce Ansible Task parameters.
   environment:
-    IC_API_KEY: "{{ sap_vm_provision_ibmcloud_api_key }}" # For legacy Ansible Collection
-    IBMCLOUD_API_KEY: "{{ sap_vm_provision_ibmcloud_api_key }}" # For IBM Cloud CLI quiet login
+    # IC_API_KEY: "{{ sap_vm_provision_ibmcloud_api_key }}" # For legacy Ansible Collection
+    # IBMCLOUD_API_KEY: "{{ sap_vm_provision_ibmcloud_api_key }}" # For IBM Cloud CLI quiet login
     IC_REGION: "{{ sap_vm_provision_ibmcloud_region }}"
   when:
     - sap_ha_pacemaker_cluster_ibmcloud_region is defined
@@ -168,9 +223,96 @@
         file: "{{ 'platform_' + sap_vm_provision_iac_type }}/{{ sap_vm_provision_iac_platform }}/execute_setup_ha.yml"
         apply:
           environment:
-            IC_API_KEY: "{{ sap_vm_provision_ibmcloud_api_key }}" # For legacy Ansible Collection
-            IBMCLOUD_API_KEY: "{{ sap_vm_provision_ibmcloud_api_key }}" # For IBM Cloud CLI quiet login
+            # IC_API_KEY: "{{ sap_vm_provision_ibmcloud_api_key }}" # For legacy Ansible Collection
+            # IBMCLOUD_API_KEY: "{{ sap_vm_provision_ibmcloud_api_key }}" # For IBM Cloud CLI quiet login
             IC_REGION: "{{ sap_vm_provision_ibmcloud_region }}"
+
+  rescue:
+    # This requires no_log set on each Ansible Task, and not set on the Ansible Task Block
+    # This requires an Ansible Task Block containing the Ansible Tasks for calling
+    # Infrastructure Platform APIs (via Ansible Modules)
+    - name: Show errors in task outputs
+      ansible.builtin.fail:
+        msg: "{{ lookup('ansible.builtin.vars', loop_item) }}"
+      loop:
+        - __sap_vm_provision_task_ibmcloud_iam_auth_policy
+        - __sap_vm_provision_task_ibmcloud_lb_provision_parallel
+        - __sap_vm_provision_task_ibmcloud_lb_provision_parallel_async_status
+        - __sap_vm_provision_task_ibmcloud_lb_update_dns
+        - __sap_vm_provision_task_ibmcloud_vs_all_info
+        - __sap_vm_provision_task_ibmcloud_lb_all_info_shell
+        - __sap_vm_provision_task_ibmcloud_lb_pool_hana1
+        - __sap_vm_provision_task_ibmcloud_lb_pool_hana2
+        - __sap_vm_provision_task_ibmcloud_lb_pool_hana3
+        - __sap_vm_provision_task_ibmcloud_lb_pool_hana4
+        - __sap_vm_provision_task_ibmcloud_lb_pool_nwas_ascs1
+        - __sap_vm_provision_task_ibmcloud_lb_pool_nwas_ascs2
+        - __sap_vm_provision_task_ibmcloud_lb_pool_nwas_ascs3
+        - __sap_vm_provision_task_ibmcloud_lb_pool_nwas_ascs4
+        - __sap_vm_provision_task_ibmcloud_lb_pool_nwas_ascs5
+        - __sap_vm_provision_task_ibmcloud_lb_pool_nwas_ers1
+        - __sap_vm_provision_task_ibmcloud_lb_pool_nwas_ers2
+        - __sap_vm_provision_task_ibmcloud_lb_pool_nwas_ers3
+        - __sap_vm_provision_task_ibmcloud_lb_pool_nwas_ers4
+        - __sap_vm_provision_task_ibmcloud_lb_pool_nwas_ers5
+        - __sap_vm_provision_task_ibmcloud_lb_pools
+        - __sap_vm_provision_task_ibmcloud_lb_pool_members_hana1
+        - __sap_vm_provision_task_ibmcloud_lb_pool_members_hana2
+        - __sap_vm_provision_task_ibmcloud_lb_pool_members_hana3
+        - __sap_vm_provision_task_ibmcloud_lb_pool_members_hana4
+        - __sap_vm_provision_task_ibmcloud_lb_pool_members_hana5
+        - __sap_vm_provision_task_ibmcloud_lb_pool_members_hana6
+        - __sap_vm_provision_task_ibmcloud_lb_pool_members_hana7
+        - __sap_vm_provision_task_ibmcloud_lb_pool_members_hana8
+        - __sap_vm_provision_task_ibmcloud_lb_pool_members_anydb1
+        - __sap_vm_provision_task_ibmcloud_lb_pool_members_anydb2
+        - __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ascs1
+        - __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ascs2
+        - __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ascs3
+        - __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ascs4
+        - __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ascs5
+        - __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ascs6
+        - __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ascs7
+        - __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ascs8
+        - __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ascs9
+        - __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ascs10
+        - __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ers1
+        - __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ers2
+        - __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ers3
+        - __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ers4
+        - __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ers5
+        - __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ers6
+        - __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ers7
+        - __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ers8
+        - __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ers9
+        - __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ers10
+        - __sap_vm_provision_task_ibmcloud_lb_frontend_listener_hana1
+        - __sap_vm_provision_task_ibmcloud_lb_frontend_listener_hana2
+        - __sap_vm_provision_task_ibmcloud_lb_frontend_listener_hana3
+        - __sap_vm_provision_task_ibmcloud_lb_frontend_listener_hana4
+        - __sap_vm_provision_task_ibmcloud_lb_frontend_listener_anydb1
+        - __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ascs1
+        - __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ascs2
+        - __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ascs3
+        - __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ascs4
+        - __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ascs5
+        - __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ers1
+        - __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ers2
+        - __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ers3
+        - __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ers4
+        - __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ers5
+        - __sap_vm_provision_task_ibmcloud_pdns_record_ha_hana
+        - __sap_vm_provision_task_ibmcloud_pdns_record_ha_anydb
+        - __sap_vm_provision_task_ibmcloud_pdns_record_ha_nwas_ascs
+        - __sap_vm_provision_task_ibmcloud_pdns_record_ha_nwas_ers
+      loop_control:
+        loop_var: loop_item
+        index_var: loop_item_index
+        label: "{{ 'Variable No. ' + (loop_item_index | string) }}"
+      when:
+        - lookup('ansible.builtin.vars', loop_item, default='') | length > 0
+        - not lookup('ansible.builtin.vars', loop_item, default='') is skipped
+        - lookup('ansible.builtin.vars', loop_item, default='') is failed
 
 
 - name: Ansible Task block to execute on target inventory hosts for HA

--- a/roles/sap_vm_provision/tasks/platform_ansible/ibmcloud_vs/execute_provision.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/ibmcloud_vs/execute_provision.yml
@@ -15,7 +15,7 @@
     - not inventory_hostname in lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan].keys()
 
 - name: Provision IBM Cloud Virtual Server instance
-  no_log: true
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_provision_host_single
   ibm.cloudcollection.ibm_is_instance:
     state: available
@@ -75,7 +75,7 @@
       {{ disks_map }}
 
 - name: Provision IBM Cloud Block Storage volumes for IBM Cloud VS instance filesystems
-  no_log: true
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_provision_host_single_volumes
   ibm.cloudcollection.ibm_is_volume:
     resource_group: "{{ __sap_vm_provision_task_ibmcloud_resource_group.resource.id }}"
@@ -93,7 +93,7 @@
     - vol_item.size > 0
 
 - name: Attach IBM Cloud Block Storage volumes as filesystem for IBM Cloud VS instance
-  no_log: true
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_provision_host_single_volume_attachments
   ibm.cloudcollection.ibm_is_instance_volume_attachment:
     name: "{{ vol_item.resource.name }}-attach"
@@ -110,7 +110,7 @@
 
 
 - name: Read IBM Cloud VS information
-  no_log: true
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_provision_host_single_info
   ibm.cloudcollection.ibm_is_instance:
     name: "{{ __sap_vm_provision_task_provision_host_single.resource.name }}"

--- a/roles/sap_vm_provision/tasks/platform_ansible/ibmcloud_vs/execute_provision.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/ibmcloud_vs/execute_provision.yml
@@ -15,26 +15,27 @@
     - not inventory_hostname in lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan].keys()
 
 - name: Provision IBM Cloud Virtual Server instance
-  register: register_provisioned_host_single
+  no_log: true
+  register: __sap_vm_provision_task_provision_host_single
   ibm.cloudcollection.ibm_is_instance:
     state: available
     name: "{{ inventory_hostname }}"
-    image: "{{ (register_ibmcloud_os_image_list.resource.images | select('search', lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_os_image_dictionary')[sap_vm_provision_ibmcloud_vs_host_os_image]) | sort(reverse=True,case_sensitive=False,attribute='name') | first).id }}"
+    image: "{{ (__sap_vm_provision_task_ibmcloud_os_image_list.resource.images | select('search', lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_os_image_dictionary')[sap_vm_provision_ibmcloud_vs_host_os_image]) | sort(reverse=True,case_sensitive=False,attribute='name') | first).id }}"
     profile: "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][scaleout_origin_host_spec | default(inventory_hostname)].virtual_machine_profile }}"
     keys:
-      - "{{ register_ibmcloud_ssh_public_key.resource.id }}"
+      - "{{ __sap_vm_provision_task_ibmcloud_ssh_public_key.resource.id }}"
 
-    resource_group: "{{ register_ibmcloud_resource_group.resource.id }}"
+    resource_group: "{{ __sap_vm_provision_task_ibmcloud_resource_group.resource.id }}"
     zone: "{{ sap_vm_provision_ibmcloud_availability_zone }}"
-    vpc: "{{ register_ibmcloud_vpc_subnet.resource.vpc }}"
+    vpc: "{{ __sap_vm_provision_task_ibmcloud_vpc_subnet.resource.vpc }}"
 
     # The Subnet assigned to the primary Virtual Network Interface (vNIC) cannot be changed
     # The Name and Security Group assigned to the Primary Network Interface (vNIC) are editable
     primary_network_interface:
       - name: "{{ inventory_hostname }}-vnic0"
-        subnet: "{{ register_ibmcloud_vpc_subnet.resource.id }}"
+        subnet: "{{ __sap_vm_provision_task_ibmcloud_vpc_subnet.resource.id }}"
         allow_ip_spoofing: "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][scaleout_origin_host_spec | default(inventory_hostname)].disable_ip_anti_spoofing }}" # When disable the Anti IP Spoofing = true, then Allow IP Spoofing = true
-        security_groups: "{{ register_ibmcloud_vpc_sg.results | map(attribute='resource.id') }}"
+        security_groups: "{{ __sap_vm_provision_task_ibmcloud_vpc_sg.results | map(attribute='resource.id') }}"
     #network_interfaces:
 
     auto_delete_volume: true
@@ -45,6 +46,8 @@
       - enabled: true
         protocol: https
         response_hop_limit: 5
+
+    ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
 
 
 # Create flat list with names for each volume to be created.
@@ -72,12 +75,15 @@
       {{ disks_map }}
 
 - name: Provision IBM Cloud Block Storage volumes for IBM Cloud VS instance filesystems
+  no_log: true
+  register: __sap_vm_provision_task_provision_host_single_volumes
   ibm.cloudcollection.ibm_is_volume:
-    resource_group: "{{ register_ibmcloud_resource_group.resource.id }}"
+    resource_group: "{{ __sap_vm_provision_task_ibmcloud_resource_group.resource.id }}"
     zone: "{{ sap_vm_provision_ibmcloud_availability_zone }}"
     name: "{{ inventory_hostname + '-vol-' + vol_item.name | replace('_', '-')}}"
     profile: "{{ vol_item.type }}"
     capacity: "{{ vol_item.size }}"
+    ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
   loop: "{{ storage_disks_map }}"
   loop_control:
     loop_var: vol_item
@@ -85,16 +91,18 @@
     label: "{{ vol_item.definition_key }}: {{ vol_item.name }} (size: {{ vol_item.size }})"
   when:
     - vol_item.size > 0
-  register: volume_provisioning
 
 - name: Attach IBM Cloud Block Storage volumes as filesystem for IBM Cloud VS instance
+  no_log: true
+  register: __sap_vm_provision_task_provision_host_single___sap_vm_provision_task_provision_host_single_volume_attachments
   ibm.cloudcollection.ibm_is_instance_volume_attachment:
     name: "{{ vol_item.resource.name }}-attach"
     volume: "{{ vol_item.resource.id }}"
-    instance: "{{ register_provisioned_host_single.resource.id }}"
+    instance: "{{ __sap_vm_provision_task_provision_host_single.resource.id }}"
     delete_volume_on_attachment_delete: true
     delete_volume_on_instance_delete: true
-  loop: "{{ volume_provisioning.results }}"
+    ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
+  loop: "{{ __sap_vm_provision_task_provision_host_single_volumes.results }}"
   loop_control:
     loop_var: vol_item
     index_var: vol_item_index
@@ -102,21 +110,23 @@
 
 
 - name: Read IBM Cloud VS information
+  no_log: true
+  register: __sap_vm_provision_task_provision_host_single_info
   ibm.cloudcollection.ibm_is_instance:
-    name: "{{ register_provisioned_host_single.resource.name }}"
-  register: instance_info
+    name: "{{ __sap_vm_provision_task_provision_host_single.resource.name }}"
+    ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
 
 - name: Add host facts
   ansible.builtin.set_fact:
-    volume_provisioning: "{{ volume_provisioning }}"
-    instance_info: "{{ instance_info }}"
+    __sap_vm_provision_task_provision_host_single_volumes: "{{ __sap_vm_provision_task_provision_host_single_volumes }}"
+    __sap_vm_provision_task_provision_host_single_info: "{{ __sap_vm_provision_task_provision_host_single_info }}"
   delegate_to: "{{ inventory_hostname }}"
   delegate_facts: true
 
 
 - name: Create fact for delegate host IP
   ansible.builtin.set_fact:
-    provisioned_private_ip: "{{ register_provisioned_host_single.resource.primary_network_interface[0].primary_ipv4_address }}"
+    provisioned_private_ip: "{{ __sap_vm_provision_task_provision_host_single.resource.primary_network_interface[0].primary_ipv4_address }}"
 
 
 - name: Copy facts to delegate host
@@ -128,7 +138,7 @@
     delegate_sap_vm_provision_bastion_ssh_port: "{{ sap_vm_provision_bastion_ssh_port }}"
     delegate_sap_vm_provision_ssh_bastion_private_key_file_path: "{{ sap_vm_provision_ssh_bastion_private_key_file_path }}"
     delegate_sap_vm_provision_ssh_host_private_key_file_path: "{{ sap_vm_provision_ssh_host_private_key_file_path }}"
-    delegate_private_ip: "{{ register_provisioned_host_single.resource.primary_network_interface[0].primary_ipv4_address }}"
+    delegate_private_ip: "{{ __sap_vm_provision_task_provision_host_single.resource.primary_network_interface[0].primary_ipv4_address }}"
     delegate_hostname: "{{ inventory_hostname }}"
     delegate_sap_vm_provision_dns_root_domain_name: "{{ sap_vm_provision_dns_root_domain }}"
 
@@ -156,14 +166,14 @@
         dest: /root/.ssh/authorized_keys
         mode: '0600'
         content: |
-          {{ register_ibmcloud_ssh_public_key.resource.public_key }}
+          {{ __sap_vm_provision_task_ibmcloud_ssh_public_key.resource.public_key }}
 
     - name: Permit root login
+      register: sshd_config
       ansible.builtin.replace:
         path: /etc/ssh/sshd_config
         regexp: '(^PermitRootLogin no)'
         replace: 'PermitRootLogin yes'
-      register: sshd_config
 
     - name: Reload sshd service
       ansible.builtin.service:
@@ -177,8 +187,8 @@
 
 - name: Append loop value to register
   ansible.builtin.set_fact:
-    register_provisioned_host_single: "{{ register_provisioned_host_single | combine( { 'host_node' : inventory_hostname } , { 'sap_host_type' : lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][scaleout_origin_host_spec | default(inventory_hostname)].sap_host_type } , { 'sap_system_type' : (lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][scaleout_origin_host_spec | default(inventory_hostname)].sap_system_type | default('')) } ) }}"
+    __sap_vm_provision_task_provision_host_single: "{{ __sap_vm_provision_task_provision_host_single | combine( { 'host_node' : inventory_hostname } , { 'sap_host_type' : lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][scaleout_origin_host_spec | default(inventory_hostname)].sap_host_type } , { 'sap_system_type' : (lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][scaleout_origin_host_spec | default(inventory_hostname)].sap_system_type | default('')) } ) }}"
 
 - name: Append output to merged register
   ansible.builtin.set_fact:
-    register_provisioned_host_all: "{{ register_provisioned_host_all + [register_provisioned_host_single] }}"
+    register_provisioned_host_all: "{{ register_provisioned_host_all + [__sap_vm_provision_task_provision_host_single] }}"

--- a/roles/sap_vm_provision/tasks/platform_ansible/ibmcloud_vs/execute_provision.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/ibmcloud_vs/execute_provision.yml
@@ -94,7 +94,7 @@
 
 - name: Attach IBM Cloud Block Storage volumes as filesystem for IBM Cloud VS instance
   no_log: true
-  register: __sap_vm_provision_task_provision_host_single___sap_vm_provision_task_provision_host_single_volume_attachments
+  register: __sap_vm_provision_task_provision_host_single_volume_attachments
   ibm.cloudcollection.ibm_is_instance_volume_attachment:
     name: "{{ vol_item.resource.name }}-attach"
     volume: "{{ vol_item.resource.id }}"

--- a/roles/sap_vm_provision/tasks/platform_ansible/ibmcloud_vs/execute_provision.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/ibmcloud_vs/execute_provision.yml
@@ -169,7 +169,7 @@
           {{ __sap_vm_provision_task_ibmcloud_ssh_public_key.resource.public_key }}
 
     - name: Permit root login
-      register: sshd_config
+      register: __sap_vm_provision_task_os_sshd_config
       ansible.builtin.replace:
         path: /etc/ssh/sshd_config
         regexp: '(^PermitRootLogin no)'

--- a/roles/sap_vm_provision/tasks/platform_ansible/ibmcloud_vs/execute_setup_ha.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/ibmcloud_vs/execute_setup_ha.yml
@@ -1,6 +1,7 @@
 ---
 
 - name: Create IBM Cloud IAM Authorization Policy for IBM Cloud Load Balancer to communicate with IBM Cloud Private DNS
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_ibmcloud_iam_auth_policy
   ibm.cloudcollection.ibm_iam_authorization_policy:
     roles: Manager
@@ -26,6 +27,7 @@
 # Private Network Load Balancer (Layer 4), restricts HA within single Availability Zone. Permits TCP and UDP, does not permit HTTP/S.
 # Use async with poll '0' to create all IBM Cloud Load Balancers in parallel
 - name: Create IBM Cloud Load Balancer (Private ALB) for each Virtual Hostname / Virtual IP required
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_ibmcloud_lb_provision_parallel
   ibm.cloudcollection.ibm_is_lb:
     resource_group: "{{ __sap_vm_provision_task_ibmcloud_resource_group.resource.id }}"
@@ -64,7 +66,7 @@
 
 # Workaround to missing Ansible Module functionality in legacy Ansible Collection
 - name: IBM Cloud CLI append DNS to Load Balancer
-  no_log: true
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_ibmcloud_lb_update_dns
   ansible.builtin.shell: |
     ibmcloud config --quiet --check-version false && ibmcloud login --apikey="{{ sap_vm_provision_ibmcloud_api_key }}" -g {{ sap_vm_provision_ibmcloud_resource_group_name }} -r {{ sap_vm_provision_ibmcloud_region }} --quiet
@@ -79,6 +81,7 @@
   failed_when: not __sap_vm_provision_task_ibmcloud_lb_update_dns.rc == 0 and not 'nothing to update the load balancer with' in __sap_vm_provision_task_ibmcloud_lb_update_dns.stderr
 
 - name: Identify IBM Cloud Virtual Servers info
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_ibmcloud_vs_all_info
   ibm.cloudcollection.ibm_is_instances_info:
     vpc: "{{ __sap_vm_provision_task_ibmcloud_vpc_subnet.resource.vpc }}"
@@ -87,7 +90,7 @@
 
 # Workaround for bug which populates region and ibmcloud_api_key as TF arguments for ibm_is_lbs_info Ansible Module in legacy Ansible Collection
 - name: IBM Cloud CLI execution to list Load Balancer/s info
-  no_log: true
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_ibmcloud_lb_all_info_shell
   ansible.builtin.shell: |
     ibmcloud config --quiet --check-version false && ibmcloud login --apikey="{{ sap_vm_provision_ibmcloud_api_key }}" -g {{ sap_vm_provision_ibmcloud_resource_group_name }} -r {{ sap_vm_provision_ibmcloud_region }} --quiet
@@ -108,6 +111,7 @@
 # Create IBM Cloud Load Balancer Back-end Pools
 
 - name: Create IBM Cloud Load Balancer Back-end Pool for SAP HANA - System DB SQL
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_ibmcloud_lb_pool_hana1
   ibm.cloudcollection.ibm_is_lb_pool:
     name: lb-sap-ha-hana-pool-sysdb-sql
@@ -123,6 +127,7 @@
   when: (groups['hana_secondary'] is defined and (groups['hana_secondary'] | length>0))
 
 - name: Create IBM Cloud Load Balancer Back-end Pool for SAP HANA - MDC Tenant 1 SQL
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_ibmcloud_lb_pool_hana2
   ibm.cloudcollection.ibm_is_lb_pool:
     name: lb-sap-ha-hana-pool-mdc1-sql
@@ -138,6 +143,7 @@
   when: (groups['hana_secondary'] is defined and (groups['hana_secondary'] | length>0))
 
 - name: Create IBM Cloud Load Balancer Back-end Pool for SAP HANA - startsrv HTTP
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_ibmcloud_lb_pool_hana3
   ibm.cloudcollection.ibm_is_lb_pool:
     name: lb-sap-ha-hana-pool-startsrv-http
@@ -153,6 +159,7 @@
   when: (groups['hana_secondary'] is defined and (groups['hana_secondary'] | length>0))
 
 - name: Create IBM Cloud Load Balancer Back-end Pool for SAP HANA - startsrv HTTPS
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_ibmcloud_lb_pool_hana4
   ibm.cloudcollection.ibm_is_lb_pool:
     name: lb-sap-ha-hana-pool-startsrv-https
@@ -168,6 +175,7 @@
   when: (groups['hana_secondary'] is defined and (groups['hana_secondary'] | length>0))
 
 - name: Create IBM Cloud Load Balancer Back-end Pool for SAP AnyDB - IBM Db2 Communication Port
+  no_log: "{{ __sap_vm_provision_no_log }}"
   ibm.cloudcollection.ibm_is_lb_pool:
     name: lb-sap-ha-anydb-pool-ibmdb2
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-anydb'))[0].id }}"
@@ -182,6 +190,7 @@
   when: (groups['anydb_secondary'] is defined and (groups['anydb_secondary'] | length>0))
 
 - name: Create IBM Cloud Load Balancer Back-end Pool for SAP NetWeaver ASCS - Dispatcher sapdp<ASCS_NN> process
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_ibmcloud_lb_pool_nwas_ascs1
   ibm.cloudcollection.ibm_is_lb_pool:
     name: lb-sap-ha-nwas-ascs-pool-dp
@@ -197,6 +206,7 @@
   when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
 
 - name: Create IBM Cloud Load Balancer Back-end Pool for SAP NetWeaver ASCS - Message Server sapms<SAPSID> process
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_ibmcloud_lb_pool_nwas_ascs2
   ibm.cloudcollection.ibm_is_lb_pool:
     name: lb-sap-ha-nwas-ascs-pool-ms
@@ -212,6 +222,7 @@
   when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
 
 - name: Create IBM Cloud Load Balancer Back-end Pool for SAP NetWeaver ASCS - Enqueue Server sapenq<SAPSID> process
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_ibmcloud_lb_pool_nwas_ascs3
   ibm.cloudcollection.ibm_is_lb_pool:
     name: lb-sap-ha-nwas-ascs-pool-enq
@@ -227,6 +238,7 @@
   when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
 
 - name: Create IBM Cloud Load Balancer Back-end Pool for SAP NetWeaver ASCS - SAP Start Service (SAPControl SOAP) HTTP sapctrl<ASCS_NN> process
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_ibmcloud_lb_pool_nwas_ascs4
   ibm.cloudcollection.ibm_is_lb_pool:
     name: lb-sap-ha-nwas-ascs-pool-sapctrl
@@ -242,6 +254,7 @@
   when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
 
 - name: Create IBM Cloud Load Balancer Back-end Pool for SAP NetWeaver ASCS - SAP Start Service (SAPControl SOAP) HTTPS (Secure) sapctrls<ASCS_NN>
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_ibmcloud_lb_pool_nwas_ascs5
   ibm.cloudcollection.ibm_is_lb_pool:
     name: lb-sap-ha-nwas-ascs-pool-sapctrls
@@ -257,6 +270,7 @@
   when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
 
 # - name: Create IBM Cloud Load Balancer Back-end Pool for SAP NetWeaver ERS - Dispatcher sapdp<ERS_NN> process
+#   no_log: "{{ __sap_vm_provision_no_log }}"
 #   register: __sap_vm_provision_task_ibmcloud_lb_pool_nwas_ers1
 #   ibm.cloudcollection.ibm_is_lb_pool:
 #     name: lb-sap-ha-nwas-ers-pool-dp
@@ -272,6 +286,7 @@
 #   when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
 
 # - name: Create IBM Cloud Load Balancer Back-end Pool for SAP NetWeaver ERS - Message Server sapms<SAPSID> process
+#   no_log: "{{ __sap_vm_provision_no_log }}"
 #   register: __sap_vm_provision_task_ibmcloud_lb_pool_nwas_ers2
 #   ibm.cloudcollection.ibm_is_lb_pool:
 #     name: lb-sap-ha-nwas-ers-pool-ms
@@ -287,6 +302,7 @@
 #   when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
 
 - name: Create IBM Cloud Load Balancer Back-end Pool for SAP NetWeaver ERS - Enqueue Replication Server sapenqr<SAPSID> process
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_ibmcloud_lb_pool_nwas_ers3
   ibm.cloudcollection.ibm_is_lb_pool:
     name: lb-sap-ha-nwas-ers-pool-enqr
@@ -302,6 +318,7 @@
   when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
 
 - name: Create IBM Cloud Load Balancer Back-end Pool for SAP NetWeaver ERS - SAP Start Service (SAPControl SOAP) HTTP sapctrl<ERS_NN> process
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_ibmcloud_lb_pool_nwas_ers4
   ibm.cloudcollection.ibm_is_lb_pool:
     name: lb-sap-ha-nwas-ers-pool-sapctrl
@@ -317,6 +334,7 @@
   when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
 
 - name: Create IBM Cloud Load Balancer Back-end Pool for SAP NetWeaver ERS - SAP Start Service (SAPControl SOAP) HTTPS (Secure) sapctrls<ERS_NN>
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_ibmcloud_lb_pool_nwas_ers5
   ibm.cloudcollection.ibm_is_lb_pool:
     name: lb-sap-ha-nwas-ers-pool-sapctrls
@@ -335,6 +353,7 @@
 # Identify the provisioned IBM Cloud Load Balancer Back-end Pools
 
 - name: Identify IBM Cloud Load Balancer Back-end Pools
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_ibmcloud_lb_pools
   ibm.cloudcollection.ibm_is_lb_pools_info:
     lb: "{{ item }}"
@@ -346,6 +365,7 @@
 
 # Primary
 - name: Create IBM Cloud Load Balancer Back-end Pool Members for SAP HANA - System DB SQL - Member 1
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_ibmcloud_lb_pool_members_hana1
   ibm.cloudcollection.ibm_is_lb_pool_member:
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-hana'))[0].id }}"
@@ -362,6 +382,7 @@
 
 # Secondary
 - name: Create IBM Cloud Load Balancer Back-end Pool Members for SAP HANA - System DB SQL - Member 2 (Failover/Secondary)
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_ibmcloud_lb_pool_members_hana2
   ibm.cloudcollection.ibm_is_lb_pool_member:
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-hana'))[0].id }}"
@@ -379,6 +400,7 @@
 
 # Primary
 - name: Create IBM Cloud Load Balancer Back-end Pool Members for SAP HANA - MDC Tenant 1 SQL - Member 1
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_ibmcloud_lb_pool_members_hana3
   ibm.cloudcollection.ibm_is_lb_pool_member:
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-hana'))[0].id }}"
@@ -395,6 +417,7 @@
 
 # Secondary
 - name: Create IBM Cloud Load Balancer Back-end Pool Members for SAP HANA - MDC Tenant 1 SQL - Member 2 (Failover/Secondary)
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_ibmcloud_lb_pool_members_hana4
   ibm.cloudcollection.ibm_is_lb_pool_member:
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-hana'))[0].id }}"
@@ -412,6 +435,7 @@
 
 # Primary
 - name: Create IBM Cloud Load Balancer Back-end Pool Members for SAP HANA - startsrv HTTP - Member 1
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_ibmcloud_lb_pool_members_hana5
   ibm.cloudcollection.ibm_is_lb_pool_member:
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-hana'))[0].id }}"
@@ -428,6 +452,7 @@
 
 # Secondary
 - name: Create IBM Cloud Load Balancer Back-end Pool Members for SAP HANA - startsrv HTTP - Member 2 (Failover/Secondary)
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_ibmcloud_lb_pool_members_hana6
   ibm.cloudcollection.ibm_is_lb_pool_member:
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-hana'))[0].id }}"
@@ -445,6 +470,7 @@
 
 # Primary
 - name: Create IBM Cloud Load Balancer Back-end Pool Members for SAP HANA - startsrv HTTPS - Member 1
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_ibmcloud_lb_pool_members_hana7
   ibm.cloudcollection.ibm_is_lb_pool_member:
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-hana'))[0].id }}"
@@ -461,6 +487,7 @@
 
 # Secondary
 - name: Create IBM Cloud Load Balancer Back-end Pool Members for SAP HANA - startsrv HTTPS - Member 2 (Failover/Secondary)
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_ibmcloud_lb_pool_members_hana8
   ibm.cloudcollection.ibm_is_lb_pool_member:
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-hana'))[0].id }}"
@@ -478,6 +505,7 @@
 
 # Primary
 - name: Create IBM Cloud Load Balancer Back-end Pool Members for SAP AnyDB - IBM Db2 Communication Port - Member 1
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_ibmcloud_lb_pool_members_anydb1
   ibm.cloudcollection.ibm_is_lb_pool_member:
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-anydb'))[0].id }}"
@@ -494,6 +522,7 @@
 
 # Secondary
 - name: Create IBM Cloud Load Balancer Back-end Pool Members for SAP AnyDB - IBM Db2 Communication Port - Member 2 (Failover/Secondary)
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_ibmcloud_lb_pool_members_anydb2
   ibm.cloudcollection.ibm_is_lb_pool_member:
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-anydb'))[0].id }}"
@@ -511,6 +540,7 @@
 
 # Primary
 - name: Create IBM Cloud Load Balancer Back-end Pool Members for SAP NetWeaver ASCS - Dispatcher sapdp<ASCS_NN> process - Member 1
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ascs1
   ibm.cloudcollection.ibm_is_lb_pool_member:
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ascs'))[0].id }}"
@@ -527,6 +557,7 @@
 
 # Secondary
 - name: Create IBM Cloud Load Balancer Back-end Pool Members for SAP NetWeaver ASCS - Dispatcher sapdp<ASCS_NN> process - Member 2 (Failover/Secondary)
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ascs2
   ibm.cloudcollection.ibm_is_lb_pool_member:
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ascs'))[0].id }}"
@@ -544,6 +575,7 @@
 
 # Primary
 - name: Create IBM Cloud Load Balancer Back-end Pool Members for SAP NetWeaver ASCS - Message Server sapms<SAPSID> process - Member 1
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ascs3
   ibm.cloudcollection.ibm_is_lb_pool_member:
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ascs'))[0].id }}"
@@ -560,6 +592,7 @@
 
 # Secondary
 - name: Create IBM Cloud Load Balancer Back-end Pool Members for SAP NetWeaver ASCS - Message Server sapms<SAPSID> process - Member 2 (Failover/Secondary)
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ascs4
   ibm.cloudcollection.ibm_is_lb_pool_member:
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ascs'))[0].id }}"
@@ -577,6 +610,7 @@
 
 # Primary
 - name: Create IBM Cloud Load Balancer Back-end Pool Members for SAP NetWeaver ASCS - Enqueue Server sapenq<SAPSID> process - Member 1
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ascs5
   ibm.cloudcollection.ibm_is_lb_pool_member:
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ascs'))[0].id }}"
@@ -593,6 +627,7 @@
 
 # Secondary
 - name: Create IBM Cloud Load Balancer Back-end Pool Members for SAP NetWeaver ASCS - Enqueue Server sapenq<SAPSID> process - Member 2 (Failover/Secondary)
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ascs6
   ibm.cloudcollection.ibm_is_lb_pool_member:
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ascs'))[0].id }}"
@@ -610,6 +645,7 @@
 
 # Primary
 - name: Create IBM Cloud Load Balancer Back-end Pool Members for SAP NetWeaver ASCS - SAP Start Service (SAPControl SOAP) HTTP sapctrl<ASCS_NN> process - Member 1
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ascs7
   ibm.cloudcollection.ibm_is_lb_pool_member:
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ascs'))[0].id }}"
@@ -626,6 +662,7 @@
 
 # Secondary
 - name: Create IBM Cloud Load Balancer Back-end Pool Members for SAP NetWeaver ASCS - SAP Start Service (SAPControl SOAP) HTTP sapctrl<ASCS_NN> process - Member 2 (Failover/Secondary)
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ascs8
   ibm.cloudcollection.ibm_is_lb_pool_member:
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ascs'))[0].id }}"
@@ -643,6 +680,7 @@
 
 # Primary
 - name: Create IBM Cloud Load Balancer Back-end Pool Members for SAP NetWeaver ASCS - SAP Start Service (SAPControl SOAP) HTTPS (Secure) sapctrls<ASCS_NN> - Member 1
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ascs9
   ibm.cloudcollection.ibm_is_lb_pool_member:
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ascs'))[0].id }}"
@@ -659,6 +697,7 @@
 
 # Secondary
 - name: Create IBM Cloud Load Balancer Back-end Pool Members for SAP NetWeaver ASCS - SAP Start Service (SAPControl SOAP) HTTPS (Secure) sapctrls<ASCS_NN> - Member 2 (Failover/Secondary)
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ascs10
   ibm.cloudcollection.ibm_is_lb_pool_member:
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ascs'))[0].id }}"
@@ -676,6 +715,7 @@
 
 # Primary
 # - name: Create IBM Cloud Load Balancer Back-end Pool Members for SAP NetWeaver ERS - Dispatcher sapdp<ERS_NN> process - Member 1
+#   no_log: "{{ __sap_vm_provision_no_log }}"
 #   register: __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ers1
 #   ibm.cloudcollection.ibm_is_lb_pool_member:
 #     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ers'))[0].id }}"
@@ -692,6 +732,7 @@
 
 # Secondary
 # - name: Create IBM Cloud Load Balancer Back-end Pool Members for SAP NetWeaver ERS - Dispatcher sapdp<ERS_NN> process - Member 2 (Failover/Secondary)
+#   no_log: "{{ __sap_vm_provision_no_log }}"
 #   register: __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ers2
 #   ibm.cloudcollection.ibm_is_lb_pool_member:
 #     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ers'))[0].id }}"
@@ -709,6 +750,7 @@
 
 # Primary
 # - name: Create IBM Cloud Load Balancer Back-end Pool Members for SAP NetWeaver ERS - Message Server sapms<SAPSID> process - Member 1
+#   no_log: "{{ __sap_vm_provision_no_log }}"
 #   register: __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ers3
 #   ibm.cloudcollection.ibm_is_lb_pool_member:
 #     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ers'))[0].id }}"
@@ -725,6 +767,7 @@
 
 # Secondary
 # - name: Create IBM Cloud Load Balancer Back-end Pool Members for SAP NetWeaver ERS - Message Server sapms<SAPSID> process - Member 2 (Failover/Secondary)
+#   no_log: "{{ __sap_vm_provision_no_log }}"
 #   register: __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ers4
 #   ibm.cloudcollection.ibm_is_lb_pool_member:
 #     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ers'))[0].id }}"
@@ -742,6 +785,7 @@
 
 # Primary
 - name: Create IBM Cloud Load Balancer Back-end Pool Members for SAP NetWeaver ERS - Enqueue Replication Server sapenqr<SAPSID> process - Member 1
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ers5
   ibm.cloudcollection.ibm_is_lb_pool_member:
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ers'))[0].id }}"
@@ -758,6 +802,7 @@
 
 # Secondary
 - name: Create IBM Cloud Load Balancer Back-end Pool Members for SAP NetWeaver ERS - Enqueue Replication Server sapenqr<SAPSID> process - Member 2 (Failover/Secondary)
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ers6
   ibm.cloudcollection.ibm_is_lb_pool_member:
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ers'))[0].id }}"
@@ -775,6 +820,7 @@
 
 # Primary
 - name: Create IBM Cloud Load Balancer Back-end Pool Members for SAP NetWeaver ERS - SAP Start Service (SAPControl SOAP) HTTP sapctrl<ERS_NN> process - Member 1
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ers7
   ibm.cloudcollection.ibm_is_lb_pool_member:
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ers'))[0].id }}"
@@ -791,6 +837,7 @@
 
 # Secondary
 - name: Create IBM Cloud Load Balancer Back-end Pool Members for SAP NetWeaver ERS - SAP Start Service (SAPControl SOAP) HTTP sapctrl<ERS_NN> process - Member 2 (Failover/Secondary)
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ers8
   ibm.cloudcollection.ibm_is_lb_pool_member:
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ers'))[0].id }}"
@@ -808,6 +855,7 @@
 
 # Primary
 - name: Create IBM Cloud Load Balancer Back-end Pool Members for SAP NetWeaver ERS - SAP Start Service (SAPControl SOAP) HTTPS (Secure) sapctrls<ERS_NN> - Member 1
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ers9
   ibm.cloudcollection.ibm_is_lb_pool_member:
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ers'))[0].id }}"
@@ -824,6 +872,7 @@
 
 # Secondary
 - name: Create IBM Cloud Load Balancer Back-end Pool Members for SAP NetWeaver ERS - SAP Start Service (SAPControl SOAP) HTTPS (Secure) sapctrls<ERS_NN> - Member 2 (Failover/Secondary)
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ers10
   ibm.cloudcollection.ibm_is_lb_pool_member:
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ers'))[0].id }}"
@@ -842,6 +891,7 @@
 # Create IBM Cloud Load Balancer Front-end Listeners (open port for Virtual IPs)
 
 - name: Create IBM Cloud Load Balancer Front-end Listener for SAP HANA - System DB SQL
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_ibmcloud_lb_frontend_listener_hana1
   ibm.cloudcollection.ibm_is_lb_listener:
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-hana'))[0].id }}"
@@ -853,6 +903,7 @@
   failed_when: not __sap_vm_provision_task_ibmcloud_lb_frontend_listener_hana1.rc == 0 and not 'listener_duplicate_port' in __sap_vm_provision_task_ibmcloud_lb_frontend_listener_hana1.stderr
 
 - name: Create IBM Cloud Load Balancer Front-end Listener for SAP HANA - MDC Tenant 1 SQL
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_ibmcloud_lb_frontend_listener_hana2
   ibm.cloudcollection.ibm_is_lb_listener:
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-hana'))[0].id }}"
@@ -864,6 +915,7 @@
   failed_when: not __sap_vm_provision_task_ibmcloud_lb_frontend_listener_hana2.rc == 0 and not 'listener_duplicate_port' in __sap_vm_provision_task_ibmcloud_lb_frontend_listener_hana2.stderr
 
 - name: Create IBM Cloud Load Balancer Front-end Listener for SAP HANA - startsrv HTTP
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_ibmcloud_lb_frontend_listener_hana3
   ibm.cloudcollection.ibm_is_lb_listener:
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-hana'))[0].id }}"
@@ -875,6 +927,7 @@
   failed_when: not __sap_vm_provision_task_ibmcloud_lb_frontend_listener_hana3.rc == 0 and not 'listener_duplicate_port' in __sap_vm_provision_task_ibmcloud_lb_frontend_listener_hana3.stderr
 
 - name: Create IBM Cloud Load Balancer Front-end Listener for SAP HANA - startsrv HTTPS
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_ibmcloud_lb_frontend_listener_hana4
   ibm.cloudcollection.ibm_is_lb_listener:
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-hana'))[0].id }}"
@@ -886,6 +939,7 @@
   failed_when: not __sap_vm_provision_task_ibmcloud_lb_frontend_listener_hana4.rc == 0 and not 'listener_duplicate_port' in __sap_vm_provision_task_ibmcloud_lb_frontend_listener_hana4.stderr
 
 - name: Create IBM Cloud Load Balancer Front-end Listener for SAP AnyDB - IBM Db2 Communication Port
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_ibmcloud_lb_frontend_listener_anydb1
   ibm.cloudcollection.ibm_is_lb_listener:
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-anydb'))[0].id }}"
@@ -897,6 +951,7 @@
   failed_when: not __sap_vm_provision_task_ibmcloud_lb_frontend_listener_anydb1.rc == 0 and not 'listener_duplicate_port' in __sap_vm_provision_task_ibmcloud_lb_frontend_listener_anydb1.stderr
 
 - name: Create IBM Cloud Load Balancer Front-end Listener for SAP NetWeaver ASCS - Dispatcher sapdp<ASCS_NN> process
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ascs1
   ibm.cloudcollection.ibm_is_lb_listener:
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ascs'))[0].id }}"
@@ -908,6 +963,7 @@
   failed_when: not __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ascs1.rc == 0 and not 'listener_duplicate_port' in __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ascs1.stderr
 
 - name: Create IBM Cloud Load Balancer Front-end Listener for SAP NetWeaver ASCS - Message Server sapms<SAPSID> process
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ascs2
   ibm.cloudcollection.ibm_is_lb_listener:
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ascs'))[0].id }}"
@@ -919,6 +975,7 @@
   failed_when: not __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ascs2.rc == 0 and not 'listener_duplicate_port' in __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ascs2.stderr
 
 - name: Create IBM Cloud Load Balancer Front-end Listener for SAP NetWeaver ASCS - Enqueue Server sapenq<SAPSID> process
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ascs3
   ibm.cloudcollection.ibm_is_lb_listener:
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ascs'))[0].id }}"
@@ -930,6 +987,7 @@
   failed_when: not __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ascs3.rc == 0 and not 'listener_duplicate_port' in __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ascs3.stderr
 
 - name: Create IBM Cloud Load Balancer Front-end Listener for SAP NetWeaver ASCS - SAP Start Service (SAPControl SOAP) HTTP sapctrl<ASCS_NN> process
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ascs4
   ibm.cloudcollection.ibm_is_lb_listener:
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ascs'))[0].id }}"
@@ -941,6 +999,7 @@
   failed_when: not __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ascs4.rc == 0 and not 'listener_duplicate_port' in __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ascs4.stderr
 
 - name: Create IBM Cloud Load Balancer Front-end Listener for SAP NetWeaver ASCS - SAP Start Service (SAPControl SOAP) HTTPS (Secure) sapctrls<ASCS_NN>
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ascs5
   ibm.cloudcollection.ibm_is_lb_listener:
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ascs'))[0].id }}"
@@ -952,28 +1011,31 @@
   failed_when: not __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ascs5.rc == 0 and not 'listener_duplicate_port' in __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ascs5.stderr
 
 # - name: Create IBM Cloud Load Balancer Front-end Listener for SAP NetWeaver ERS - Dispatcher sapdp<ERS_NN> process
+#   no_log: "{{ __sap_vm_provision_no_log }}"
 #   register: __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ers1
-#  ibm.cloudcollection.ibm_is_lb_listener:
-#    lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ers'))[0].id }}"
-#    default_pool: "{{ (__sap_vm_provision_task_ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-nwas-ers-pool-dp'))[0].id }}"
-#    protocol: tcp
-#    port: "{{ ('32' + sap_system_nwas_abap_ers_instance_nr) | int }}"
-#    ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
+#   ibm.cloudcollection.ibm_is_lb_listener:
+#     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ers'))[0].id }}"
+#     default_pool: "{{ (__sap_vm_provision_task_ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-nwas-ers-pool-dp'))[0].id }}"
+#     protocol: tcp
+#     port: "{{ ('32' + sap_system_nwas_abap_ers_instance_nr) | int }}"
+#     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
 #   when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
 #   failed_when: not __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ers1.rc == 0 and not 'listener_duplicate_port' in __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ers1.stderr
 
 # - name: Create IBM Cloud Load Balancer Front-end Listener for SAP NetWeaver ERS - Message Server sapms<SAPSID> process
+#   no_log: "{{ __sap_vm_provision_no_log }}"
 #   register: __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ers2
-#  ibm.cloudcollection.ibm_is_lb_listener:
-#    lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ers'))[0].id }}"
-#    default_pool: "{{ (__sap_vm_provision_task_ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-nwas-ers-pool-ms'))[0].id }}"
-#    protocol: tcp
-#    port: "{{ ('36' + sap_system_nwas_abap_ers_instance_nr) | int }}"
-#    ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
+#   ibm.cloudcollection.ibm_is_lb_listener:
+#     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ers'))[0].id }}"
+#     default_pool: "{{ (__sap_vm_provision_task_ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-nwas-ers-pool-ms'))[0].id }}"
+#     protocol: tcp
+#     port: "{{ ('36' + sap_system_nwas_abap_ers_instance_nr) | int }}"
+#     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
 #   when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
 #   failed_when: not __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ers2.rc == 0 and not 'listener_duplicate_port' in __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ers2.stderr
 
 - name: Create IBM Cloud Load Balancer Front-end Listener for SAP NetWeaver ERS - Enqueue Replication Server sapenqr<SAPSID> process
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ers3
   ibm.cloudcollection.ibm_is_lb_listener:
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ers'))[0].id }}"
@@ -985,6 +1047,7 @@
   failed_when: not __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ers3.rc == 0 and not 'listener_duplicate_port' in __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ers3.stderr
 
 - name: Create IBM Cloud Load Balancer Front-end Listener for SAP NetWeaver ERS - SAP Start Service (SAPControl SOAP) HTTP sapctrl<ERS_NN> process
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ers4
   ibm.cloudcollection.ibm_is_lb_listener:
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ers'))[0].id }}"
@@ -996,6 +1059,7 @@
   failed_when: not __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ers4.rc == 0 and not 'listener_duplicate_port' in __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ers4.stderr
 
 - name: Create IBM Cloud Load Balancer Front-end Listener for SAP NetWeaver ERS - SAP Start Service (SAPControl SOAP) HTTPS (Secure) sapctrls<ERS_NN>
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ers5
   ibm.cloudcollection.ibm_is_lb_listener:
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ers'))[0].id }}"
@@ -1010,6 +1074,7 @@
 # Set DNS A Record for Virtual IP (use the first of the IBM Cloud Load Balancer instance assigned Private IPs in the VPC Subnet Range)
 
 - name: IBM Cloud Private DNS Record for SAP HANA HA Virtual Hostname
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_ibmcloud_pdns_record_ha_hana
   ibm.cloudcollection.ibm_dns_resource_record:
     instance_id: "{{ __sap_vm_provision_task_ibmcloud_pdns_service_instance.resource.guid }}"
@@ -1027,6 +1092,7 @@
     - groups["hana_secondary"] is defined and (groups["hana_secondary"]|length>0)
 
 - name: IBM Cloud Private DNS Record for SAP AnyDB HA Virtual Hostname
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_ibmcloud_pdns_record_ha_anydb
   ibm.cloudcollection.ibm_dns_resource_record:
     instance_id: "{{ __sap_vm_provision_task_ibmcloud_pdns_service_instance.resource.guid }}"
@@ -1044,6 +1110,7 @@
     - groups["anydb_secondary"] is defined and (groups["anydb_secondary"]|length>0)
 
 - name: IBM Cloud Private DNS Record for SAP NetWeaver ASCS HA Virtual Hostname
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_ibmcloud_pdns_record_ha_nwas_ascs
   ibm.cloudcollection.ibm_dns_resource_record:
     instance_id: "{{ __sap_vm_provision_task_ibmcloud_pdns_service_instance.resource.guid }}"
@@ -1061,6 +1128,7 @@
     - groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
 
 - name: IBM Cloud Private DNS Record for SAP NetWeaver ERS HA Virtual Hostname
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_ibmcloud_pdns_record_ha_nwas_ers
   ibm.cloudcollection.ibm_dns_resource_record:
     instance_id: "{{ __sap_vm_provision_task_ibmcloud_pdns_service_instance.resource.guid }}"

--- a/roles/sap_vm_provision/tasks/platform_ansible/ibmcloud_vs/execute_setup_ha.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/ibmcloud_vs/execute_setup_ha.yml
@@ -1,15 +1,16 @@
 ---
 
 - name: Create IBM Cloud IAM Authorization Policy for IBM Cloud Load Balancer to communicate with IBM Cloud Private DNS
-  register: ibmcloud_iam_auth_policy
+  register: __sap_vm_provision_task_ibmcloud_iam_auth_policy
   ibm.cloudcollection.ibm_iam_authorization_policy:
     roles: Manager
-    source_resource_group_id: "{{ register_ibmcloud_resource_group.resource.id }}"
-    target_resource_group_id: "{{ register_ibmcloud_resource_group.resource.id }}"
+    source_resource_group_id: "{{ __sap_vm_provision_task_ibmcloud_resource_group.resource.id }}"
+    target_resource_group_id: "{{ __sap_vm_provision_task_ibmcloud_resource_group.resource.id }}"
     source_service_name: is
     source_resource_type: load-balancer
     target_service_name: dns-svcs
-  failed_when: not ibmcloud_iam_auth_policy.rc == 0 and not 'access policy with identical attributes already exists' in ibmcloud_iam_auth_policy.stderr
+    ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
+  failed_when: not __sap_vm_provision_task_ibmcloud_iam_auth_policy.rc == 0 and not 'access policy with identical attributes already exists' in __sap_vm_provision_task_ibmcloud_iam_auth_policy.stderr
 
 
 # The IBM Cloud Load Balancer is provisioned before Linux Pacemaker and requires a temporary Health Check Probe port to be used with an an active OS service listening.
@@ -25,20 +26,21 @@
 # Private Network Load Balancer (Layer 4), restricts HA within single Availability Zone. Permits TCP and UDP, does not permit HTTP/S.
 # Use async with poll '0' to create all IBM Cloud Load Balancers in parallel
 - name: Create IBM Cloud Load Balancer (Private ALB) for each Virtual Hostname / Virtual IP required
-  register: ibmcloud_lb_provision_parallel
+  register: __sap_vm_provision_task_ibmcloud_lb_provision_parallel
   ibm.cloudcollection.ibm_is_lb:
-    resource_group: "{{ register_ibmcloud_resource_group.resource.id }}"
+    resource_group: "{{ __sap_vm_provision_task_ibmcloud_resource_group.resource.id }}"
     name: "{{ item }}"
     type: private
-    subnets: ["{{ register_ibmcloud_vpc_subnet.resource.id }}"]
-    security_groups: "{{ register_ibmcloud_vpc_sg.results | map(attribute='resource.id') }}"
+    subnets: ["{{ __sap_vm_provision_task_ibmcloud_vpc_subnet.resource.id }}"]
+    security_groups: "{{ __sap_vm_provision_task_ibmcloud_vpc_sg.results | map(attribute='resource.id') }}"
     #access_tags:
     logging: true # For ALB L7, not NLB L4
     #profile: network-fixed / dynamic # For NLB L4, not ALB L7
     #route_mode: false # For NLB L4, not ALB L7
     # dns: # Unsupported by legacy Ansible Collection, use IBM Cloud CLI as workaround
-    #   instance_crn: "{{ register_ibmcloud_pdns_service_instance.resource.resource_crn }}"
-    #   zone_id: "{{ (register_ibmcloud_pdns.resource.dns_zones | selectattr('name', '==', sap_vm_provision_dns_root_domain) | first).zone_id }}"
+    #   instance_crn: "{{ __sap_vm_provision_task_ibmcloud_pdns_service_instance.resource.resource_crn }}"
+    #   zone_id: "{{ (__sap_vm_provision_task_ibmcloud_pdns.resource.dns_zones | selectattr('name', '==', sap_vm_provision_dns_root_domain) | first).zone_id }}"
+    ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
   loop:
     - "{{ 'lb-sap-ha-hana' if (groups['hana_secondary'] is defined and (groups['hana_secondary'] | length>0)) else '' }}"
     - "{{ 'lb-sap-ha-anydb' if (groups['anydb_secondary'] is defined and (groups['anydb_secondary'] | length>0)) else '' }}"
@@ -51,53 +53,62 @@
   poll: 0 # parallel
 
 - name: Wait for IBM Cloud Load Balancer provisioning
-  register: async_status_ibmcloud_lb_provision_parallel
+  register: __sap_vm_provision_task_ibmcloud_lb_provision_parallel_async_status
   ansible.builtin.async_status:
     jid: "{{ item.ansible_job_id }}"
   retries: 40
   delay: 30 # seconds
-  until: async_status_ibmcloud_lb_provision_parallel.finished
-  loop: "{{ ibmcloud_lb_provision_parallel.results | selectattr('ansible_job_id', 'defined') }}"
-  # failed_when: not async_status_ibmcloud_lb_provision_parallel.rc == 0
+  until: __sap_vm_provision_task_ibmcloud_lb_provision_parallel_async_status.finished
+  loop: "{{ __sap_vm_provision_task_ibmcloud_lb_provision_parallel.results | selectattr('ansible_job_id', 'defined') }}"
+  # failed_when: not __sap_vm_provision_task_ibmcloud_lb_provision_parallel_async_status.rc == 0
 
 # Workaround to missing Ansible Module functionality in legacy Ansible Collection
 - name: IBM Cloud CLI append DNS to Load Balancer
-  register: ibmcloud_lb_update_dns
+  no_log: true
+  register: __sap_vm_provision_task_ibmcloud_lb_update_dns
   ansible.builtin.shell: |
-    ibmcloud config --quiet --check-version false && ibmcloud login -g {{ sap_vm_provision_ibmcloud_resource_group_name }} -r {{ sap_vm_provision_ibmcloud_region }} --quiet
+    ibmcloud config --quiet --check-version false && ibmcloud login --apikey="{{ sap_vm_provision_ibmcloud_api_key }}" -g {{ sap_vm_provision_ibmcloud_resource_group_name }} -r {{ sap_vm_provision_ibmcloud_region }} --quiet
     ibmcloud plugin install infrastructure-service -f --quiet
-    ibmcloud is load-balancer-update "{{ item }}" --dns-instance-crn "{{ register_ibmcloud_pdns_service_instance.resource.resource_crn }}" --dns-zone-id "{{ (register_ibmcloud_pdns.resource.dns_zones | selectattr('name', '==', sap_vm_provision_dns_root_domain) | first).zone_id }}"
+    ibmcloud is load-balancer-update "{{ item }}" --dns-instance-crn "{{ __sap_vm_provision_task_ibmcloud_pdns_service_instance.resource.resource_crn }}" --dns-zone-id "{{ (__sap_vm_provision_task_ibmcloud_pdns.resource.dns_zones | selectattr('name', '==', sap_vm_provision_dns_root_domain) | first).zone_id }}"
   loop:
     - "{{ 'lb-sap-ha-hana' if (groups['hana_secondary'] is defined and (groups['hana_secondary'] | length>0)) else '' }}"
     - "{{ 'lb-sap-ha-anydb' if (groups['anydb_secondary'] is defined and (groups['anydb_secondary'] | length>0)) else '' }}"
     - "{{ 'lb-sap-ha-nwas-ascs' if (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0)) else '' }}"
     - "{{ 'lb-sap-ha-nwas-ers' if (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0)) else '' }}"
   when: not item == ''
-  failed_when: not ibmcloud_lb_update_dns.rc == 0 and not 'nothing to update the load balancer with' in ibmcloud_lb_update_dns.stderr
+  failed_when: not __sap_vm_provision_task_ibmcloud_lb_update_dns.rc == 0 and not 'nothing to update the load balancer with' in __sap_vm_provision_task_ibmcloud_lb_update_dns.stderr
 
 - name: Identify IBM Cloud Virtual Servers info
-  register: ibmcloud_vs_all_info
+  register: __sap_vm_provision_task_ibmcloud_vs_all_info
   ibm.cloudcollection.ibm_is_instances_info:
-    vpc: "{{ register_ibmcloud_vpc_subnet.resource.vpc }}"
+    vpc: "{{ __sap_vm_provision_task_ibmcloud_vpc_subnet.resource.vpc }}"
+    ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
 
 
 # Workaround for bug which populates region and ibmcloud_api_key as TF arguments for ibm_is_lbs_info Ansible Module in legacy Ansible Collection
 - name: IBM Cloud CLI execution to list Load Balancer/s info
-  register: ibmcloud_lbs_all_info_shell
+  no_log: true
+  register: __sap_vm_provision_task_ibmcloud_lb_all_info_shell
   ansible.builtin.shell: |
-    ibmcloud config --quiet --check-version false && ibmcloud login -g {{ sap_vm_provision_ibmcloud_resource_group_name }} -r {{ sap_vm_provision_ibmcloud_region }} --quiet
+    ibmcloud config --quiet --check-version false && ibmcloud login --apikey="{{ sap_vm_provision_ibmcloud_api_key }}" -g {{ sap_vm_provision_ibmcloud_resource_group_name }} -r {{ sap_vm_provision_ibmcloud_region }} --quiet
     #ibmcloud plugin install infrastructure-service -f --quiet
     ibmcloud is load-balancers --quiet --output json
 
 - name: Set fact for IBM Cloud Load Balancer/s info
   ansible.builtin.set_fact:
-    ibmcloud_lbs_all_info: "{{ ibmcloud_lbs_all_info_shell.stdout | split('Space:') | last | trim | from_json }}"
+    ibmcloud_lbs_all_info: "{{ __sap_vm_provision_task_ibmcloud_lb_all_info_shell.stdout | split('Space:') | last | trim | from_json }}"
+
+# Required because CLI executed with API Key
+- name: Set fact for Ansible Tasks debug with redaction
+  ansible.builtin.set_fact:
+    __sap_vm_provision_task_ibmcloud_lb_update_dns: "{{ __sap_vm_provision_task_ibmcloud_lb_update_dns | regex_replace(sap_vm_provision_ibmcloud_api_key) }}"
+    __sap_vm_provision_task_ibmcloud_lb_all_info_shell: "{{ __sap_vm_provision_task_ibmcloud_lb_all_info_shell | regex_replace(sap_vm_provision_ibmcloud_api_key) }}"
 
 
 # Create IBM Cloud Load Balancer Back-end Pools
 
 - name: Create IBM Cloud Load Balancer Back-end Pool for SAP HANA - System DB SQL
-  register: __ibmcloud_lb_pool_hana1
+  register: __sap_vm_provision_task_ibmcloud_lb_pool_hana1
   ibm.cloudcollection.ibm_is_lb_pool:
     name: lb-sap-ha-hana-pool-sysdb-sql
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-hana'))[0].id }}"
@@ -108,10 +119,11 @@
     health_timeout: 10
     health_type: tcp
     health_monitor_port: 55550
+    ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
   when: (groups['hana_secondary'] is defined and (groups['hana_secondary'] | length>0))
 
 - name: Create IBM Cloud Load Balancer Back-end Pool for SAP HANA - MDC Tenant 1 SQL
-  register: __ibmcloud_lb_pool_hana2
+  register: __sap_vm_provision_task_ibmcloud_lb_pool_hana2
   ibm.cloudcollection.ibm_is_lb_pool:
     name: lb-sap-ha-hana-pool-mdc1-sql
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-hana'))[0].id }}"
@@ -122,10 +134,11 @@
     health_timeout: 10
     health_type: tcp
     health_monitor_port: 55550
+    ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
   when: (groups['hana_secondary'] is defined and (groups['hana_secondary'] | length>0))
 
 - name: Create IBM Cloud Load Balancer Back-end Pool for SAP HANA - startsrv HTTP
-  register: __ibmcloud_lb_pool_hana3
+  register: __sap_vm_provision_task_ibmcloud_lb_pool_hana3
   ibm.cloudcollection.ibm_is_lb_pool:
     name: lb-sap-ha-hana-pool-startsrv-http
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-hana'))[0].id }}"
@@ -136,10 +149,11 @@
     health_timeout: 10
     health_type: tcp
     health_monitor_port: 55550
+    ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
   when: (groups['hana_secondary'] is defined and (groups['hana_secondary'] | length>0))
 
 - name: Create IBM Cloud Load Balancer Back-end Pool for SAP HANA - startsrv HTTPS
-  register: __ibmcloud_lb_pool_hana4
+  register: __sap_vm_provision_task_ibmcloud_lb_pool_hana4
   ibm.cloudcollection.ibm_is_lb_pool:
     name: lb-sap-ha-hana-pool-startsrv-https
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-hana'))[0].id }}"
@@ -150,6 +164,7 @@
     health_timeout: 10
     health_type: tcp
     health_monitor_port: 55550
+    ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
   when: (groups['hana_secondary'] is defined and (groups['hana_secondary'] | length>0))
 
 - name: Create IBM Cloud Load Balancer Back-end Pool for SAP AnyDB - IBM Db2 Communication Port
@@ -163,10 +178,11 @@
     health_timeout: 10
     health_type: tcp
     health_monitor_port: 55550
+    ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
   when: (groups['anydb_secondary'] is defined and (groups['anydb_secondary'] | length>0))
 
 - name: Create IBM Cloud Load Balancer Back-end Pool for SAP NetWeaver ASCS - Dispatcher sapdp<ASCS_NN> process
-  register: __ibmcloud_lb_pool_nwas_ascs1
+  register: __sap_vm_provision_task_ibmcloud_lb_pool_nwas_ascs1
   ibm.cloudcollection.ibm_is_lb_pool:
     name: lb-sap-ha-nwas-ascs-pool-dp
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ascs'))[0].id }}"
@@ -177,10 +193,11 @@
     health_timeout: 10
     health_type: tcp
     health_monitor_port: 55551
+    ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
   when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
 
 - name: Create IBM Cloud Load Balancer Back-end Pool for SAP NetWeaver ASCS - Message Server sapms<SAPSID> process
-  register: __ibmcloud_lb_pool_nwas_ascs2
+  register: __sap_vm_provision_task_ibmcloud_lb_pool_nwas_ascs2
   ibm.cloudcollection.ibm_is_lb_pool:
     name: lb-sap-ha-nwas-ascs-pool-ms
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ascs'))[0].id }}"
@@ -191,10 +208,11 @@
     health_timeout: 10
     health_type: tcp
     health_monitor_port: 55551
+    ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
   when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
 
 - name: Create IBM Cloud Load Balancer Back-end Pool for SAP NetWeaver ASCS - Enqueue Server sapenq<SAPSID> process
-  register: __ibmcloud_lb_pool_nwas_ascs3
+  register: __sap_vm_provision_task_ibmcloud_lb_pool_nwas_ascs3
   ibm.cloudcollection.ibm_is_lb_pool:
     name: lb-sap-ha-nwas-ascs-pool-enq
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ascs'))[0].id }}"
@@ -205,10 +223,11 @@
     health_timeout: 10
     health_type: tcp
     health_monitor_port: 55551
+    ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
   when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
 
 - name: Create IBM Cloud Load Balancer Back-end Pool for SAP NetWeaver ASCS - SAP Start Service (SAPControl SOAP) HTTP sapctrl<ASCS_NN> process
-  register: __ibmcloud_lb_pool_nwas_ascs4
+  register: __sap_vm_provision_task_ibmcloud_lb_pool_nwas_ascs4
   ibm.cloudcollection.ibm_is_lb_pool:
     name: lb-sap-ha-nwas-ascs-pool-sapctrl
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ascs'))[0].id }}"
@@ -219,10 +238,11 @@
     health_timeout: 10
     health_type: tcp
     health_monitor_port: 55551
+    ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
   when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
 
 - name: Create IBM Cloud Load Balancer Back-end Pool for SAP NetWeaver ASCS - SAP Start Service (SAPControl SOAP) HTTPS (Secure) sapctrls<ASCS_NN>
-  register: __ibmcloud_lb_pool_nwas_ascs5
+  register: __sap_vm_provision_task_ibmcloud_lb_pool_nwas_ascs5
   ibm.cloudcollection.ibm_is_lb_pool:
     name: lb-sap-ha-nwas-ascs-pool-sapctrls
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ascs'))[0].id }}"
@@ -233,10 +253,11 @@
     health_timeout: 10
     health_type: tcp
     health_monitor_port: 55551
+    ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
   when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
 
 # - name: Create IBM Cloud Load Balancer Back-end Pool for SAP NetWeaver ERS - Dispatcher sapdp<ERS_NN> process
-#   register: __ibmcloud_lb_pool_nwas_ers1
+#   register: __sap_vm_provision_task_ibmcloud_lb_pool_nwas_ers1
 #   ibm.cloudcollection.ibm_is_lb_pool:
 #     name: lb-sap-ha-nwas-ers-pool-dp
 #     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ers'))[0].id }}"
@@ -247,10 +268,11 @@
 #     health_timeout: 10
 #     health_type: tcp
 #     health_monitor_port: 55552
+#     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
 #   when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
 
 # - name: Create IBM Cloud Load Balancer Back-end Pool for SAP NetWeaver ERS - Message Server sapms<SAPSID> process
-#   register: __ibmcloud_lb_pool_nwas_ers2
+#   register: __sap_vm_provision_task_ibmcloud_lb_pool_nwas_ers2
 #   ibm.cloudcollection.ibm_is_lb_pool:
 #     name: lb-sap-ha-nwas-ers-pool-ms
 #     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ers'))[0].id }}"
@@ -261,10 +283,11 @@
 #     health_timeout: 10
 #     health_type: tcp
 #     health_monitor_port: 55552
+#     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
 #   when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
 
 - name: Create IBM Cloud Load Balancer Back-end Pool for SAP NetWeaver ERS - Enqueue Replication Server sapenqr<SAPSID> process
-  register: __ibmcloud_lb_pool_nwas_ers3
+  register: __sap_vm_provision_task_ibmcloud_lb_pool_nwas_ers3
   ibm.cloudcollection.ibm_is_lb_pool:
     name: lb-sap-ha-nwas-ers-pool-enqr
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ers'))[0].id }}"
@@ -275,10 +298,11 @@
     health_timeout: 10
     health_type: tcp
     health_monitor_port: 55552
+    ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
   when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
 
 - name: Create IBM Cloud Load Balancer Back-end Pool for SAP NetWeaver ERS - SAP Start Service (SAPControl SOAP) HTTP sapctrl<ERS_NN> process
-  register: __ibmcloud_lb_pool_nwas_ers4
+  register: __sap_vm_provision_task_ibmcloud_lb_pool_nwas_ers4
   ibm.cloudcollection.ibm_is_lb_pool:
     name: lb-sap-ha-nwas-ers-pool-sapctrl
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ers'))[0].id }}"
@@ -289,10 +313,11 @@
     health_timeout: 10
     health_type: tcp
     health_monitor_port: 55552
+    ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
   when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
 
 - name: Create IBM Cloud Load Balancer Back-end Pool for SAP NetWeaver ERS - SAP Start Service (SAPControl SOAP) HTTPS (Secure) sapctrls<ERS_NN>
-  register: __ibmcloud_lb_pool_nwas_ers5
+  register: __sap_vm_provision_task_ibmcloud_lb_pool_nwas_ers5
   ibm.cloudcollection.ibm_is_lb_pool:
     name: lb-sap-ha-nwas-ers-pool-sapctrls
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ers'))[0].id }}"
@@ -303,15 +328,17 @@
     health_timeout: 10
     health_type: tcp
     health_monitor_port: 55552
+    ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
   when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
 
 
 # Identify the provisioned IBM Cloud Load Balancer Back-end Pools
 
 - name: Identify IBM Cloud Load Balancer Back-end Pools
-  register: __ibmcloud_lb_pools
+  register: __sap_vm_provision_task_ibmcloud_lb_pools
   ibm.cloudcollection.ibm_is_lb_pools_info:
     lb: "{{ item }}"
+    ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
   loop: "{{ ibmcloud_lbs_all_info | map(attribute='id') }}"
 
 
@@ -319,634 +346,680 @@
 
 # Primary
 - name: Create IBM Cloud Load Balancer Back-end Pool Members for SAP HANA - System DB SQL - Member 1
-  register: __ibmcloud_lb_pool_members_hana1
+  register: __sap_vm_provision_task_ibmcloud_lb_pool_members_hana1
   ibm.cloudcollection.ibm_is_lb_pool_member:
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-hana'))[0].id }}"
-    pool: "{{ (__ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-hana-pool-sysdb-sql'))[0].id }}"
-    target_address: "{{ (ibmcloud_vs_all_info.resource.instances | selectattr('name', '==', host_node))[0].primary_network_interface[0].primary_ipv4_address }}"
+    pool: "{{ (__sap_vm_provision_task_ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-hana-pool-sysdb-sql'))[0].id }}"
+    target_address: "{{ (__sap_vm_provision_task_ibmcloud_vs_all_info.resource.instances | selectattr('name', '==', host_node))[0].primary_network_interface[0].primary_ipv4_address }}"
     port: "{{ ('3' + sap_system_hana_db_instance_nr + '13') | int }}"
     weight: 100
+    ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
   loop: "{{ (groups['hana_primary'] | default([]) ) }}"
   loop_control:
     loop_var: host_node
   when: (groups['hana_secondary'] is defined and (groups['hana_secondary'] | length>0))
-  failed_when: not __ibmcloud_lb_pool_members_hana1.rc == 0 and not 'already exists in a pool' in __ibmcloud_lb_pool_members_hana1.stderr
+  failed_when: not __sap_vm_provision_task_ibmcloud_lb_pool_members_hana1.rc == 0 and not 'already exists in a pool' in __sap_vm_provision_task_ibmcloud_lb_pool_members_hana1.stderr
 
 # Secondary
 - name: Create IBM Cloud Load Balancer Back-end Pool Members for SAP HANA - System DB SQL - Member 2 (Failover/Secondary)
-  register: __ibmcloud_lb_pool_members_hana2
+  register: __sap_vm_provision_task_ibmcloud_lb_pool_members_hana2
   ibm.cloudcollection.ibm_is_lb_pool_member:
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-hana'))[0].id }}"
-    pool: "{{ (__ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-hana-pool-sysdb-sql'))[0].id }}"
-    target_address: "{{ (ibmcloud_vs_all_info.resource.instances | selectattr('name', '==', host_node))[0].primary_network_interface[0].primary_ipv4_address }}"
+    pool: "{{ (__sap_vm_provision_task_ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-hana-pool-sysdb-sql'))[0].id }}"
+    target_address: "{{ (__sap_vm_provision_task_ibmcloud_vs_all_info.resource.instances | selectattr('name', '==', host_node))[0].primary_network_interface[0].primary_ipv4_address }}"
     port: "{{ ('3' + sap_system_hana_db_instance_nr + '13') | int }}"
     weight: 1
+    ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
   loop: "{{ (groups['hana_secondary'] | default([]) ) }}"
   loop_control:
     loop_var: host_node
   when: (groups['hana_secondary'] is defined and (groups['hana_secondary'] | length>0))
-  failed_when: not __ibmcloud_lb_pool_members_hana2.rc == 0 and not 'already exists in a pool' in __ibmcloud_lb_pool_members_hana2.stderr
+  failed_when: not __sap_vm_provision_task_ibmcloud_lb_pool_members_hana2.rc == 0 and not 'already exists in a pool' in __sap_vm_provision_task_ibmcloud_lb_pool_members_hana2.stderr
 
 
 # Primary
 - name: Create IBM Cloud Load Balancer Back-end Pool Members for SAP HANA - MDC Tenant 1 SQL - Member 1
-  register: __ibmcloud_lb_pool_members_hana3
+  register: __sap_vm_provision_task_ibmcloud_lb_pool_members_hana3
   ibm.cloudcollection.ibm_is_lb_pool_member:
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-hana'))[0].id }}"
-    pool: "{{ (__ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-hana-pool-mdc1-sql'))[0].id }}"
-    target_address: "{{ (ibmcloud_vs_all_info.resource.instances | selectattr('name', '==', host_node))[0].primary_network_interface[0].primary_ipv4_address }}"
+    pool: "{{ (__sap_vm_provision_task_ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-hana-pool-mdc1-sql'))[0].id }}"
+    target_address: "{{ (__sap_vm_provision_task_ibmcloud_vs_all_info.resource.instances | selectattr('name', '==', host_node))[0].primary_network_interface[0].primary_ipv4_address }}"
     port: "{{ ('3' + sap_system_hana_db_instance_nr + '15') | int }}"
     weight: 100
+    ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
   loop: "{{ (groups['hana_primary'] | default([]) ) }}"
   loop_control:
     loop_var: host_node
   when: (groups['hana_secondary'] is defined and (groups['hana_secondary'] | length>0))
-  failed_when: not __ibmcloud_lb_pool_members_hana3.rc == 0 and not 'already exists in a pool' in __ibmcloud_lb_pool_members_hana3.stderr
+  failed_when: not __sap_vm_provision_task_ibmcloud_lb_pool_members_hana3.rc == 0 and not 'already exists in a pool' in __sap_vm_provision_task_ibmcloud_lb_pool_members_hana3.stderr
 
 # Secondary
 - name: Create IBM Cloud Load Balancer Back-end Pool Members for SAP HANA - MDC Tenant 1 SQL - Member 2 (Failover/Secondary)
-  register: __ibmcloud_lb_pool_members_hana4
+  register: __sap_vm_provision_task_ibmcloud_lb_pool_members_hana4
   ibm.cloudcollection.ibm_is_lb_pool_member:
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-hana'))[0].id }}"
-    pool: "{{ (__ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-hana-pool-mdc1-sql'))[0].id }}"
-    target_address: "{{ (ibmcloud_vs_all_info.resource.instances | selectattr('name', '==', host_node))[0].primary_network_interface[0].primary_ipv4_address }}"
+    pool: "{{ (__sap_vm_provision_task_ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-hana-pool-mdc1-sql'))[0].id }}"
+    target_address: "{{ (__sap_vm_provision_task_ibmcloud_vs_all_info.resource.instances | selectattr('name', '==', host_node))[0].primary_network_interface[0].primary_ipv4_address }}"
     port: "{{ ('3' + sap_system_hana_db_instance_nr + '15') | int }}"
     weight: 1
+    ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
   loop: "{{ (groups['hana_secondary'] | default([]) ) }}"
   loop_control:
     loop_var: host_node
   when: (groups['hana_secondary'] is defined and (groups['hana_secondary'] | length>0))
-  failed_when: not __ibmcloud_lb_pool_members_hana4.rc == 0 and not 'already exists in a pool' in __ibmcloud_lb_pool_members_hana4.stderr
+  failed_when: not __sap_vm_provision_task_ibmcloud_lb_pool_members_hana4.rc == 0 and not 'already exists in a pool' in __sap_vm_provision_task_ibmcloud_lb_pool_members_hana4.stderr
 
 
 # Primary
 - name: Create IBM Cloud Load Balancer Back-end Pool Members for SAP HANA - startsrv HTTP - Member 1
-  register: __ibmcloud_lb_pool_members_hana5
+  register: __sap_vm_provision_task_ibmcloud_lb_pool_members_hana5
   ibm.cloudcollection.ibm_is_lb_pool_member:
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-hana'))[0].id }}"
-    pool: "{{ (__ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-hana-pool-startsrv-http'))[0].id }}"
-    target_address: "{{ (ibmcloud_vs_all_info.resource.instances | selectattr('name', '==', host_node))[0].primary_network_interface[0].primary_ipv4_address }}"
+    pool: "{{ (__sap_vm_provision_task_ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-hana-pool-startsrv-http'))[0].id }}"
+    target_address: "{{ (__sap_vm_provision_task_ibmcloud_vs_all_info.resource.instances | selectattr('name', '==', host_node))[0].primary_network_interface[0].primary_ipv4_address }}"
     port: "{{ ('5' + sap_system_hana_db_instance_nr + '13') | int }}"
     weight: 100
+    ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
   loop: "{{ (groups['hana_primary'] | default([]) ) }}"
   loop_control:
     loop_var: host_node
   when: (groups['hana_secondary'] is defined and (groups['hana_secondary'] | length>0))
-  failed_when: not __ibmcloud_lb_pool_members_hana5.rc == 0 and not 'already exists in a pool' in __ibmcloud_lb_pool_members_hana5.stderr
+  failed_when: not __sap_vm_provision_task_ibmcloud_lb_pool_members_hana5.rc == 0 and not 'already exists in a pool' in __sap_vm_provision_task_ibmcloud_lb_pool_members_hana5.stderr
 
 # Secondary
 - name: Create IBM Cloud Load Balancer Back-end Pool Members for SAP HANA - startsrv HTTP - Member 2 (Failover/Secondary)
-  register: __ibmcloud_lb_pool_members_hana6
+  register: __sap_vm_provision_task_ibmcloud_lb_pool_members_hana6
   ibm.cloudcollection.ibm_is_lb_pool_member:
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-hana'))[0].id }}"
-    pool: "{{ (__ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-hana-pool-startsrv-http'))[0].id }}"
-    target_address: "{{ (ibmcloud_vs_all_info.resource.instances | selectattr('name', '==', host_node))[0].primary_network_interface[0].primary_ipv4_address }}"
+    pool: "{{ (__sap_vm_provision_task_ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-hana-pool-startsrv-http'))[0].id }}"
+    target_address: "{{ (__sap_vm_provision_task_ibmcloud_vs_all_info.resource.instances | selectattr('name', '==', host_node))[0].primary_network_interface[0].primary_ipv4_address }}"
     port: "{{ ('5' + sap_system_hana_db_instance_nr + '13') | int }}"
     weight: 1
+    ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
   loop: "{{ (groups['hana_secondary'] | default([]) ) }}"
   loop_control:
     loop_var: host_node
   when: (groups['hana_secondary'] is defined and (groups['hana_secondary'] | length>0))
-  failed_when: not __ibmcloud_lb_pool_members_hana6.rc == 0 and not 'already exists in a pool' in __ibmcloud_lb_pool_members_hana6.stderr
+  failed_when: not __sap_vm_provision_task_ibmcloud_lb_pool_members_hana6.rc == 0 and not 'already exists in a pool' in __sap_vm_provision_task_ibmcloud_lb_pool_members_hana6.stderr
 
 
 # Primary
 - name: Create IBM Cloud Load Balancer Back-end Pool Members for SAP HANA - startsrv HTTPS - Member 1
-  register: __ibmcloud_lb_pool_members_hana7
+  register: __sap_vm_provision_task_ibmcloud_lb_pool_members_hana7
   ibm.cloudcollection.ibm_is_lb_pool_member:
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-hana'))[0].id }}"
-    pool: "{{ (__ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-hana-pool-startsrv-https'))[0].id }}"
-    target_address: "{{ (ibmcloud_vs_all_info.resource.instances | selectattr('name', '==', host_node))[0].primary_network_interface[0].primary_ipv4_address }}"
+    pool: "{{ (__sap_vm_provision_task_ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-hana-pool-startsrv-https'))[0].id }}"
+    target_address: "{{ (__sap_vm_provision_task_ibmcloud_vs_all_info.resource.instances | selectattr('name', '==', host_node))[0].primary_network_interface[0].primary_ipv4_address }}"
     port: "{{ ('5' + sap_system_hana_db_instance_nr + '14') | int }}"
     weight: 100
+    ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
   loop: "{{ (groups['hana_primary'] | default([]) ) }}"
   loop_control:
     loop_var: host_node
   when: (groups['hana_secondary'] is defined and (groups['hana_secondary'] | length>0))
-  failed_when: not __ibmcloud_lb_pool_members_hana7.rc == 0 and not 'already exists in a pool' in __ibmcloud_lb_pool_members_hana7.stderr
+  failed_when: not __sap_vm_provision_task_ibmcloud_lb_pool_members_hana7.rc == 0 and not 'already exists in a pool' in __sap_vm_provision_task_ibmcloud_lb_pool_members_hana7.stderr
 
 # Secondary
 - name: Create IBM Cloud Load Balancer Back-end Pool Members for SAP HANA - startsrv HTTPS - Member 2 (Failover/Secondary)
-  register: __ibmcloud_lb_pool_members_hana8
+  register: __sap_vm_provision_task_ibmcloud_lb_pool_members_hana8
   ibm.cloudcollection.ibm_is_lb_pool_member:
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-hana'))[0].id }}"
-    pool: "{{ (__ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-hana-pool-startsrv-https'))[0].id }}"
-    target_address: "{{ (ibmcloud_vs_all_info.resource.instances | selectattr('name', '==', host_node))[0].primary_network_interface[0].primary_ipv4_address }}"
+    pool: "{{ (__sap_vm_provision_task_ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-hana-pool-startsrv-https'))[0].id }}"
+    target_address: "{{ (__sap_vm_provision_task_ibmcloud_vs_all_info.resource.instances | selectattr('name', '==', host_node))[0].primary_network_interface[0].primary_ipv4_address }}"
     port: "{{ ('5' + sap_system_hana_db_instance_nr + '14') | int }}"
     weight: 1
+    ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
   loop: "{{ (groups['hana_secondary'] | default([]) ) }}"
   loop_control:
     loop_var: host_node
   when: (groups['hana_secondary'] is defined and (groups['hana_secondary'] | length>0))
-  failed_when: not __ibmcloud_lb_pool_members_hana8.rc == 0 and not 'already exists in a pool' in __ibmcloud_lb_pool_members_hana8.stderr
+  failed_when: not __sap_vm_provision_task_ibmcloud_lb_pool_members_hana8.rc == 0 and not 'already exists in a pool' in __sap_vm_provision_task_ibmcloud_lb_pool_members_hana8.stderr
 
 
 # Primary
 - name: Create IBM Cloud Load Balancer Back-end Pool Members for SAP AnyDB - IBM Db2 Communication Port - Member 1
-  register: __ibmcloud_lb_pool_members_anydb1
+  register: __sap_vm_provision_task_ibmcloud_lb_pool_members_anydb1
   ibm.cloudcollection.ibm_is_lb_pool_member:
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-anydb'))[0].id }}"
-    pool: "{{ (__ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-anydb-pool-ibmdb2'))[0].id }}"
-    target_address: "{{ (ibmcloud_vs_all_info.resource.instances | selectattr('name', '==', host_node))[0].primary_network_interface[0].primary_ipv4_address }}"
+    pool: "{{ (__sap_vm_provision_task_ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-anydb-pool-ibmdb2'))[0].id }}"
+    target_address: "{{ (__sap_vm_provision_task_ibmcloud_vs_all_info.resource.instances | selectattr('name', '==', host_node))[0].primary_network_interface[0].primary_ipv4_address }}"
     port: 5912
     weight: 100
+    ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
   loop: "{{ (groups['anydb_primary'] | default([]) ) }}"
   loop_control:
     loop_var: host_node
   when: (groups['anydb_secondary'] is defined and (groups['anydb_secondary'] | length>0))
-  failed_when: not __ibmcloud_lb_pool_members_anydb1.rc == 0 and not 'already exists in a pool' in __ibmcloud_lb_pool_members_anydb1.stderr
+  failed_when: not __sap_vm_provision_task_ibmcloud_lb_pool_members_anydb1.rc == 0 and not 'already exists in a pool' in __sap_vm_provision_task_ibmcloud_lb_pool_members_anydb1.stderr
 
 # Secondary
 - name: Create IBM Cloud Load Balancer Back-end Pool Members for SAP AnyDB - IBM Db2 Communication Port - Member 2 (Failover/Secondary)
-  register: __ibmcloud_lb_pool_members_anydb2
+  register: __sap_vm_provision_task_ibmcloud_lb_pool_members_anydb2
   ibm.cloudcollection.ibm_is_lb_pool_member:
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-anydb'))[0].id }}"
-    pool: "{{ (__ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-anydb-pool-ibmdb2'))[0].id }}"
-    target_address: "{{ (ibmcloud_vs_all_info.resource.instances | selectattr('name', '==', host_node))[0].primary_network_interface[0].primary_ipv4_address }}"
+    pool: "{{ (__sap_vm_provision_task_ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-anydb-pool-ibmdb2'))[0].id }}"
+    target_address: "{{ (__sap_vm_provision_task_ibmcloud_vs_all_info.resource.instances | selectattr('name', '==', host_node))[0].primary_network_interface[0].primary_ipv4_address }}"
     port: 5912
     weight: 1
+    ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
   loop: "{{ (groups['anydb_secondary'] | default([]) ) }}"
   loop_control:
     loop_var: host_node
   when: (groups['anydb_secondary'] is defined and (groups['anydb_secondary'] | length>0))
-  failed_when: not __ibmcloud_lb_pool_members_anydb2.rc == 0 and not 'already exists in a pool' in __ibmcloud_lb_pool_members_anydb2.stderr
+  failed_when: not __sap_vm_provision_task_ibmcloud_lb_pool_members_anydb2.rc == 0 and not 'already exists in a pool' in __sap_vm_provision_task_ibmcloud_lb_pool_members_anydb2.stderr
 
 
 # Primary
 - name: Create IBM Cloud Load Balancer Back-end Pool Members for SAP NetWeaver ASCS - Dispatcher sapdp<ASCS_NN> process - Member 1
-  register: __ibmcloud_lb_pool_members_nwas_ascs1
+  register: __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ascs1
   ibm.cloudcollection.ibm_is_lb_pool_member:
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ascs'))[0].id }}"
-    pool: "{{ (__ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-nwas-ascs-pool-dp'))[0].id }}"
-    target_address: "{{ (ibmcloud_vs_all_info.resource.instances | selectattr('name', '==', host_node))[0].primary_network_interface[0].primary_ipv4_address }}"
+    pool: "{{ (__sap_vm_provision_task_ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-nwas-ascs-pool-dp'))[0].id }}"
+    target_address: "{{ (__sap_vm_provision_task_ibmcloud_vs_all_info.resource.instances | selectattr('name', '==', host_node))[0].primary_network_interface[0].primary_ipv4_address }}"
     port: "{{ ('32' + sap_system_nwas_abap_ascs_instance_nr) | int }}"
     weight: 100
+    ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
   loop: "{{ (groups['nwas_ascs'] | default([]) ) }}"
   loop_control:
     loop_var: host_node
   when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
-  failed_when: not __ibmcloud_lb_pool_members_nwas_ascs1.rc == 0 and not 'already exists in a pool' in __ibmcloud_lb_pool_members_nwas_ascs1.stderr
+  failed_when: not __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ascs1.rc == 0 and not 'already exists in a pool' in __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ascs1.stderr
 
 # Secondary
 - name: Create IBM Cloud Load Balancer Back-end Pool Members for SAP NetWeaver ASCS - Dispatcher sapdp<ASCS_NN> process - Member 2 (Failover/Secondary)
-  register: __ibmcloud_lb_pool_members_nwas_ascs2
+  register: __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ascs2
   ibm.cloudcollection.ibm_is_lb_pool_member:
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ascs'))[0].id }}"
-    pool: "{{ (__ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-nwas-ascs-pool-dp'))[0].id }}"
-    target_address: "{{ (ibmcloud_vs_all_info.resource.instances | selectattr('name', '==', host_node))[0].primary_network_interface[0].primary_ipv4_address }}"
+    pool: "{{ (__sap_vm_provision_task_ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-nwas-ascs-pool-dp'))[0].id }}"
+    target_address: "{{ (__sap_vm_provision_task_ibmcloud_vs_all_info.resource.instances | selectattr('name', '==', host_node))[0].primary_network_interface[0].primary_ipv4_address }}"
     port: "{{ ('32' + sap_system_nwas_abap_ascs_instance_nr) | int }}"
     weight: 1
+    ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
   loop: "{{ (groups['nwas_ers'] | default([]) ) }}"
   loop_control:
     loop_var: host_node
   when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
-  failed_when: not __ibmcloud_lb_pool_members_nwas_ascs2.rc == 0 and not 'already exists in a pool' in __ibmcloud_lb_pool_members_nwas_ascs2.stderr
+  failed_when: not __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ascs2.rc == 0 and not 'already exists in a pool' in __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ascs2.stderr
 
 
 # Primary
 - name: Create IBM Cloud Load Balancer Back-end Pool Members for SAP NetWeaver ASCS - Message Server sapms<SAPSID> process - Member 1
-  register: __ibmcloud_lb_pool_members_nwas_ascs3
+  register: __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ascs3
   ibm.cloudcollection.ibm_is_lb_pool_member:
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ascs'))[0].id }}"
-    pool: "{{ (__ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-nwas-ascs-pool-ms'))[0].id }}"
-    target_address: "{{ (ibmcloud_vs_all_info.resource.instances | selectattr('name', '==', host_node))[0].primary_network_interface[0].primary_ipv4_address }}"
+    pool: "{{ (__sap_vm_provision_task_ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-nwas-ascs-pool-ms'))[0].id }}"
+    target_address: "{{ (__sap_vm_provision_task_ibmcloud_vs_all_info.resource.instances | selectattr('name', '==', host_node))[0].primary_network_interface[0].primary_ipv4_address }}"
     port: "{{ ('36' + sap_system_nwas_abap_ascs_instance_nr) | int }}"
     weight: 100
+    ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
   loop: "{{ (groups['nwas_ascs'] | default([]) ) }}"
   loop_control:
     loop_var: host_node
   when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
-  failed_when: not __ibmcloud_lb_pool_members_nwas_ascs3.rc == 0 and not 'already exists in a pool' in __ibmcloud_lb_pool_members_nwas_ascs3.stderr
+  failed_when: not __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ascs3.rc == 0 and not 'already exists in a pool' in __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ascs3.stderr
 
 # Secondary
 - name: Create IBM Cloud Load Balancer Back-end Pool Members for SAP NetWeaver ASCS - Message Server sapms<SAPSID> process - Member 2 (Failover/Secondary)
-  register: __ibmcloud_lb_pool_members_nwas_ascs4
+  register: __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ascs4
   ibm.cloudcollection.ibm_is_lb_pool_member:
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ascs'))[0].id }}"
-    pool: "{{ (__ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-nwas-ascs-pool-ms'))[0].id }}"
-    target_address: "{{ (ibmcloud_vs_all_info.resource.instances | selectattr('name', '==', host_node))[0].primary_network_interface[0].primary_ipv4_address }}"
+    pool: "{{ (__sap_vm_provision_task_ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-nwas-ascs-pool-ms'))[0].id }}"
+    target_address: "{{ (__sap_vm_provision_task_ibmcloud_vs_all_info.resource.instances | selectattr('name', '==', host_node))[0].primary_network_interface[0].primary_ipv4_address }}"
     port: "{{ ('36' + sap_system_nwas_abap_ascs_instance_nr) | int }}"
     weight: 1
+    ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
   loop: "{{ (groups['nwas_ers'] | default([]) ) }}"
   loop_control:
     loop_var: host_node
   when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
-  failed_when: not __ibmcloud_lb_pool_members_nwas_ascs4.rc == 0 and not 'already exists in a pool' in __ibmcloud_lb_pool_members_nwas_ascs4.stderr
+  failed_when: not __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ascs4.rc == 0 and not 'already exists in a pool' in __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ascs4.stderr
 
 
 # Primary
 - name: Create IBM Cloud Load Balancer Back-end Pool Members for SAP NetWeaver ASCS - Enqueue Server sapenq<SAPSID> process - Member 1
-  register: __ibmcloud_lb_pool_members_nwas_ascs5
+  register: __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ascs5
   ibm.cloudcollection.ibm_is_lb_pool_member:
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ascs'))[0].id }}"
-    pool: "{{ (__ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-nwas-ascs-pool-enq'))[0].id }}"
-    target_address: "{{ (ibmcloud_vs_all_info.resource.instances | selectattr('name', '==', host_node))[0].primary_network_interface[0].primary_ipv4_address }}"
+    pool: "{{ (__sap_vm_provision_task_ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-nwas-ascs-pool-enq'))[0].id }}"
+    target_address: "{{ (__sap_vm_provision_task_ibmcloud_vs_all_info.resource.instances | selectattr('name', '==', host_node))[0].primary_network_interface[0].primary_ipv4_address }}"
     port: "{{ ('39' + sap_system_nwas_abap_ascs_instance_nr) | int }}"
     weight: 100
+    ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
   loop: "{{ (groups['nwas_ascs'] | default([]) ) }}"
   loop_control:
     loop_var: host_node
   when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
-  failed_when: not __ibmcloud_lb_pool_members_nwas_ascs5.rc == 0 and not 'already exists in a pool' in __ibmcloud_lb_pool_members_nwas_ascs5.stderr
+  failed_when: not __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ascs5.rc == 0 and not 'already exists in a pool' in __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ascs5.stderr
 
 # Secondary
 - name: Create IBM Cloud Load Balancer Back-end Pool Members for SAP NetWeaver ASCS - Enqueue Server sapenq<SAPSID> process - Member 2 (Failover/Secondary)
-  register: __ibmcloud_lb_pool_members_nwas_ascs6
+  register: __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ascs6
   ibm.cloudcollection.ibm_is_lb_pool_member:
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ascs'))[0].id }}"
-    pool: "{{ (__ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-nwas-ascs-pool-enq'))[0].id }}"
-    target_address: "{{ (ibmcloud_vs_all_info.resource.instances | selectattr('name', '==', host_node))[0].primary_network_interface[0].primary_ipv4_address }}"
+    pool: "{{ (__sap_vm_provision_task_ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-nwas-ascs-pool-enq'))[0].id }}"
+    target_address: "{{ (__sap_vm_provision_task_ibmcloud_vs_all_info.resource.instances | selectattr('name', '==', host_node))[0].primary_network_interface[0].primary_ipv4_address }}"
     port: "{{ ('39' + sap_system_nwas_abap_ascs_instance_nr) | int }}"
     weight: 1
+    ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
   loop: "{{ (groups['nwas_ers'] | default([]) ) }}"
   loop_control:
     loop_var: host_node
   when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
-  failed_when: not __ibmcloud_lb_pool_members_nwas_ascs6.rc == 0 and not 'already exists in a pool' in __ibmcloud_lb_pool_members_nwas_ascs6.stderr
+  failed_when: not __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ascs6.rc == 0 and not 'already exists in a pool' in __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ascs6.stderr
 
 
 # Primary
 - name: Create IBM Cloud Load Balancer Back-end Pool Members for SAP NetWeaver ASCS - SAP Start Service (SAPControl SOAP) HTTP sapctrl<ASCS_NN> process - Member 1
-  register: __ibmcloud_lb_pool_members_nwas_ascs7
+  register: __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ascs7
   ibm.cloudcollection.ibm_is_lb_pool_member:
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ascs'))[0].id }}"
-    pool: "{{ (__ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-nwas-ascs-pool-sapctrl'))[0].id }}"
-    target_address: "{{ (ibmcloud_vs_all_info.resource.instances | selectattr('name', '==', host_node))[0].primary_network_interface[0].primary_ipv4_address }}"
+    pool: "{{ (__sap_vm_provision_task_ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-nwas-ascs-pool-sapctrl'))[0].id }}"
+    target_address: "{{ (__sap_vm_provision_task_ibmcloud_vs_all_info.resource.instances | selectattr('name', '==', host_node))[0].primary_network_interface[0].primary_ipv4_address }}"
     port: "{{ ('5' + sap_system_nwas_abap_ascs_instance_nr + '13') | int }}"
     weight: 100
+    ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
   loop: "{{ (groups['nwas_ascs'] | default([]) ) }}"
   loop_control:
     loop_var: host_node
   when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
-  failed_when: not __ibmcloud_lb_pool_members_nwas_ascs7.rc == 0 and not 'already exists in a pool' in __ibmcloud_lb_pool_members_nwas_ascs7.stderr
+  failed_when: not __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ascs7.rc == 0 and not 'already exists in a pool' in __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ascs7.stderr
 
 # Secondary
 - name: Create IBM Cloud Load Balancer Back-end Pool Members for SAP NetWeaver ASCS - SAP Start Service (SAPControl SOAP) HTTP sapctrl<ASCS_NN> process - Member 2 (Failover/Secondary)
-  register: __ibmcloud_lb_pool_members_nwas_ascs8
+  register: __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ascs8
   ibm.cloudcollection.ibm_is_lb_pool_member:
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ascs'))[0].id }}"
-    pool: "{{ (__ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-nwas-ascs-pool-sapctrl'))[0].id }}"
-    target_address: "{{ (ibmcloud_vs_all_info.resource.instances | selectattr('name', '==', host_node))[0].primary_network_interface[0].primary_ipv4_address }}"
+    pool: "{{ (__sap_vm_provision_task_ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-nwas-ascs-pool-sapctrl'))[0].id }}"
+    target_address: "{{ (__sap_vm_provision_task_ibmcloud_vs_all_info.resource.instances | selectattr('name', '==', host_node))[0].primary_network_interface[0].primary_ipv4_address }}"
     port: "{{ ('5' + sap_system_nwas_abap_ascs_instance_nr + '13') | int }}"
     weight: 1
+    ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
   loop: "{{ (groups['nwas_ers'] | default([]) ) }}"
   loop_control:
     loop_var: host_node
   when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
-  failed_when: not __ibmcloud_lb_pool_members_nwas_ascs8.rc == 0 and not 'already exists in a pool' in __ibmcloud_lb_pool_members_nwas_ascs8.stderr
+  failed_when: not __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ascs8.rc == 0 and not 'already exists in a pool' in __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ascs8.stderr
 
 
 # Primary
 - name: Create IBM Cloud Load Balancer Back-end Pool Members for SAP NetWeaver ASCS - SAP Start Service (SAPControl SOAP) HTTPS (Secure) sapctrls<ASCS_NN> - Member 1
-  register: __ibmcloud_lb_pool_members_nwas_ascs9
+  register: __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ascs9
   ibm.cloudcollection.ibm_is_lb_pool_member:
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ascs'))[0].id }}"
-    pool: "{{ (__ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-nwas-ascs-pool-sapctrls'))[0].id }}"
-    target_address: "{{ (ibmcloud_vs_all_info.resource.instances | selectattr('name', '==', host_node))[0].primary_network_interface[0].primary_ipv4_address }}"
+    pool: "{{ (__sap_vm_provision_task_ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-nwas-ascs-pool-sapctrls'))[0].id }}"
+    target_address: "{{ (__sap_vm_provision_task_ibmcloud_vs_all_info.resource.instances | selectattr('name', '==', host_node))[0].primary_network_interface[0].primary_ipv4_address }}"
     port: "{{ ('5' + sap_system_nwas_abap_ascs_instance_nr + '14') | int }}"
     weight: 100
+    ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
   loop: "{{ (groups['nwas_ascs'] | default([]) ) }}"
   loop_control:
     loop_var: host_node
   when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
-  failed_when: not __ibmcloud_lb_pool_members_nwas_ascs9.rc == 0 and not 'already exists in a pool' in __ibmcloud_lb_pool_members_nwas_ascs9.stderr
+  failed_when: not __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ascs9.rc == 0 and not 'already exists in a pool' in __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ascs9.stderr
 
 # Secondary
 - name: Create IBM Cloud Load Balancer Back-end Pool Members for SAP NetWeaver ASCS - SAP Start Service (SAPControl SOAP) HTTPS (Secure) sapctrls<ASCS_NN> - Member 2 (Failover/Secondary)
-  register: __ibmcloud_lb_pool_members_nwas_ascs10
+  register: __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ascs10
   ibm.cloudcollection.ibm_is_lb_pool_member:
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ascs'))[0].id }}"
-    pool: "{{ (__ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-nwas-ascs-pool-sapctrls'))[0].id }}"
-    target_address: "{{ (ibmcloud_vs_all_info.resource.instances | selectattr('name', '==', host_node))[0].primary_network_interface[0].primary_ipv4_address }}"
+    pool: "{{ (__sap_vm_provision_task_ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-nwas-ascs-pool-sapctrls'))[0].id }}"
+    target_address: "{{ (__sap_vm_provision_task_ibmcloud_vs_all_info.resource.instances | selectattr('name', '==', host_node))[0].primary_network_interface[0].primary_ipv4_address }}"
     port: "{{ ('5' + sap_system_nwas_abap_ascs_instance_nr + '14') | int }}"
     weight: 1
+    ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
   loop: "{{ (groups['nwas_ers'] | default([]) ) }}"
   loop_control:
     loop_var: host_node
   when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
-  failed_when: not __ibmcloud_lb_pool_members_nwas_ascs10.rc == 0 and not 'already exists in a pool' in __ibmcloud_lb_pool_members_nwas_ascs10.stderr
+  failed_when: not __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ascs10.rc == 0 and not 'already exists in a pool' in __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ascs10.stderr
 
 
 # Primary
 # - name: Create IBM Cloud Load Balancer Back-end Pool Members for SAP NetWeaver ERS - Dispatcher sapdp<ERS_NN> process - Member 1
-#   register: __ibmcloud_lb_pool_members_nwas_ers1
+#   register: __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ers1
 #   ibm.cloudcollection.ibm_is_lb_pool_member:
 #     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ers'))[0].id }}"
-#     pool: "{{ (__ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-nwas-ers-pool-dp'))[0].id }}"
-#     target_address: "{{ (ibmcloud_vs_all_info.resource.instances | selectattr('name', '==', host_node))[0].primary_network_interface[0].primary_ipv4_address }}"
+#     pool: "{{ (__sap_vm_provision_task_ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-nwas-ers-pool-dp'))[0].id }}"
+#     target_address: "{{ (__sap_vm_provision_task_ibmcloud_vs_all_info.resource.instances | selectattr('name', '==', host_node))[0].primary_network_interface[0].primary_ipv4_address }}"
 #     port: "{{ ('32' + sap_system_nwas_abap_ers_instance_nr) | int }}"
 #     weight: 100
+#     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
 #   loop: "{{ (groups['nwas_ers'] | default([]) ) }}"
 #   loop_control:
 #     loop_var: host_node
 #   when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
-#   failed_when: not __ibmcloud_lb_pool_members_nwas_ers1.rc == 0 and not 'already exists in a pool' in __ibmcloud_lb_pool_members_nwas_ers1.stderr
+#   failed_when: not __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ers1.rc == 0 and not 'already exists in a pool' in __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ers1.stderr
 
 # Secondary
 # - name: Create IBM Cloud Load Balancer Back-end Pool Members for SAP NetWeaver ERS - Dispatcher sapdp<ERS_NN> process - Member 2 (Failover/Secondary)
-#   register: __ibmcloud_lb_pool_members_nwas_ers2
+#   register: __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ers2
 #   ibm.cloudcollection.ibm_is_lb_pool_member:
 #     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ers'))[0].id }}"
-#     pool: "{{ (__ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-nwas-ers-pool-dp'))[0].id }}"
-#     target_address: "{{ (ibmcloud_vs_all_info.resource.instances | selectattr('name', '==', host_node))[0].primary_network_interface[0].primary_ipv4_address }}"
+#     pool: "{{ (__sap_vm_provision_task_ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-nwas-ers-pool-dp'))[0].id }}"
+#     target_address: "{{ (__sap_vm_provision_task_ibmcloud_vs_all_info.resource.instances | selectattr('name', '==', host_node))[0].primary_network_interface[0].primary_ipv4_address }}"
 #     port: "{{ ('32' + sap_system_nwas_abap_ers_instance_nr) | int }}"
 #     weight: 1
+#     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
 #   loop: "{{ (groups['nwas_ascs'] | default([]) ) }}"
 #   loop_control:
 #     loop_var: host_node
 #   when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
-#   failed_when: not __ibmcloud_lb_pool_members_nwas_ers2.rc == 0 and not 'already exists in a pool' in __ibmcloud_lb_pool_members_nwas_ers2.stderr
+#   failed_when: not __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ers2.rc == 0 and not 'already exists in a pool' in __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ers2.stderr
 
 
 # Primary
 # - name: Create IBM Cloud Load Balancer Back-end Pool Members for SAP NetWeaver ERS - Message Server sapms<SAPSID> process - Member 1
-#   register: __ibmcloud_lb_pool_members_nwas_ers3
+#   register: __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ers3
 #   ibm.cloudcollection.ibm_is_lb_pool_member:
 #     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ers'))[0].id }}"
-#     pool: "{{ (__ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-nwas-ers-pool-ms'))[0].id }}"
-#     target_address: "{{ (ibmcloud_vs_all_info.resource.instances | selectattr('name', '==', host_node))[0].primary_network_interface[0].primary_ipv4_address }}"
+#     pool: "{{ (__sap_vm_provision_task_ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-nwas-ers-pool-ms'))[0].id }}"
+#     target_address: "{{ (__sap_vm_provision_task_ibmcloud_vs_all_info.resource.instances | selectattr('name', '==', host_node))[0].primary_network_interface[0].primary_ipv4_address }}"
 #     port: "{{ ('36' + sap_system_nwas_abap_ers_instance_nr) | int }}"
 #     weight: 100
+#     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
 #   loop: "{{ (groups['nwas_ers'] | default([]) ) }}"
 #   loop_control:
 #     loop_var: host_node
 #   when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
-#   failed_when: not __ibmcloud_lb_pool_members_nwas_ers3.rc == 0 and not 'already exists in a pool' in __ibmcloud_lb_pool_members_nwas_ers3.stderr
+#   failed_when: not __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ers3.rc == 0 and not 'already exists in a pool' in __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ers3.stderr
 
 # Secondary
 # - name: Create IBM Cloud Load Balancer Back-end Pool Members for SAP NetWeaver ERS - Message Server sapms<SAPSID> process - Member 2 (Failover/Secondary)
-#   register: __ibmcloud_lb_pool_members_nwas_ers4
+#   register: __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ers4
 #   ibm.cloudcollection.ibm_is_lb_pool_member:
 #     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ers'))[0].id }}"
-#     pool: "{{ (__ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-nwas-ers-pool-ms'))[0].id }}"
-#     target_address: "{{ (ibmcloud_vs_all_info.resource.instances | selectattr('name', '==', host_node))[0].primary_network_interface[0].primary_ipv4_address }}"
+#     pool: "{{ (__sap_vm_provision_task_ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-nwas-ers-pool-ms'))[0].id }}"
+#     target_address: "{{ (__sap_vm_provision_task_ibmcloud_vs_all_info.resource.instances | selectattr('name', '==', host_node))[0].primary_network_interface[0].primary_ipv4_address }}"
 #     port: "{{ ('36' + sap_system_nwas_abap_ers_instance_nr) | int }}"
 #     weight: 1
+#     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
 #   loop: "{{ (groups['nwas_ascs'] | default([]) ) }}"
 #   loop_control:
 #     loop_var: host_node
 #   when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
-#   failed_when: not __ibmcloud_lb_pool_members_nwas_ers4.rc == 0 and not 'already exists in a pool' in __ibmcloud_lb_pool_members_nwas_ers4.stderr
+#   failed_when: not __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ers4.rc == 0 and not 'already exists in a pool' in __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ers4.stderr
 
 
 # Primary
 - name: Create IBM Cloud Load Balancer Back-end Pool Members for SAP NetWeaver ERS - Enqueue Replication Server sapenqr<SAPSID> process - Member 1
-  register: __ibmcloud_lb_pool_members_nwas_ers5
+  register: __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ers5
   ibm.cloudcollection.ibm_is_lb_pool_member:
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ers'))[0].id }}"
-    pool: "{{ (__ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-nwas-ers-pool-enqr'))[0].id }}"
-    target_address: "{{ (ibmcloud_vs_all_info.resource.instances | selectattr('name', '==', host_node))[0].primary_network_interface[0].primary_ipv4_address }}"
+    pool: "{{ (__sap_vm_provision_task_ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-nwas-ers-pool-enqr'))[0].id }}"
+    target_address: "{{ (__sap_vm_provision_task_ibmcloud_vs_all_info.resource.instances | selectattr('name', '==', host_node))[0].primary_network_interface[0].primary_ipv4_address }}"
     port: "{{ ('39' + sap_system_nwas_abap_ers_instance_nr) | int }}"
     weight: 100
+    ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
   loop: "{{ (groups['nwas_ers'] | default([]) ) }}"
   loop_control:
     loop_var: host_node
   when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
-  failed_when: not __ibmcloud_lb_pool_members_nwas_ers5.rc == 0 and not 'already exists in a pool' in __ibmcloud_lb_pool_members_nwas_ers5.stderr
+  failed_when: not __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ers5.rc == 0 and not 'already exists in a pool' in __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ers5.stderr
 
 # Secondary
 - name: Create IBM Cloud Load Balancer Back-end Pool Members for SAP NetWeaver ERS - Enqueue Replication Server sapenqr<SAPSID> process - Member 2 (Failover/Secondary)
-  register: __ibmcloud_lb_pool_members_nwas_ers6
+  register: __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ers6
   ibm.cloudcollection.ibm_is_lb_pool_member:
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ers'))[0].id }}"
-    pool: "{{ (__ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-nwas-ers-pool-enqr'))[0].id }}"
-    target_address: "{{ (ibmcloud_vs_all_info.resource.instances | selectattr('name', '==', host_node))[0].primary_network_interface[0].primary_ipv4_address }}"
+    pool: "{{ (__sap_vm_provision_task_ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-nwas-ers-pool-enqr'))[0].id }}"
+    target_address: "{{ (__sap_vm_provision_task_ibmcloud_vs_all_info.resource.instances | selectattr('name', '==', host_node))[0].primary_network_interface[0].primary_ipv4_address }}"
     port: "{{ ('39' + sap_system_nwas_abap_ers_instance_nr) | int }}"
     weight: 1
+    ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
   loop: "{{ (groups['nwas_ascs'] | default([]) ) }}"
   loop_control:
     loop_var: host_node
   when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
-  failed_when: not __ibmcloud_lb_pool_members_nwas_ers6.rc == 0 and not 'already exists in a pool' in __ibmcloud_lb_pool_members_nwas_ers6.stderr
+  failed_when: not __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ers6.rc == 0 and not 'already exists in a pool' in __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ers6.stderr
 
 
 # Primary
 - name: Create IBM Cloud Load Balancer Back-end Pool Members for SAP NetWeaver ERS - SAP Start Service (SAPControl SOAP) HTTP sapctrl<ERS_NN> process - Member 1
-  register: __ibmcloud_lb_pool_members_nwas_ers7
+  register: __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ers7
   ibm.cloudcollection.ibm_is_lb_pool_member:
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ers'))[0].id }}"
-    pool: "{{ (__ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-nwas-ers-pool-sapctrl'))[0].id }}"
-    target_address: "{{ (ibmcloud_vs_all_info.resource.instances | selectattr('name', '==', host_node))[0].primary_network_interface[0].primary_ipv4_address }}"
+    pool: "{{ (__sap_vm_provision_task_ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-nwas-ers-pool-sapctrl'))[0].id }}"
+    target_address: "{{ (__sap_vm_provision_task_ibmcloud_vs_all_info.resource.instances | selectattr('name', '==', host_node))[0].primary_network_interface[0].primary_ipv4_address }}"
     port: "{{ ('5' + sap_system_nwas_abap_ers_instance_nr + '13') | int }}"
     weight: 100
+    ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
   loop: "{{ (groups['nwas_ers'] | default([]) ) }}"
   loop_control:
     loop_var: host_node
   when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
-  failed_when: not __ibmcloud_lb_pool_members_nwas_ers7.rc == 0 and not 'already exists in a pool' in __ibmcloud_lb_pool_members_nwas_ers7.stderr
+  failed_when: not __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ers7.rc == 0 and not 'already exists in a pool' in __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ers7.stderr
 
 # Secondary
 - name: Create IBM Cloud Load Balancer Back-end Pool Members for SAP NetWeaver ERS - SAP Start Service (SAPControl SOAP) HTTP sapctrl<ERS_NN> process - Member 2 (Failover/Secondary)
-  register: __ibmcloud_lb_pool_members_nwas_ers8
+  register: __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ers8
   ibm.cloudcollection.ibm_is_lb_pool_member:
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ers'))[0].id }}"
-    pool: "{{ (__ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-nwas-ers-pool-sapctrl'))[0].id }}"
-    target_address: "{{ (ibmcloud_vs_all_info.resource.instances | selectattr('name', '==', host_node))[0].primary_network_interface[0].primary_ipv4_address }}"
+    pool: "{{ (__sap_vm_provision_task_ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-nwas-ers-pool-sapctrl'))[0].id }}"
+    target_address: "{{ (__sap_vm_provision_task_ibmcloud_vs_all_info.resource.instances | selectattr('name', '==', host_node))[0].primary_network_interface[0].primary_ipv4_address }}"
     port: "{{ ('5' + sap_system_nwas_abap_ers_instance_nr + '13') | int }}"
     weight: 1
+    ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
   loop: "{{ (groups['nwas_ascs'] | default([]) ) }}"
   loop_control:
     loop_var: host_node
   when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
-  failed_when: not __ibmcloud_lb_pool_members_nwas_ers8.rc == 0 and not 'already exists in a pool' in __ibmcloud_lb_pool_members_nwas_ers8.stderr
+  failed_when: not __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ers8.rc == 0 and not 'already exists in a pool' in __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ers8.stderr
 
 
 # Primary
 - name: Create IBM Cloud Load Balancer Back-end Pool Members for SAP NetWeaver ERS - SAP Start Service (SAPControl SOAP) HTTPS (Secure) sapctrls<ERS_NN> - Member 1
-  register: __ibmcloud_lb_pool_members_nwas_ers9
+  register: __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ers9
   ibm.cloudcollection.ibm_is_lb_pool_member:
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ers'))[0].id }}"
-    pool: "{{ (__ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-nwas-ers-pool-sapctrls'))[0].id }}"
-    target_address: "{{ (ibmcloud_vs_all_info.resource.instances | selectattr('name', '==', host_node))[0].primary_network_interface[0].primary_ipv4_address }}"
+    pool: "{{ (__sap_vm_provision_task_ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-nwas-ers-pool-sapctrls'))[0].id }}"
+    target_address: "{{ (__sap_vm_provision_task_ibmcloud_vs_all_info.resource.instances | selectattr('name', '==', host_node))[0].primary_network_interface[0].primary_ipv4_address }}"
     port: "{{ ('5' + sap_system_nwas_abap_ers_instance_nr + '14') | int }}"
     weight: 100
+    ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
   loop: "{{ (groups['nwas_ers'] | default([]) ) }}"
   loop_control:
     loop_var: host_node
   when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
-  failed_when: not __ibmcloud_lb_pool_members_nwas_ers9.rc == 0 and not 'already exists in a pool' in __ibmcloud_lb_pool_members_nwas_ers9.stderr
+  failed_when: not __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ers9.rc == 0 and not 'already exists in a pool' in __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ers9.stderr
 
 # Secondary
 - name: Create IBM Cloud Load Balancer Back-end Pool Members for SAP NetWeaver ERS - SAP Start Service (SAPControl SOAP) HTTPS (Secure) sapctrls<ERS_NN> - Member 2 (Failover/Secondary)
-  register: __ibmcloud_lb_pool_members_nwas_ers10
+  register: __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ers10
   ibm.cloudcollection.ibm_is_lb_pool_member:
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ers'))[0].id }}"
-    pool: "{{ (__ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-nwas-ers-pool-sapctrls'))[0].id }}"
-    target_address: "{{ (ibmcloud_vs_all_info.resource.instances | selectattr('name', '==', host_node))[0].primary_network_interface[0].primary_ipv4_address }}"
+    pool: "{{ (__sap_vm_provision_task_ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-nwas-ers-pool-sapctrls'))[0].id }}"
+    target_address: "{{ (__sap_vm_provision_task_ibmcloud_vs_all_info.resource.instances | selectattr('name', '==', host_node))[0].primary_network_interface[0].primary_ipv4_address }}"
     port: "{{ ('5' + sap_system_nwas_abap_ers_instance_nr + '14') | int }}"
     weight: 1
+    ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
   loop: "{{ (groups['nwas_ascs'] | default([]) ) }}"
   loop_control:
     loop_var: host_node
   when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
-  failed_when: not __ibmcloud_lb_pool_members_nwas_ers10.rc == 0 and not 'already exists in a pool' in __ibmcloud_lb_pool_members_nwas_ers10.stderr
+  failed_when: not __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ers10.rc == 0 and not 'already exists in a pool' in __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ers10.stderr
 
 
 # Create IBM Cloud Load Balancer Front-end Listeners (open port for Virtual IPs)
 
 - name: Create IBM Cloud Load Balancer Front-end Listener for SAP HANA - System DB SQL
-  register: __ibmcloud_lb_frontend_listener_hana1
+  register: __sap_vm_provision_task_ibmcloud_lb_frontend_listener_hana1
   ibm.cloudcollection.ibm_is_lb_listener:
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-hana'))[0].id }}"
-    default_pool: "{{ (__ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-hana-pool-sysdb-sql'))[0].id }}"
+    default_pool: "{{ (__sap_vm_provision_task_ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-hana-pool-sysdb-sql'))[0].id }}"
     protocol: tcp
     port: "{{ ('3' + sap_system_hana_db_instance_nr + '13') | int }}"
+    ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
   when: (groups['hana_secondary'] is defined and (groups['hana_secondary'] | length>0))
-  failed_when: not __ibmcloud_lb_frontend_listener_hana1.rc == 0 and not 'listener_duplicate_port' in __ibmcloud_lb_frontend_listener_hana1.stderr
+  failed_when: not __sap_vm_provision_task_ibmcloud_lb_frontend_listener_hana1.rc == 0 and not 'listener_duplicate_port' in __sap_vm_provision_task_ibmcloud_lb_frontend_listener_hana1.stderr
 
 - name: Create IBM Cloud Load Balancer Front-end Listener for SAP HANA - MDC Tenant 1 SQL
-  register: __ibmcloud_lb_frontend_listener_hana2
+  register: __sap_vm_provision_task_ibmcloud_lb_frontend_listener_hana2
   ibm.cloudcollection.ibm_is_lb_listener:
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-hana'))[0].id }}"
-    default_pool: "{{ (__ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-hana-pool-mdc1-sql'))[0].id }}"
+    default_pool: "{{ (__sap_vm_provision_task_ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-hana-pool-mdc1-sql'))[0].id }}"
     protocol: tcp
     port: "{{ ('3' + sap_system_hana_db_instance_nr + '15') | int }}"
+    ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
   when: (groups['hana_secondary'] is defined and (groups['hana_secondary'] | length>0))
-  failed_when: not __ibmcloud_lb_frontend_listener_hana2.rc == 0 and not 'listener_duplicate_port' in __ibmcloud_lb_frontend_listener_hana2.stderr
+  failed_when: not __sap_vm_provision_task_ibmcloud_lb_frontend_listener_hana2.rc == 0 and not 'listener_duplicate_port' in __sap_vm_provision_task_ibmcloud_lb_frontend_listener_hana2.stderr
 
 - name: Create IBM Cloud Load Balancer Front-end Listener for SAP HANA - startsrv HTTP
-  register: __ibmcloud_lb_frontend_listener_hana3
+  register: __sap_vm_provision_task_ibmcloud_lb_frontend_listener_hana3
   ibm.cloudcollection.ibm_is_lb_listener:
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-hana'))[0].id }}"
-    default_pool: "{{ (__ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-hana-pool-startsrv-http'))[0].id }}"
+    default_pool: "{{ (__sap_vm_provision_task_ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-hana-pool-startsrv-http'))[0].id }}"
     protocol: tcp
     port: "{{ ('5' + sap_system_hana_db_instance_nr + '13') | int }}"
+    ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
   when: (groups['hana_secondary'] is defined and (groups['hana_secondary'] | length>0))
-  failed_when: not __ibmcloud_lb_frontend_listener_hana3.rc == 0 and not 'listener_duplicate_port' in __ibmcloud_lb_frontend_listener_hana3.stderr
+  failed_when: not __sap_vm_provision_task_ibmcloud_lb_frontend_listener_hana3.rc == 0 and not 'listener_duplicate_port' in __sap_vm_provision_task_ibmcloud_lb_frontend_listener_hana3.stderr
 
 - name: Create IBM Cloud Load Balancer Front-end Listener for SAP HANA - startsrv HTTPS
-  register: __ibmcloud_lb_frontend_listener_hana4
+  register: __sap_vm_provision_task_ibmcloud_lb_frontend_listener_hana4
   ibm.cloudcollection.ibm_is_lb_listener:
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-hana'))[0].id }}"
-    default_pool: "{{ (__ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-hana-pool-startsrv-https'))[0].id }}"
+    default_pool: "{{ (__sap_vm_provision_task_ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-hana-pool-startsrv-https'))[0].id }}"
     protocol: tcp
     port: "{{ ('5' + sap_system_hana_db_instance_nr + '14') | int }}"
+    ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
   when: (groups['hana_secondary'] is defined and (groups['hana_secondary'] | length>0))
-  failed_when: not __ibmcloud_lb_frontend_listener_hana4.rc == 0 and not 'listener_duplicate_port' in __ibmcloud_lb_frontend_listener_hana4.stderr
+  failed_when: not __sap_vm_provision_task_ibmcloud_lb_frontend_listener_hana4.rc == 0 and not 'listener_duplicate_port' in __sap_vm_provision_task_ibmcloud_lb_frontend_listener_hana4.stderr
 
 - name: Create IBM Cloud Load Balancer Front-end Listener for SAP AnyDB - IBM Db2 Communication Port
-  register: __ibmcloud_lb_frontend_listener_anydb1
+  register: __sap_vm_provision_task_ibmcloud_lb_frontend_listener_anydb1
   ibm.cloudcollection.ibm_is_lb_listener:
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-anydb'))[0].id }}"
-    default_pool: "{{ (__ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-anydb-pool-ibmdb2'))[0].id }}"
+    default_pool: "{{ (__sap_vm_provision_task_ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-anydb-pool-ibmdb2'))[0].id }}"
     protocol: tcp
     port: 5912
+    ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
   when: (groups['anydb_secondary'] is defined and (groups['anydb_secondary'] | length>0))
-  failed_when: not __ibmcloud_lb_frontend_listener_anydb1.rc == 0 and not 'listener_duplicate_port' in __ibmcloud_lb_frontend_listener_anydb1.stderr
+  failed_when: not __sap_vm_provision_task_ibmcloud_lb_frontend_listener_anydb1.rc == 0 and not 'listener_duplicate_port' in __sap_vm_provision_task_ibmcloud_lb_frontend_listener_anydb1.stderr
 
 - name: Create IBM Cloud Load Balancer Front-end Listener for SAP NetWeaver ASCS - Dispatcher sapdp<ASCS_NN> process
-  register: __ibmcloud_lb_frontend_listener_ascs1
+  register: __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ascs1
   ibm.cloudcollection.ibm_is_lb_listener:
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ascs'))[0].id }}"
-    default_pool: "{{ (__ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-nwas-ascs-pool-dp'))[0].id }}"
+    default_pool: "{{ (__sap_vm_provision_task_ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-nwas-ascs-pool-dp'))[0].id }}"
     protocol: tcp
     port: "{{ ('32' + sap_system_nwas_abap_ascs_instance_nr) | int }}"
+    ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
   when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
-  failed_when: not __ibmcloud_lb_frontend_listener_ascs1.rc == 0 and not 'listener_duplicate_port' in __ibmcloud_lb_frontend_listener_ascs1.stderr
+  failed_when: not __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ascs1.rc == 0 and not 'listener_duplicate_port' in __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ascs1.stderr
 
 - name: Create IBM Cloud Load Balancer Front-end Listener for SAP NetWeaver ASCS - Message Server sapms<SAPSID> process
-  register: __ibmcloud_lb_frontend_listener_ascs2
+  register: __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ascs2
   ibm.cloudcollection.ibm_is_lb_listener:
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ascs'))[0].id }}"
-    default_pool: "{{ (__ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-nwas-ascs-pool-ms'))[0].id }}"
+    default_pool: "{{ (__sap_vm_provision_task_ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-nwas-ascs-pool-ms'))[0].id }}"
     protocol: tcp
     port: "{{ ('36' + sap_system_nwas_abap_ascs_instance_nr) | int }}"
+    ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
   when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
-  failed_when: not __ibmcloud_lb_frontend_listener_ascs2.rc == 0 and not 'listener_duplicate_port' in __ibmcloud_lb_frontend_listener_ascs2.stderr
+  failed_when: not __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ascs2.rc == 0 and not 'listener_duplicate_port' in __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ascs2.stderr
 
 - name: Create IBM Cloud Load Balancer Front-end Listener for SAP NetWeaver ASCS - Enqueue Server sapenq<SAPSID> process
-  register: __ibmcloud_lb_frontend_listener_ascs3
+  register: __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ascs3
   ibm.cloudcollection.ibm_is_lb_listener:
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ascs'))[0].id }}"
-    default_pool: "{{ (__ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-nwas-ascs-pool-enq'))[0].id }}"
+    default_pool: "{{ (__sap_vm_provision_task_ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-nwas-ascs-pool-enq'))[0].id }}"
     protocol: tcp
     port: "{{ ('39' + sap_system_nwas_abap_ascs_instance_nr) | int }}"
+    ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
   when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
-  failed_when: not __ibmcloud_lb_frontend_listener_ascs3.rc == 0 and not 'listener_duplicate_port' in __ibmcloud_lb_frontend_listener_ascs3.stderr
+  failed_when: not __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ascs3.rc == 0 and not 'listener_duplicate_port' in __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ascs3.stderr
 
 - name: Create IBM Cloud Load Balancer Front-end Listener for SAP NetWeaver ASCS - SAP Start Service (SAPControl SOAP) HTTP sapctrl<ASCS_NN> process
-  register: __ibmcloud_lb_frontend_listener_ascs4
+  register: __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ascs4
   ibm.cloudcollection.ibm_is_lb_listener:
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ascs'))[0].id }}"
-    default_pool: "{{ (__ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-nwas-ascs-pool-sapctrl'))[0].id }}"
+    default_pool: "{{ (__sap_vm_provision_task_ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-nwas-ascs-pool-sapctrl'))[0].id }}"
     protocol: tcp
     port: "{{ ('5' + sap_system_nwas_abap_ascs_instance_nr + '13') | int }}"
+    ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
   when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
-  failed_when: not __ibmcloud_lb_frontend_listener_ascs4.rc == 0 and not 'listener_duplicate_port' in __ibmcloud_lb_frontend_listener_ascs4.stderr
+  failed_when: not __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ascs4.rc == 0 and not 'listener_duplicate_port' in __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ascs4.stderr
 
 - name: Create IBM Cloud Load Balancer Front-end Listener for SAP NetWeaver ASCS - SAP Start Service (SAPControl SOAP) HTTPS (Secure) sapctrls<ASCS_NN>
-  register: __ibmcloud_lb_frontend_listener_ascs5
+  register: __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ascs5
   ibm.cloudcollection.ibm_is_lb_listener:
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ascs'))[0].id }}"
-    default_pool: "{{ (__ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-nwas-ascs-pool-sapctrls'))[0].id }}"
+    default_pool: "{{ (__sap_vm_provision_task_ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-nwas-ascs-pool-sapctrls'))[0].id }}"
     protocol: tcp
     port: "{{ ('5' + sap_system_nwas_abap_ascs_instance_nr + '14') | int }}"
+    ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
   when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
-  failed_when: not __ibmcloud_lb_frontend_listener_ascs5.rc == 0 and not 'listener_duplicate_port' in __ibmcloud_lb_frontend_listener_ascs5.stderr
+  failed_when: not __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ascs5.rc == 0 and not 'listener_duplicate_port' in __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ascs5.stderr
 
 # - name: Create IBM Cloud Load Balancer Front-end Listener for SAP NetWeaver ERS - Dispatcher sapdp<ERS_NN> process
-#   register: __ibmcloud_lb_frontend_listener_ers1
+#   register: __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ers1
 #  ibm.cloudcollection.ibm_is_lb_listener:
 #    lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ers'))[0].id }}"
-#    default_pool: "{{ (__ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-nwas-ers-pool-dp'))[0].id }}"
+#    default_pool: "{{ (__sap_vm_provision_task_ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-nwas-ers-pool-dp'))[0].id }}"
 #    protocol: tcp
 #    port: "{{ ('32' + sap_system_nwas_abap_ers_instance_nr) | int }}"
+#    ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
 #   when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
-#   failed_when: not __ibmcloud_lb_frontend_listener_ers1.rc == 0 and not 'listener_duplicate_port' in __ibmcloud_lb_frontend_listener_ers1.stderr
+#   failed_when: not __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ers1.rc == 0 and not 'listener_duplicate_port' in __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ers1.stderr
 
 # - name: Create IBM Cloud Load Balancer Front-end Listener for SAP NetWeaver ERS - Message Server sapms<SAPSID> process
-#   register: __ibmcloud_lb_frontend_listener_ers2
+#   register: __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ers2
 #  ibm.cloudcollection.ibm_is_lb_listener:
 #    lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ers'))[0].id }}"
-#    default_pool: "{{ (__ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-nwas-ers-pool-ms'))[0].id }}"
+#    default_pool: "{{ (__sap_vm_provision_task_ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-nwas-ers-pool-ms'))[0].id }}"
 #    protocol: tcp
 #    port: "{{ ('36' + sap_system_nwas_abap_ers_instance_nr) | int }}"
+#    ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
 #   when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
-#   failed_when: not __ibmcloud_lb_frontend_listener_ers2.rc == 0 and not 'listener_duplicate_port' in __ibmcloud_lb_frontend_listener_ers2.stderr
+#   failed_when: not __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ers2.rc == 0 and not 'listener_duplicate_port' in __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ers2.stderr
 
 - name: Create IBM Cloud Load Balancer Front-end Listener for SAP NetWeaver ERS - Enqueue Replication Server sapenqr<SAPSID> process
-  register: __ibmcloud_lb_frontend_listener_ers3
+  register: __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ers3
   ibm.cloudcollection.ibm_is_lb_listener:
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ers'))[0].id }}"
-    default_pool: "{{ (__ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-nwas-ers-pool-enqr'))[0].id }}"
+    default_pool: "{{ (__sap_vm_provision_task_ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-nwas-ers-pool-enqr'))[0].id }}"
     protocol: tcp
     port: "{{ ('39' + sap_system_nwas_abap_ers_instance_nr) | int }}"
+    ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
   when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
-  failed_when: not __ibmcloud_lb_frontend_listener_ers3.rc == 0 and not 'listener_duplicate_port' in __ibmcloud_lb_frontend_listener_ers3.stderr
+  failed_when: not __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ers3.rc == 0 and not 'listener_duplicate_port' in __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ers3.stderr
 
 - name: Create IBM Cloud Load Balancer Front-end Listener for SAP NetWeaver ERS - SAP Start Service (SAPControl SOAP) HTTP sapctrl<ERS_NN> process
-  register: __ibmcloud_lb_frontend_listener_ers4
+  register: __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ers4
   ibm.cloudcollection.ibm_is_lb_listener:
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ers'))[0].id }}"
-    default_pool: "{{ (__ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-nwas-ers-pool-sapctrl'))[0].id }}"
+    default_pool: "{{ (__sap_vm_provision_task_ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-nwas-ers-pool-sapctrl'))[0].id }}"
     protocol: tcp
     port: "{{ ('5' + sap_system_nwas_abap_ers_instance_nr + '13') | int }}"
+    ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
   when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
-  failed_when: not __ibmcloud_lb_frontend_listener_ers4.rc == 0 and not 'listener_duplicate_port' in __ibmcloud_lb_frontend_listener_ers4.stderr
+  failed_when: not __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ers4.rc == 0 and not 'listener_duplicate_port' in __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ers4.stderr
 
 - name: Create IBM Cloud Load Balancer Front-end Listener for SAP NetWeaver ERS - SAP Start Service (SAPControl SOAP) HTTPS (Secure) sapctrls<ERS_NN>
-  register: __ibmcloud_lb_frontend_listener_ers5
+  register: __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ers5
   ibm.cloudcollection.ibm_is_lb_listener:
     lb: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ers'))[0].id }}"
-    default_pool: "{{ (__ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-nwas-ers-pool-sapctrls'))[0].id }}"
+    default_pool: "{{ (__sap_vm_provision_task_ibmcloud_lb_pools.results | json_query('[*].resource.pools') | flatten | selectattr('name', '==', 'lb-sap-ha-nwas-ers-pool-sapctrls'))[0].id }}"
     protocol: tcp
     port: "{{ ('5' + sap_system_nwas_abap_ers_instance_nr + '14') | int }}"
+    ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
   when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
-  failed_when: not __ibmcloud_lb_frontend_listener_ers5.rc == 0 and not 'listener_duplicate_port' in __ibmcloud_lb_frontend_listener_ers5.stderr
+  failed_when: not __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ers5.rc == 0 and not 'listener_duplicate_port' in __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ers5.stderr
 
 
 # Set DNS A Record for Virtual IP (use the first of the IBM Cloud Load Balancer instance assigned Private IPs in the VPC Subnet Range)
 
 - name: IBM Cloud Private DNS Record for SAP HANA HA Virtual Hostname
-  register: register_ibmcloud_pdns_record_ha_hana
+  register: __sap_vm_provision_task_ibmcloud_pdns_record_ha_hana
   ibm.cloudcollection.ibm_dns_resource_record:
-    instance_id: "{{ register_ibmcloud_pdns_service_instance.resource.guid }}"
-    zone_id: "{{ (register_ibmcloud_pdns.resource.dns_zones | selectattr('name', '==', sap_vm_provision_dns_root_domain) | first).zone_id }}"
+    instance_id: "{{ __sap_vm_provision_task_ibmcloud_pdns_service_instance.resource.guid }}"
+    zone_id: "{{ (__sap_vm_provision_task_ibmcloud_pdns.resource.dns_zones | selectattr('name', '==', sap_vm_provision_dns_root_domain) | first).zone_id }}"
     name: "{{ sap_swpm_db_host }}.{{ hostvars[host_node].sap_vm_provision_dns_root_domain }}" # Host FQDN
     rdata: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-hana'))[0].private_ips[0].address }}" # IP Address
     type: A
     ttl: 7200
-  failed_when: not register_ibmcloud_pdns_record.rc == 0 and not 'The record already exists' in register_ibmcloud_pdns_record.stderr
+    ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
+  failed_when: not __sap_vm_provision_task_ibmcloud_pdns_record.rc == 0 and not 'The record already exists' in __sap_vm_provision_task_ibmcloud_pdns_record.stderr
   loop: "{{ (groups['hana_primary'] | default([])) }}"
   loop_control:
     loop_var: host_node
@@ -954,15 +1027,16 @@
     - groups["hana_secondary"] is defined and (groups["hana_secondary"]|length>0)
 
 - name: IBM Cloud Private DNS Record for SAP AnyDB HA Virtual Hostname
-  register: register_ibmcloud_pdns_record_ha_anydb
+  register: __sap_vm_provision_task_ibmcloud_pdns_record_ha_anydb
   ibm.cloudcollection.ibm_dns_resource_record:
-    instance_id: "{{ register_ibmcloud_pdns_service_instance.resource.guid }}"
-    zone_id: "{{ (register_ibmcloud_pdns.resource.dns_zones | selectattr('name', '==', sap_vm_provision_dns_root_domain) | first).zone_id }}"
+    instance_id: "{{ __sap_vm_provision_task_ibmcloud_pdns_service_instance.resource.guid }}"
+    zone_id: "{{ (__sap_vm_provision_task_ibmcloud_pdns.resource.dns_zones | selectattr('name', '==', sap_vm_provision_dns_root_domain) | first).zone_id }}"
     name: "{{ sap_swpm_db_host }}.{{ hostvars[host_node].sap_vm_provision_dns_root_domain }}" # Host FQDN
     rdata: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-anydb'))[0].private_ips[0].address }}" # IP Address
     type: A
     ttl: 7200
-  failed_when: not register_ibmcloud_pdns_record.rc == 0 and not 'The record already exists' in register_ibmcloud_pdns_record.stderr
+    ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
+  failed_when: not __sap_vm_provision_task_ibmcloud_pdns_record.rc == 0 and not 'The record already exists' in __sap_vm_provision_task_ibmcloud_pdns_record.stderr
   loop: "{{ (groups['anydb_primary'] | default([])) }}"
   loop_control:
     loop_var: host_node
@@ -970,15 +1044,16 @@
     - groups["anydb_secondary"] is defined and (groups["anydb_secondary"]|length>0)
 
 - name: IBM Cloud Private DNS Record for SAP NetWeaver ASCS HA Virtual Hostname
-  register: register_ibmcloud_pdns_record_ha_nwas_ascs
+  register: __sap_vm_provision_task_ibmcloud_pdns_record_ha_nwas_ascs
   ibm.cloudcollection.ibm_dns_resource_record:
-    instance_id: "{{ register_ibmcloud_pdns_service_instance.resource.guid }}"
-    zone_id: "{{ (register_ibmcloud_pdns.resource.dns_zones | selectattr('name', '==', sap_vm_provision_dns_root_domain) | first).zone_id }}"
+    instance_id: "{{ __sap_vm_provision_task_ibmcloud_pdns_service_instance.resource.guid }}"
+    zone_id: "{{ (__sap_vm_provision_task_ibmcloud_pdns.resource.dns_zones | selectattr('name', '==', sap_vm_provision_dns_root_domain) | first).zone_id }}"
     name: "{{ sap_swpm_ascs_instance_hostname }}.{{ hostvars[host_node].sap_vm_provision_dns_root_domain }}" # Host FQDN
     rdata: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ascs'))[0].private_ips[0].address }}" # IP Address
     type: A
     ttl: 7200
-  failed_when: not register_ibmcloud_pdns_record.rc == 0 and not 'The record already exists' in register_ibmcloud_pdns_record.stderr
+    ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
+  failed_when: not __sap_vm_provision_task_ibmcloud_pdns_record.rc == 0 and not 'The record already exists' in __sap_vm_provision_task_ibmcloud_pdns_record.stderr
   loop: "{{ (groups['nwas_ascs'] | default([])) }}"
   loop_control:
     loop_var: host_node
@@ -986,15 +1061,16 @@
     - groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
 
 - name: IBM Cloud Private DNS Record for SAP NetWeaver ERS HA Virtual Hostname
-  register: register_ibmcloud_pdns_record_ha_nwas_ers
+  register: __sap_vm_provision_task_ibmcloud_pdns_record_ha_nwas_ers
   ibm.cloudcollection.ibm_dns_resource_record:
-    instance_id: "{{ register_ibmcloud_pdns_service_instance.resource.guid }}"
-    zone_id: "{{ (register_ibmcloud_pdns.resource.dns_zones | selectattr('name', '==', sap_vm_provision_dns_root_domain) | first).zone_id }}"
+    instance_id: "{{ __sap_vm_provision_task_ibmcloud_pdns_service_instance.resource.guid }}"
+    zone_id: "{{ (__sap_vm_provision_task_ibmcloud_pdns.resource.dns_zones | selectattr('name', '==', sap_vm_provision_dns_root_domain) | first).zone_id }}"
     name: "{{ sap_swpm_ers_instance_hostname }}.{{ hostvars[host_node].sap_vm_provision_dns_root_domain }}" # Host FQDN
     rdata: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ers'))[0].private_ips[0].address }}" # IP Address
     type: A
     ttl: 7200
-  failed_when: not register_ibmcloud_pdns_record.rc == 0 and not 'The record already exists' in register_ibmcloud_pdns_record.stderr
+    ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
+  failed_when: not __sap_vm_provision_task_ibmcloud_pdns_record.rc == 0 and not 'The record already exists' in __sap_vm_provision_task_ibmcloud_pdns_record.stderr
   loop: "{{ (groups['nwas_ers'] | default([])) }}"
   loop_control:
     loop_var: host_node

--- a/roles/sap_vm_provision/tasks/platform_ansible/ibmcloud_vs/post_deployment_execute.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/ibmcloud_vs/post_deployment_execute.yml
@@ -13,8 +13,8 @@
   delegate_to: localhost
   run_once: true
   environment:
-    IC_API_KEY: "{{ sap_vm_provision_ibmcloud_api_key }}" # For legacy Ansible Collection
-    IBMCLOUD_API_KEY: "{{ sap_vm_provision_ibmcloud_api_key }}" # For IBM Cloud CLI quiet login
+    # IC_API_KEY: "{{ sap_vm_provision_ibmcloud_api_key }}" # For legacy Ansible Collection
+    # IBMCLOUD_API_KEY: "{{ sap_vm_provision_ibmcloud_api_key }}" # For IBM Cloud CLI quiet login
     IC_REGION: "{{ sap_vm_provision_ibmcloud_region }}"
   when:
     - sap_ha_pacemaker_cluster_ibmcloud_region is defined
@@ -54,7 +54,7 @@
 
     # Workaround for bug which populates region and ibmcloud_api_key as TF arguments for ibm_is_lbs_info Ansible Module in legacy Ansible Collection
     - name: IBM Cloud CLI execution to list Load Balancer/s info
-      register: ibmcloud_lbs_all_info_shell
+      register: __sap_vm_provision_task_ibmcloud_lb_all_info_shell
       ansible.builtin.shell: |
         ibmcloud config --quiet --check-version false && ibmcloud login -g {{ sap_vm_provision_ibmcloud_resource_group_name }} -r {{ sap_vm_provision_ibmcloud_region }} --quiet
         #ibmcloud plugin install infrastructure-service -f --quiet
@@ -62,7 +62,7 @@
 
     - name: Set fact for IBM Cloud Load Balancer/s info
       ansible.builtin.set_fact:
-        ibmcloud_lbs_all_info: "{{ ibmcloud_lbs_all_info_shell.stdout | split('Space:') | last | trim | from_json }}"
+        ibmcloud_lbs_all_info: "{{ __sap_vm_provision_task_ibmcloud_lb_all_info_shell.stdout | split('Space:') | last | trim | from_json }}"
 
     - name: Set fact for IBM Cloud Load Balancer Back-end Pools to target
       ansible.builtin.set_fact:
@@ -77,9 +77,10 @@
       when: "('lb-sap-ha-hana' in item.name) or ('lb-sap-ha-anydb' in item.name) or ('lb-sap-ha-nwas-ascs' in item.name) or ('lb-sap-ha-nwas-ers' in item.name)"
 
     # - name: Identify IBM Cloud Load Balancer Back-end Pools
-    #   register: __ibmcloud_lb_pools
+    #   register: __sap_vm_provision_task_ibmcloud_lb_pools
     #   ibm.cloudcollection.ibm_is_lb_pools_info:
     #     lb: "{{ item.id }}"
+    #     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
     #   loop: "{{ ibmcloud_lbs_all_info }}"
     #   loop_control:
     #     label: "{{ item.name }}"
@@ -87,7 +88,7 @@
 
 
     - name: Update IBM Cloud Load Balancer Back-end Pool Health Check Port to Linux Pacemaker controlled listening port for SAP HANA - System DB SQL
-      register: __ibmcloud_lb_pool_hana1
+      register: __sap_vm_provision_task_ibmcloud_lb_pool_hana1
       ibm.cloudcollection.ibm_is_lb_pool:
         id: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-hana'))[0].id }}/{{ ((ibmcloud_lbs_all_info | json_query('[*].pools') | flatten) | selectattr('name', '==', 'lb-sap-ha-hana-pool-sysdb-sql') | first).id }}"
         name: lb-sap-ha-hana-pool-sysdb-sql
@@ -99,10 +100,11 @@
         health_timeout: 10
         health_type: tcp
         health_monitor_port: "{{ ibmcloud_lb_pool_healthcheck_hana }}"
+        ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
       when: (groups['hana_secondary'] is defined and (groups['hana_secondary'] | length>0))
 
     - name: Update IBM Cloud Load Balancer Back-end Pool Health Check Port to Linux Pacemaker controlled listening port for SAP HANA - MDC Tenant 1 SQL
-      register: __ibmcloud_lb_pool_hana2
+      register: __sap_vm_provision_task_ibmcloud_lb_pool_hana2
       ibm.cloudcollection.ibm_is_lb_pool:
         id: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-hana'))[0].id }}/{{ ((ibmcloud_lbs_all_info | json_query('[*].pools') | flatten) | selectattr('name', '==', 'lb-sap-ha-hana-pool-mdc1-sql') | first).id }}"
         name: lb-sap-ha-hana-pool-mdc1-sql
@@ -114,10 +116,11 @@
         health_timeout: 10
         health_type: tcp
         health_monitor_port: "{{ ibmcloud_lb_pool_healthcheck_hana }}"
+        ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
       when: (groups['hana_secondary'] is defined and (groups['hana_secondary'] | length>0))
 
     - name: Update IBM Cloud Load Balancer Back-end Pool Health Check Port to Linux Pacemaker controlled listening port for SAP HANA - startsrv HTTP
-      register: __ibmcloud_lb_pool_hana3
+      register: __sap_vm_provision_task_ibmcloud_lb_pool_hana3
       ibm.cloudcollection.ibm_is_lb_pool:
         id: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-hana'))[0].id }}/{{ ((ibmcloud_lbs_all_info | json_query('[*].pools') | flatten) | selectattr('name', '==', 'lb-sap-ha-hana-pool-startsrv-http') | first).id }}"
         name: lb-sap-ha-hana-pool-startsrv-http
@@ -129,10 +132,11 @@
         health_timeout: 10
         health_type: tcp
         health_monitor_port: "{{ ibmcloud_lb_pool_healthcheck_hana }}"
+        ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
       when: (groups['hana_secondary'] is defined and (groups['hana_secondary'] | length>0))
 
     - name: Update IBM Cloud Load Balancer Back-end Pool Health Check Port to Linux Pacemaker controlled listening port for SAP HANA - startsrv HTTPS
-      register: __ibmcloud_lb_pool_hana4
+      register: __sap_vm_provision_task_ibmcloud_lb_pool_hana4
       ibm.cloudcollection.ibm_is_lb_pool:
         id: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-hana'))[0].id }}/{{ ((ibmcloud_lbs_all_info | json_query('[*].pools') | flatten) | selectattr('name', '==', 'lb-sap-ha-hana-pool-startsrv-https') | first).id }}"
         name: lb-sap-ha-hana-pool-startsrv-https
@@ -144,6 +148,7 @@
         health_timeout: 10
         health_type: tcp
         health_monitor_port: "{{ ibmcloud_lb_pool_healthcheck_hana }}"
+        ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
       when: (groups['hana_secondary'] is defined and (groups['hana_secondary'] | length>0))
 
     - name: Update IBM Cloud Load Balancer Back-end Pool Health Check Port to Linux Pacemaker controlled listening port for SAP AnyDB - IBM Db2 Communication Port
@@ -158,10 +163,11 @@
         health_timeout: 10
         health_type: tcp
         health_monitor_port: 62700
+        ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
       when: (groups['anydb_secondary'] is defined and (groups['anydb_secondary'] | length>0))
 
     - name: Update IBM Cloud Load Balancer Back-end Pool Health Check Port to Linux Pacemaker controlled listening port for SAP NetWeaver ASCS - Dispatcher sapdp<ASCS_NN> process
-      register: __ibmcloud_lb_pool_nwas_ascs1
+      register: __sap_vm_provision_task_ibmcloud_lb_pool_nwas_ascs1
       ibm.cloudcollection.ibm_is_lb_pool:
         id: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ascs'))[0].id }}/{{ ((ibmcloud_lbs_all_info | json_query('[*].pools') | flatten) | selectattr('name', '==', 'lb-sap-ha-nwas-ascs-pool-dp') | first).id }}"
         name: lb-sap-ha-nwas-ascs-pool-dp
@@ -173,10 +179,11 @@
         health_timeout: 10
         health_type: tcp
         health_monitor_port: "{{ ibmcloud_lb_pool_healthcheck_nwas_ascs }}"
+        ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
       when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
 
     - name: Update IBM Cloud Load Balancer Back-end Pool Health Check Port to Linux Pacemaker controlled listening port for SAP NetWeaver ASCS - Message Server sapms<SAPSID> process
-      register: __ibmcloud_lb_pool_nwas_ascs2
+      register: __sap_vm_provision_task_ibmcloud_lb_pool_nwas_ascs2
       ibm.cloudcollection.ibm_is_lb_pool:
         id: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ascs'))[0].id }}/{{ ((ibmcloud_lbs_all_info | json_query('[*].pools') | flatten) | selectattr('name', '==', 'lb-sap-ha-nwas-ascs-pool-ms') | first).id }}"
         name: lb-sap-ha-nwas-ascs-pool-ms
@@ -188,10 +195,11 @@
         health_timeout: 10
         health_type: tcp
         health_monitor_port: "{{ ibmcloud_lb_pool_healthcheck_nwas_ascs }}"
+        ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
       when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
 
     - name: Update IBM Cloud Load Balancer Back-end Pool Health Check Port to Linux Pacemaker controlled listening port for SAP NetWeaver ASCS - Enqueue Server sapenq<SAPSID> process
-      register: __ibmcloud_lb_pool_nwas_ascs3
+      register: __sap_vm_provision_task_ibmcloud_lb_pool_nwas_ascs3
       ibm.cloudcollection.ibm_is_lb_pool:
         id: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ascs'))[0].id }}/{{ ((ibmcloud_lbs_all_info | json_query('[*].pools') | flatten) | selectattr('name', '==', 'lb-sap-ha-nwas-ascs-pool-enq') | first).id }}"
         name: lb-sap-ha-nwas-ascs-pool-enq
@@ -203,10 +211,11 @@
         health_timeout: 10
         health_type: tcp
         health_monitor_port: "{{ ibmcloud_lb_pool_healthcheck_nwas_ascs }}"
+        ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
       when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
 
     - name: Update IBM Cloud Load Balancer Back-end Pool Health Check Port to Linux Pacemaker controlled listening port for SAP NetWeaver ASCS - SAP Start Service (SAPControl SOAP) HTTP sapctrl<ASCS_NN> process
-      register: __ibmcloud_lb_pool_nwas_ascs4
+      register: __sap_vm_provision_task_ibmcloud_lb_pool_nwas_ascs4
       ibm.cloudcollection.ibm_is_lb_pool:
         id: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ascs'))[0].id }}/{{ ((ibmcloud_lbs_all_info | json_query('[*].pools') | flatten) | selectattr('name', '==', 'lb-sap-ha-nwas-ascs-pool-sapctrl') | first).id }}"
         name: lb-sap-ha-nwas-ascs-pool-sapctrl
@@ -218,10 +227,11 @@
         health_timeout: 10
         health_type: tcp
         health_monitor_port: "{{ ibmcloud_lb_pool_healthcheck_nwas_ascs }}"
+        ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
       when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
 
     - name: Update IBM Cloud Load Balancer Back-end Pool Health Check Port to Linux Pacemaker controlled listening port for SAP NetWeaver ASCS - SAP Start Service (SAPControl SOAP) HTTPS (Secure) sapctrls<ASCS_NN>
-      register: __ibmcloud_lb_pool_nwas_ascs5
+      register: __sap_vm_provision_task_ibmcloud_lb_pool_nwas_ascs5
       ibm.cloudcollection.ibm_is_lb_pool:
         id: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ascs'))[0].id }}/{{ ((ibmcloud_lbs_all_info | json_query('[*].pools') | flatten) | selectattr('name', '==', 'lb-sap-ha-nwas-ascs-pool-sapctrls') | first).id }}"
         name: lb-sap-ha-nwas-ascs-pool-sapctrls
@@ -233,10 +243,11 @@
         health_timeout: 10
         health_type: tcp
         health_monitor_port: "{{ ibmcloud_lb_pool_healthcheck_nwas_ascs }}"
+        ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
       when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
 
     # - name: Update IBM Cloud Load Balancer Back-end Pool Health Check Port to Linux Pacemaker controlled listening port for SAP NetWeaver ERS - Dispatcher sapdp<ERS_NN> process
-    #   register: __ibmcloud_lb_pool_nwas_ers1
+    #   register: __sap_vm_provision_task_ibmcloud_lb_pool_nwas_ers1
     #   ibm.cloudcollection.ibm_is_lb_pool:
     #     id: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ers'))[0].id }}/{{ ((ibmcloud_lbs_all_info | json_query('[*].pools') | flatten) | selectattr('name', '==', 'lb-sap-ha-nwas-ers-pool-dp') | first).id }}"
     #     name: lb-sap-ha-nwas-ers-pool-dp
@@ -248,10 +259,11 @@
     #     health_timeout: 10
     #     health_type: tcp
     #     health_monitor_port: "{{ ibmcloud_lb_pool_healthcheck_nwas_ers }}"
+    #     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
     #   when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
 
     # - name: Update IBM Cloud Load Balancer Back-end Pool Health Check Port to Linux Pacemaker controlled listening port for SAP NetWeaver ERS - Message Server sapms<SAPSID> process
-    #   register: __ibmcloud_lb_pool_nwas_ers2
+    #   register: __sap_vm_provision_task_ibmcloud_lb_pool_nwas_ers2
     #   ibm.cloudcollection.ibm_is_lb_pool:
     #     id: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ers'))[0].id }}/{{ ((ibmcloud_lbs_all_info | json_query('[*].pools') | flatten) | selectattr('name', '==', 'lb-sap-ha-nwas-ers-pool-ms') | first).id }}"
     #     name: lb-sap-ha-nwas-ers-pool-ms
@@ -263,10 +275,11 @@
     #     health_timeout: 10
     #     health_type: tcp
     #     health_monitor_port: "{{ ibmcloud_lb_pool_healthcheck_nwas_ers }}"
+    #     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
     #   when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
 
     - name: Update IBM Cloud Load Balancer Back-end Pool Health Check Port to Linux Pacemaker controlled listening port for SAP NetWeaver ERS - Enqueue Replication Server sapenqr<SAPSID> process
-      register: __ibmcloud_lb_pool_nwas_ers3
+      register: __sap_vm_provision_task_ibmcloud_lb_pool_nwas_ers3
       ibm.cloudcollection.ibm_is_lb_pool:
         id: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ers'))[0].id }}/{{ ((ibmcloud_lbs_all_info | json_query('[*].pools') | flatten) | selectattr('name', '==', 'lb-sap-ha-nwas-ers-pool-enqr') | first).id }}"
         name: lb-sap-ha-nwas-ers-pool-enqr
@@ -278,10 +291,11 @@
         health_timeout: 10
         health_type: tcp
         health_monitor_port: "{{ ibmcloud_lb_pool_healthcheck_nwas_ers }}"
+        ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
       when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
 
     - name: Update IBM Cloud Load Balancer Back-end Pool Health Check Port to Linux Pacemaker controlled listening port for SAP NetWeaver ERS - SAP Start Service (SAPControl SOAP) HTTP sapctrl<ERS_NN> process
-      register: __ibmcloud_lb_pool_nwas_ers4
+      register: __sap_vm_provision_task_ibmcloud_lb_pool_nwas_ers4
       ibm.cloudcollection.ibm_is_lb_pool:
         id: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ers'))[0].id }}/{{ ((ibmcloud_lbs_all_info | json_query('[*].pools') | flatten) | selectattr('name', '==', 'lb-sap-ha-nwas-ers-pool-sapctrl') | first).id }}"
         name: lb-sap-ha-nwas-ers-pool-sapctrl
@@ -293,10 +307,11 @@
         health_timeout: 10
         health_type: tcp
         health_monitor_port: "{{ ibmcloud_lb_pool_healthcheck_nwas_ers }}"
+        ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
       when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
 
     - name: Update IBM Cloud Load Balancer Back-end Pool Health Check Port to Linux Pacemaker controlled listening port for SAP NetWeaver ERS - SAP Start Service (SAPControl SOAP) HTTPS (Secure) sapctrls<ERS_NN>
-      register: __ibmcloud_lb_pool_nwas_ers5
+      register: __sap_vm_provision_task_ibmcloud_lb_pool_nwas_ers5
       ibm.cloudcollection.ibm_is_lb_pool:
         id: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ers'))[0].id }}/{{ ((ibmcloud_lbs_all_info | json_query('[*].pools') | flatten) | selectattr('name', '==', 'lb-sap-ha-nwas-ers-pool-sapctrls') | first).id }}"
         name: lb-sap-ha-nwas-ers-pool-sapctrls
@@ -308,4 +323,5 @@
         health_timeout: 10
         health_type: tcp
         health_monitor_port: "{{ ibmcloud_lb_pool_healthcheck_nwas_ers }}"
+        ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
       when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))

--- a/roles/sap_vm_provision/tasks/platform_ansible/ibmcloud_vs/post_deployment_execute.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/ibmcloud_vs/post_deployment_execute.yml
@@ -77,6 +77,7 @@
       when: "('lb-sap-ha-hana' in item.name) or ('lb-sap-ha-anydb' in item.name) or ('lb-sap-ha-nwas-ascs' in item.name) or ('lb-sap-ha-nwas-ers' in item.name)"
 
     # - name: Identify IBM Cloud Load Balancer Back-end Pools
+    #   no_log: "{{ __sap_vm_provision_no_log }}"
     #   register: __sap_vm_provision_task_ibmcloud_lb_pools
     #   ibm.cloudcollection.ibm_is_lb_pools_info:
     #     lb: "{{ item.id }}"
@@ -88,6 +89,7 @@
 
 
     - name: Update IBM Cloud Load Balancer Back-end Pool Health Check Port to Linux Pacemaker controlled listening port for SAP HANA - System DB SQL
+      no_log: "{{ __sap_vm_provision_no_log }}"
       register: __sap_vm_provision_task_ibmcloud_lb_pool_hana1
       ibm.cloudcollection.ibm_is_lb_pool:
         id: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-hana'))[0].id }}/{{ ((ibmcloud_lbs_all_info | json_query('[*].pools') | flatten) | selectattr('name', '==', 'lb-sap-ha-hana-pool-sysdb-sql') | first).id }}"
@@ -104,6 +106,7 @@
       when: (groups['hana_secondary'] is defined and (groups['hana_secondary'] | length>0))
 
     - name: Update IBM Cloud Load Balancer Back-end Pool Health Check Port to Linux Pacemaker controlled listening port for SAP HANA - MDC Tenant 1 SQL
+      no_log: "{{ __sap_vm_provision_no_log }}"
       register: __sap_vm_provision_task_ibmcloud_lb_pool_hana2
       ibm.cloudcollection.ibm_is_lb_pool:
         id: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-hana'))[0].id }}/{{ ((ibmcloud_lbs_all_info | json_query('[*].pools') | flatten) | selectattr('name', '==', 'lb-sap-ha-hana-pool-mdc1-sql') | first).id }}"
@@ -120,6 +123,7 @@
       when: (groups['hana_secondary'] is defined and (groups['hana_secondary'] | length>0))
 
     - name: Update IBM Cloud Load Balancer Back-end Pool Health Check Port to Linux Pacemaker controlled listening port for SAP HANA - startsrv HTTP
+      no_log: "{{ __sap_vm_provision_no_log }}"
       register: __sap_vm_provision_task_ibmcloud_lb_pool_hana3
       ibm.cloudcollection.ibm_is_lb_pool:
         id: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-hana'))[0].id }}/{{ ((ibmcloud_lbs_all_info | json_query('[*].pools') | flatten) | selectattr('name', '==', 'lb-sap-ha-hana-pool-startsrv-http') | first).id }}"
@@ -136,6 +140,7 @@
       when: (groups['hana_secondary'] is defined and (groups['hana_secondary'] | length>0))
 
     - name: Update IBM Cloud Load Balancer Back-end Pool Health Check Port to Linux Pacemaker controlled listening port for SAP HANA - startsrv HTTPS
+      no_log: "{{ __sap_vm_provision_no_log }}"
       register: __sap_vm_provision_task_ibmcloud_lb_pool_hana4
       ibm.cloudcollection.ibm_is_lb_pool:
         id: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-hana'))[0].id }}/{{ ((ibmcloud_lbs_all_info | json_query('[*].pools') | flatten) | selectattr('name', '==', 'lb-sap-ha-hana-pool-startsrv-https') | first).id }}"
@@ -152,6 +157,7 @@
       when: (groups['hana_secondary'] is defined and (groups['hana_secondary'] | length>0))
 
     - name: Update IBM Cloud Load Balancer Back-end Pool Health Check Port to Linux Pacemaker controlled listening port for SAP AnyDB - IBM Db2 Communication Port
+      no_log: "{{ __sap_vm_provision_no_log }}"
       ibm.cloudcollection.ibm_is_lb_pool:
         id: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-anydb'))[0].id }}/{{ ((ibmcloud_lbs_all_info | json_query('[*].pools') | flatten) | selectattr('name', '==', 'lb-sap-ha-anydb-pool-ibmdb2') | first).id }}"
         name: lb-sap-ha-anydb-pool-ibmdb2
@@ -167,6 +173,7 @@
       when: (groups['anydb_secondary'] is defined and (groups['anydb_secondary'] | length>0))
 
     - name: Update IBM Cloud Load Balancer Back-end Pool Health Check Port to Linux Pacemaker controlled listening port for SAP NetWeaver ASCS - Dispatcher sapdp<ASCS_NN> process
+      no_log: "{{ __sap_vm_provision_no_log }}"
       register: __sap_vm_provision_task_ibmcloud_lb_pool_nwas_ascs1
       ibm.cloudcollection.ibm_is_lb_pool:
         id: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ascs'))[0].id }}/{{ ((ibmcloud_lbs_all_info | json_query('[*].pools') | flatten) | selectattr('name', '==', 'lb-sap-ha-nwas-ascs-pool-dp') | first).id }}"
@@ -183,6 +190,7 @@
       when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
 
     - name: Update IBM Cloud Load Balancer Back-end Pool Health Check Port to Linux Pacemaker controlled listening port for SAP NetWeaver ASCS - Message Server sapms<SAPSID> process
+      no_log: "{{ __sap_vm_provision_no_log }}"
       register: __sap_vm_provision_task_ibmcloud_lb_pool_nwas_ascs2
       ibm.cloudcollection.ibm_is_lb_pool:
         id: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ascs'))[0].id }}/{{ ((ibmcloud_lbs_all_info | json_query('[*].pools') | flatten) | selectattr('name', '==', 'lb-sap-ha-nwas-ascs-pool-ms') | first).id }}"
@@ -199,6 +207,7 @@
       when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
 
     - name: Update IBM Cloud Load Balancer Back-end Pool Health Check Port to Linux Pacemaker controlled listening port for SAP NetWeaver ASCS - Enqueue Server sapenq<SAPSID> process
+      no_log: "{{ __sap_vm_provision_no_log }}"
       register: __sap_vm_provision_task_ibmcloud_lb_pool_nwas_ascs3
       ibm.cloudcollection.ibm_is_lb_pool:
         id: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ascs'))[0].id }}/{{ ((ibmcloud_lbs_all_info | json_query('[*].pools') | flatten) | selectattr('name', '==', 'lb-sap-ha-nwas-ascs-pool-enq') | first).id }}"
@@ -215,6 +224,7 @@
       when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
 
     - name: Update IBM Cloud Load Balancer Back-end Pool Health Check Port to Linux Pacemaker controlled listening port for SAP NetWeaver ASCS - SAP Start Service (SAPControl SOAP) HTTP sapctrl<ASCS_NN> process
+      no_log: "{{ __sap_vm_provision_no_log }}"
       register: __sap_vm_provision_task_ibmcloud_lb_pool_nwas_ascs4
       ibm.cloudcollection.ibm_is_lb_pool:
         id: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ascs'))[0].id }}/{{ ((ibmcloud_lbs_all_info | json_query('[*].pools') | flatten) | selectattr('name', '==', 'lb-sap-ha-nwas-ascs-pool-sapctrl') | first).id }}"
@@ -231,6 +241,7 @@
       when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
 
     - name: Update IBM Cloud Load Balancer Back-end Pool Health Check Port to Linux Pacemaker controlled listening port for SAP NetWeaver ASCS - SAP Start Service (SAPControl SOAP) HTTPS (Secure) sapctrls<ASCS_NN>
+      no_log: "{{ __sap_vm_provision_no_log }}"
       register: __sap_vm_provision_task_ibmcloud_lb_pool_nwas_ascs5
       ibm.cloudcollection.ibm_is_lb_pool:
         id: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ascs'))[0].id }}/{{ ((ibmcloud_lbs_all_info | json_query('[*].pools') | flatten) | selectattr('name', '==', 'lb-sap-ha-nwas-ascs-pool-sapctrls') | first).id }}"
@@ -247,6 +258,7 @@
       when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
 
     # - name: Update IBM Cloud Load Balancer Back-end Pool Health Check Port to Linux Pacemaker controlled listening port for SAP NetWeaver ERS - Dispatcher sapdp<ERS_NN> process
+    #   no_log: "{{ __sap_vm_provision_no_log }}"
     #   register: __sap_vm_provision_task_ibmcloud_lb_pool_nwas_ers1
     #   ibm.cloudcollection.ibm_is_lb_pool:
     #     id: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ers'))[0].id }}/{{ ((ibmcloud_lbs_all_info | json_query('[*].pools') | flatten) | selectattr('name', '==', 'lb-sap-ha-nwas-ers-pool-dp') | first).id }}"
@@ -263,6 +275,7 @@
     #   when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
 
     # - name: Update IBM Cloud Load Balancer Back-end Pool Health Check Port to Linux Pacemaker controlled listening port for SAP NetWeaver ERS - Message Server sapms<SAPSID> process
+    #   no_log: "{{ __sap_vm_provision_no_log }}"
     #   register: __sap_vm_provision_task_ibmcloud_lb_pool_nwas_ers2
     #   ibm.cloudcollection.ibm_is_lb_pool:
     #     id: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ers'))[0].id }}/{{ ((ibmcloud_lbs_all_info | json_query('[*].pools') | flatten) | selectattr('name', '==', 'lb-sap-ha-nwas-ers-pool-ms') | first).id }}"
@@ -279,6 +292,7 @@
     #   when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
 
     - name: Update IBM Cloud Load Balancer Back-end Pool Health Check Port to Linux Pacemaker controlled listening port for SAP NetWeaver ERS - Enqueue Replication Server sapenqr<SAPSID> process
+      no_log: "{{ __sap_vm_provision_no_log }}"
       register: __sap_vm_provision_task_ibmcloud_lb_pool_nwas_ers3
       ibm.cloudcollection.ibm_is_lb_pool:
         id: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ers'))[0].id }}/{{ ((ibmcloud_lbs_all_info | json_query('[*].pools') | flatten) | selectattr('name', '==', 'lb-sap-ha-nwas-ers-pool-enqr') | first).id }}"
@@ -295,6 +309,7 @@
       when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
 
     - name: Update IBM Cloud Load Balancer Back-end Pool Health Check Port to Linux Pacemaker controlled listening port for SAP NetWeaver ERS - SAP Start Service (SAPControl SOAP) HTTP sapctrl<ERS_NN> process
+      no_log: "{{ __sap_vm_provision_no_log }}"
       register: __sap_vm_provision_task_ibmcloud_lb_pool_nwas_ers4
       ibm.cloudcollection.ibm_is_lb_pool:
         id: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ers'))[0].id }}/{{ ((ibmcloud_lbs_all_info | json_query('[*].pools') | flatten) | selectattr('name', '==', 'lb-sap-ha-nwas-ers-pool-sapctrl') | first).id }}"
@@ -311,6 +326,7 @@
       when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
 
     - name: Update IBM Cloud Load Balancer Back-end Pool Health Check Port to Linux Pacemaker controlled listening port for SAP NetWeaver ERS - SAP Start Service (SAPControl SOAP) HTTPS (Secure) sapctrls<ERS_NN>
+      no_log: "{{ __sap_vm_provision_no_log }}"
       register: __sap_vm_provision_task_ibmcloud_lb_pool_nwas_ers5
       ibm.cloudcollection.ibm_is_lb_pool:
         id: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', 'lb-sap-ha-nwas-ers'))[0].id }}/{{ ((ibmcloud_lbs_all_info | json_query('[*].pools') | flatten) | selectattr('name', '==', 'lb-sap-ha-nwas-ers-pool-sapctrls') | first).id }}"

--- a/roles/sap_vm_provision/tasks/platform_ansible/ibmpowervm_vm/execute_main.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/ibmpowervm_vm/execute_main.yml
@@ -42,14 +42,14 @@
   throttle: 1
 
 - name: Provision hosts to IBM PowerVM
-  register: register_provisioned_hosts
+  register: __sap_vm_provision_task_provision_host_all_run
   ansible.builtin.include_tasks:
     file: "{{ 'platform_' + sap_vm_provision_iac_type }}/{{ sap_vm_provision_iac_platform }}/execute_provision.yml"
   vars:
     openstack_auth_delegate: "{{ openstack_auth }}"
 
 - name: Add hosts provisioned to the Ansible Inventory
-  register: register_add_hosts
+  register: __sap_vm_provision_task_provision_host_all_add
   ansible.builtin.add_host:
     name: "{{ add_item[0].host_node }}"
     groups: "{{ add_item[0].sap_system_type + '_' if (add_item[0].sap_system_type != '') }}{{ add_item[0].sap_host_type }}"
@@ -76,7 +76,7 @@
     file: common/set_ansible_vars.yml
 
   #  - ansible.builtin.debug:
-  #      var: register_add_hosts.results
+  #      var: __sap_vm_provision_task_provision_host_all_add.results
 
 - name: Ansible Task block to execute on target inventory hosts
   delegate_to: "{{ inventory_hostname }}"

--- a/roles/sap_vm_provision/tasks/platform_ansible/ibmpowervm_vm/execute_main.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/ibmpowervm_vm/execute_main.yml
@@ -45,11 +45,11 @@
       no_log: "{{ __sap_vm_provision_no_log }}"
       register: __sap_vm_provision_task_ibmpowervm_ssh_public_key
       openstack.cloud.keypair:
-        auth: "{{ __sap_vm_provision_task_ibmpowervm_openstack_auth }}"
-        validate_certs: false # Allow Self-Signed Certificate
         state: present
         name: "{{ sap_vm_provision_ibmpowervm_key_pair_name_ssh_host_public_key }}"
         public_key: "{{ lookup('ansible.builtin.file', sap_vm_provision_ssh_host_public_key_file_path ) }}"
+        validate_certs: false # Allow Self-Signed Certificate
+        auth: "{{ __sap_vm_provision_task_ibmpowervm_openstack_auth }}"
       throttle: 1
 
     - name: Provision hosts to IBM PowerVM

--- a/roles/sap_vm_provision/tasks/platform_ansible/ibmpowervm_vm/execute_main.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/ibmpowervm_vm/execute_main.yml
@@ -1,82 +1,127 @@
 ---
 
-# Method 1 for auth, set fact and reuse with validate_certs on each Ansible Task
-- name: Openstack Authentication - Method 1
-  ansible.builtin.set_fact:
-    openstack_auth:
-      auth_url: "{{ sap_vm_provision_ibmpowervm_vc_auth_endpoint }}"
-      username: "{{ sap_vm_provision_ibmpowervm_vc_user }}"
-      password: "{{ sap_vm_provision_ibmpowervm_vc_user_password }}"
-      project_name: "{{ sap_vm_provision_ibmpowervm_vc_project_name }}"
-      project_domain_name: "default" # If blank will cause error "Expecting to find domain in project"
-      user_domain_name: "default" # If blank will cause error "Expecting to find domain in user"
+- name: Ansible Task block for looped provisioning of IBM PowerVM Virtual Machines
+  any_errors_fatal: true
+  # Using environment, no_log is ineffective and log will show 'EXEC /bin/sh -c 'ENV_VAR=value python3 /AnsiballZ_ansible_module_name.py && sleep 0'
+  # Therefore do not use environment for secrets, use only for non-sensitive values as this will reduce Ansible Task parameters.
+  # environment:
+  block:
 
-# Method 2 for auth, obtain token and subsequently set each task with environment e.g. OS_TOKEN: "{{ openstack_session.auth_token }}"
-# Use if requiring direct API call or CLI commands
-# - name: Openstack Authentication - Method 2
-#   register: openstack_session
-#   openstack.cloud.auth:
-#     auth:
-#       auth_url: "{{ sap_vm_provision_ibmpowervm_vc_auth_endpoint }}"
-#       username: "{{ sap_vm_provision_ibmpowervm_vc_user }}"
-#       password: "{{ sap_vm_provision_ibmpowervm_vc_user_password }}"
-#       project_name: "{{ sap_vm_provision_ibmpowervm_vc_project_name }}"
-#       project_domain_name: "default" # If blank will cause error "Expecting to find domain in project"
-#       user_domain_name: "default" # If blank will cause error "Expecting to find domain in user"
-#     interface: internal # internal, public, admin
-#     validate_certs: false # Allow Self-Signed Certificate
-#     wait: true
-#   when: openstack_auth is undefined or not openstack_auth
+    # Method 1 for auth, set fact and reuse with validate_certs on each Ansible Task
+    - name: Openstack Authentication - Method 1
+      no_log: "{{ __sap_vm_provision_no_log }}"
+      ansible.builtin.set_fact:
+        __sap_vm_provision_task_ibmpowervm_openstack_auth:
+          auth_url: "{{ sap_vm_provision_ibmpowervm_vc_auth_endpoint }}"
+          username: "{{ sap_vm_provision_ibmpowervm_vc_user }}"
+          password: "{{ sap_vm_provision_ibmpowervm_vc_user_password }}"
+          project_name: "{{ sap_vm_provision_ibmpowervm_vc_project_name }}"
+          project_domain_name: "default" # If blank will cause error "Expecting to find domain in project"
+          user_domain_name: "default" # If blank will cause error "Expecting to find domain in user"
 
-- name: Set fact to hold loop variables from include_tasks
-  ansible.builtin.set_fact:
-    register_provisioned_host_all: []
+    # Method 2 for auth, obtain token and subsequently set each task with environment e.g. OS_TOKEN: "{{ __sap_vm_provision_task_ibmpowervm_openstack_session.auth_token }}"
+    # Use if requiring direct API call or CLI commands
+    # - name: Openstack Authentication - Method 2
+    #   no_log: "{{ __sap_vm_provision_no_log }}"
+    #   register: __sap_vm_provision_task_ibmpowervm_openstack_session
+    #   openstack.cloud.auth:
+    #     auth:
+    #       auth_url: "{{ sap_vm_provision_ibmpowervm_vc_auth_endpoint }}"
+    #       username: "{{ sap_vm_provision_ibmpowervm_vc_user }}"
+    #       password: "{{ sap_vm_provision_ibmpowervm_vc_user_password }}"
+    #       project_name: "{{ sap_vm_provision_ibmpowervm_vc_project_name }}"
+    #       project_domain_name: "default" # If blank will cause error "Expecting to find domain in project"
+    #       user_domain_name: "default" # If blank will cause error "Expecting to find domain in user"
+    #     interface: internal # internal, public, admin
+    #     validate_certs: false # Allow Self-Signed Certificate
+    #     wait: true
+    #   when: __sap_vm_provision_task_ibmpowervm_openstack_auth is undefined or not __sap_vm_provision_task_ibmpowervm_openstack_auth
 
-- name: Create IBM PowerVM SSH Key Pair
-  openstack.cloud.keypair:
-    auth: "{{ openstack_auth }}"
-    validate_certs: false # Allow Self-Signed Certificate
-    state: present
-    name: "{{ sap_vm_provision_ibmpowervm_key_pair_name_ssh_host_public_key }}"
-    public_key: "{{ lookup('ansible.builtin.file', sap_vm_provision_ssh_host_public_key_file_path ) }}"
-  throttle: 1
+    - name: Set fact to hold loop variables from include_tasks
+      ansible.builtin.set_fact:
+        register_provisioned_host_all: []
 
-- name: Provision hosts to IBM PowerVM
-  register: __sap_vm_provision_task_provision_host_all_run
-  ansible.builtin.include_tasks:
-    file: "{{ 'platform_' + sap_vm_provision_iac_type }}/{{ sap_vm_provision_iac_platform }}/execute_provision.yml"
-  vars:
-    openstack_auth_delegate: "{{ openstack_auth }}"
+    - name: Create IBM PowerVM SSH Key Pair
+      no_log: "{{ __sap_vm_provision_no_log }}"
+      register: __sap_vm_provision_task_ibmpowervm_ssh_public_key
+      openstack.cloud.keypair:
+        auth: "{{ __sap_vm_provision_task_ibmpowervm_openstack_auth }}"
+        validate_certs: false # Allow Self-Signed Certificate
+        state: present
+        name: "{{ sap_vm_provision_ibmpowervm_key_pair_name_ssh_host_public_key }}"
+        public_key: "{{ lookup('ansible.builtin.file', sap_vm_provision_ssh_host_public_key_file_path ) }}"
+      throttle: 1
 
-- name: Add hosts provisioned to the Ansible Inventory
-  register: __sap_vm_provision_task_provision_host_all_add
-  ansible.builtin.add_host:
-    name: "{{ add_item[0].host_node }}"
-    groups: "{{ add_item[0].sap_system_type + '_' if (add_item[0].sap_system_type != '') }}{{ add_item[0].sap_host_type }}"
-    ansible_host: "{{ add_item[0].access_ipv4 }}"
-    ansible_user: "root"
-    ansible_ssh_private_key_file: "{{ sap_vm_provision_ssh_host_private_key_file_path }}"
-    ansible_ssh_common_args: -o ConnectTimeout=180 -o ControlMaster=auto -o ControlPersist=3600s -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ForwardX11=no
-  loop: "{{ ansible_play_hosts | map('extract', hostvars, 'register_provisioned_host_all')  }}"
-  loop_control:
-    label: "{{ add_item[0].host_node }}"
-    loop_var: add_item
+    - name: Provision hosts to IBM PowerVM
+      no_log: "{{ __sap_vm_provision_no_log }}"
+      register: __sap_vm_provision_task_provision_host_all_run
+      ansible.builtin.include_tasks:
+        file: "{{ 'platform_' + sap_vm_provision_iac_type }}/{{ sap_vm_provision_iac_platform }}/execute_provision.yml"
+      vars:
+        __sap_vm_provision_task_ibmpowervm_openstack_auth_delegate: "{{ __sap_vm_provision_task_ibmpowervm_openstack_auth }}"
+
+    - name: Add hosts provisioned to the Ansible Inventory
+      no_log: "{{ __sap_vm_provision_no_log }}"
+      register: __sap_vm_provision_task_provision_host_all_add
+      ansible.builtin.add_host:
+        name: "{{ add_item[0].host_node }}"
+        groups: "{{ add_item[0].sap_system_type + '_' if (add_item[0].sap_system_type != '') }}{{ add_item[0].sap_host_type }}"
+        ansible_host: "{{ add_item[0].access_ipv4 }}"
+        ansible_user: "root"
+        ansible_ssh_private_key_file: "{{ sap_vm_provision_ssh_host_private_key_file_path }}"
+        ansible_ssh_common_args: -o ConnectTimeout=180 -o ControlMaster=auto -o ControlPersist=3600s -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ForwardX11=no
+      loop: "{{ ansible_play_hosts | map('extract', hostvars, 'register_provisioned_host_all')  }}"
+      loop_control:
+        label: "{{ add_item[0].host_node }}"
+        loop_var: add_item
 
 
 # Cannot override any variables from extravars input, see https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_variables.html#understanding-variable-precedence
 # Ensure no default value exists for any prompted variable before execution of Ansible Playbook
 
-- name: Set fact to hold all inventory hosts in all groups
-  ansible.builtin.set_fact:
-    groups_merged_list: "{{ [ [ groups['hana_primary'] | default([]) ] , [ groups['hana_secondary'] | default([]) ] , [ groups['nwas_ascs'] | default([]) ] , [ groups['nwas_ers'] | default([]) ] , [ groups['nwas_pas'] | default([]) ] , [ groups['nwas_aas'] | default([]) ] ] | flatten | select() }}"
+    - name: Set fact to hold all inventory hosts in all groups
+      ansible.builtin.set_fact:
+        groups_merged_list: "{{ [ [ groups['hana_primary'] | default([]) ] , [ groups['hana_secondary'] | default([]) ] , [ groups['nwas_ascs'] | default([]) ] , [ groups['nwas_ers'] | default([]) ] , [ groups['nwas_pas'] | default([]) ] , [ groups['nwas_aas'] | default([]) ] ] | flatten | select() }}"
 
-- name: Set Ansible Vars
-  register: __sap_vm_provision_task_ansible_vars_set
-  ansible.builtin.include_tasks:
-    file: common/set_ansible_vars.yml
+    - name: Set Ansible Vars
+      register: __sap_vm_provision_task_ansible_vars_set
+      ansible.builtin.include_tasks:
+        file: common/set_ansible_vars.yml
 
   #  - ansible.builtin.debug:
   #      var: __sap_vm_provision_task_provision_host_all_add.results
+
+  rescue:
+    # This requires no_log set on each Ansible Task, and not set on the Ansible Task Block
+    # This requires an Ansible Task Block containing the Ansible Tasks for calling
+    # Infrastructure Platform APIs (via Ansible Modules)
+    - name: Show errors in task outputs
+      ansible.builtin.fail:
+        msg: "{{ lookup('ansible.builtin.vars', loop_item) }}"
+      loop:
+        - __sap_vm_provision_task_ibmpowervm_ssh_public_key
+        - __sap_vm_provision_task_provision_host_all_run
+        - __sap_vm_provision_task_provision_host_single_check_exists
+        - __sap_vm_provision_task_ibmpowervm_os_image_info
+        - __sap_vm_provision_task_ibmpowervm_network
+        - __sap_vm_provision_task_ibmpowervm_compute_template
+        - __sap_vm_provision_task_provision_host_single
+        - __sap_vm_provision_task_provision_host_single_vnic
+        - __sap_vm_provision_task_ansible_facts_host_disks_info
+        - __sap_vm_provision_task_provision_host_single_volumes
+        - __sap_vm_provision_task_provision_host_single_volume_attachments
+        - __sap_vm_provision_task_os_rescan_scsi_bus_output
+        - __sap_vm_provision_task_provision_host_single_info
+        - __sap_vm_provision_task_provision_host_all_add
+      loop_control:
+        loop_var: loop_item
+        index_var: loop_item_index
+        label: "{{ 'Variable No. ' + (loop_item_index | string) }}"
+      when:
+        - lookup('ansible.builtin.vars', loop_item, default='') | length > 0
+        - not lookup('ansible.builtin.vars', loop_item, default='') is skipped
+        - lookup('ansible.builtin.vars', loop_item, default='') is failed
+
 
 - name: Ansible Task block to execute on target inventory hosts
   delegate_to: "{{ inventory_hostname }}"

--- a/roles/sap_vm_provision/tasks/platform_ansible/ibmpowervm_vm/execute_main.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/ibmpowervm_vm/execute_main.yml
@@ -71,7 +71,7 @@
     groups_merged_list: "{{ [ [ groups['hana_primary'] | default([]) ] , [ groups['hana_secondary'] | default([]) ] , [ groups['nwas_ascs'] | default([]) ] , [ groups['nwas_ers'] | default([]) ] , [ groups['nwas_pas'] | default([]) ] , [ groups['nwas_aas'] | default([]) ] ] | flatten | select() }}"
 
 - name: Set Ansible Vars
-  register: register_set_ansible_vars
+  register: __sap_vm_provision_task_ansible_vars_set
   ansible.builtin.include_tasks:
     file: common/set_ansible_vars.yml
 
@@ -95,26 +95,26 @@
         name: "{{ inventory_hostname_short }}"
 
     - name: Set /etc/hosts
-      register: register_etc_hosts_file
+      register: __sap_vm_provision_task_os_etc_hosts
       ansible.builtin.include_tasks:
         file: common/set_etc_hosts.yml
 
     - name: Set /etc/hosts for HA
-      register: register_etc_hosts_file_ha
+      register: __sap_vm_provision_task_os_etc_hosts_ha
       ansible.builtin.include_tasks:
         file: common/set_etc_hosts_ha.yml
       when:
         - (groups["hana_secondary"] is defined and (groups["hana_secondary"] | length>0)) or (groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0)) or (groups["anydb_secondary"] is defined and (groups["anydb_secondary"] | length>0))
 
     - name: Set /etc/hosts for Scale-Out
-      register: register_etc_hosts_file_scaleout
+      register: __sap_vm_provision_task_os_etc_hosts_scaleout
       ansible.builtin.include_tasks:
         file: common/set_etc_hosts_scaleout.yml
       when:
         - (groups["hana_primary"] is defined and (groups["hana_primary"] | length>0)) and (sap_hana_scaleout_active_coordinator is defined or sap_hana_scaleout_active_worker is defined or sap_hana_scaleout_standby is defined)
 
     - name: Set vars for sap_storage_setup Ansible Role
-      register: register_ansible_vars_storage
+      register: __sap_vm_provision_task_ansible_vars_storage
       ansible.builtin.include_tasks:
         file: common/set_ansible_vars_storage.yml
 

--- a/roles/sap_vm_provision/tasks/platform_ansible/ibmpowervm_vm/execute_main.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/ibmpowervm_vm/execute_main.yml
@@ -14,6 +14,7 @@
 # Method 2 for auth, obtain token and subsequently set each task with environment e.g. OS_TOKEN: "{{ openstack_session.auth_token }}"
 # Use if requiring direct API call or CLI commands
 # - name: Openstack Authentication - Method 2
+#   register: openstack_session
 #   openstack.cloud.auth:
 #     auth:
 #       auth_url: "{{ sap_vm_provision_ibmpowervm_vc_auth_endpoint }}"
@@ -26,7 +27,6 @@
 #     validate_certs: false # Allow Self-Signed Certificate
 #     wait: true
 #   when: openstack_auth is undefined or not openstack_auth
-#   register: openstack_session
 
 - name: Set fact to hold loop variables from include_tasks
   ansible.builtin.set_fact:

--- a/roles/sap_vm_provision/tasks/platform_ansible/ibmpowervm_vm/execute_main.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/ibmpowervm_vm/execute_main.yml
@@ -53,7 +53,6 @@
       throttle: 1
 
     - name: Provision hosts to IBM PowerVM
-      no_log: "{{ __sap_vm_provision_no_log }}"
       register: __sap_vm_provision_task_provision_host_all_run
       ansible.builtin.include_tasks:
         file: "{{ 'platform_' + sap_vm_provision_iac_type }}/{{ sap_vm_provision_iac_platform }}/execute_provision.yml"

--- a/roles/sap_vm_provision/tasks/platform_ansible/ibmpowervm_vm/execute_provision.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/ibmpowervm_vm/execute_provision.yml
@@ -24,21 +24,21 @@
 - name: Check if VM exists
   register: __sap_vm_provision_task_provision_host_single_check_exists
   openstack.cloud.server_info:
-    auth: "{{ openstack_auth_delegate }}"
+    auth: "{{ __sap_vm_provision_task_ibmpowervm_openstack_auth_delegate }}"
     validate_certs: false # Allow Self-Signed Certificate
     name: "{{ inventory_hostname }}"
 
 - name: Check OS Image available in IBM PowerVM
-  register: register_ibmpowervm_available_os
+  register: __sap_vm_provision_task_ibmpowervm_os_image_info
   openstack.cloud.image_info:
-    auth: "{{ openstack_auth_delegate }}"
+    auth: "{{ __sap_vm_provision_task_ibmpowervm_openstack_auth_delegate }}"
     validate_certs: false # Allow Self-Signed Certificate
     image: "{{ sap_vm_provision_ibmpowervm_vm_host_os_image }}"
 
 - name: Check network available in IBM PowerVM
-  register: register_ibmpowervm_available_network
+  register: __sap_vm_provision_task_ibmpowervm_network
   openstack.cloud.networks_info:
-    auth: "{{ openstack_auth }}"
+    auth: "{{ __sap_vm_provision_task_ibmpowervm_openstack_auth }}"
     validate_certs: false # Allow Self-Signed Certificate
     name: "{{ sap_vm_provision_ibmpowervm_network_name }}"
 
@@ -54,9 +54,9 @@
 
     # See documented IBM PowerVM Compute Template (OpenStack Flavor) extra specs - https://www.ibm.com/docs/en/powervc-cloud/latest?topic=apis-flavors-extra-specs
     - name: Create IBM PowerVM Compute Template
-      register: register_ibmpowervm_compute_template
+      register: __sap_vm_provision_task_ibmpowervm_compute_template
       openstack.cloud.compute_flavor:
-        auth: "{{ openstack_auth }}"
+        auth: "{{ __sap_vm_provision_task_ibmpowervm_openstack_auth }}"
         validate_certs: false # Allow Self-Signed Certificate
 
         state: present
@@ -104,9 +104,9 @@
 
 
     - name: Provision IBM PowerVM vNIC (Network Port)
-      register: register_provisioned_host_vnic_single
+      register: __sap_vm_provision_task_provision_host_single_vnic
       openstack.cloud.port:
-        auth: "{{ openstack_auth }}"
+        auth: "{{ __sap_vm_provision_task_ibmpowervm_openstack_auth }}"
         validate_certs: false # Allow Self-Signed Certificate
         state: present
         name: "{{ inventory_hostname }}-vnic0"
@@ -134,7 +134,7 @@
     - name: Provision IBM PowerVM Virtual Machine (LPAR)
       register: __sap_vm_provision_task_provision_host_single
       openstack.cloud.server:
-        auth: "{{ openstack_auth }}"
+        auth: "{{ __sap_vm_provision_task_ibmpowervm_openstack_auth }}"
         validate_certs: false # Allow Self-Signed Certificate
 
         ## Virtual Machine target Hypervisor definition
@@ -149,7 +149,7 @@
         description: "{{ inventory_hostname }} created by Ansible Playbook for SAP"
 
         ## Virtual Machine main resources definition
-        flavor: "{{ register_ibmpowervm_compute_template.flavor.id }}"
+        flavor: "{{ __sap_vm_provision_task_ibmpowervm_compute_template.flavor.id }}"
         image: "{{ sap_vm_provision_ibmpowervm_vm_host_os_image }}" # Do not set boot_from_volume, boot_volume or volumes parameters when cloning OS Image template
         terminate_volume: true
         key_name: "{{ sap_vm_provision_ibmpowervm_key_pair_name_ssh_host_public_key }}"
@@ -177,16 +177,16 @@
 
 
 - name: Collect info on IBM PowerVM vNIC (Network Port)
-  register: register_provisioned_host_vnic_single
+  register: __sap_vm_provision_task_provision_host_single_vnic
   openstack.cloud.port_info:
-    auth: "{{ openstack_auth }}"
+    auth: "{{ __sap_vm_provision_task_ibmpowervm_openstack_auth }}"
     validate_certs: false # Allow Self-Signed Certificate
     name: "{{ inventory_hostname }}-vnic0"
 
 
 - name: Create fact for delegate host IP
   ansible.builtin.set_fact:
-    provisioned_private_ip: "{{ register_provisioned_host_vnic_single.ports[0].fixed_ips[0].ip_address }}"
+    provisioned_private_ip: "{{ __sap_vm_provision_task_provision_host_single_vnic.ports[0].fixed_ips[0].ip_address }}"
 
 
 # OpenStack APIs cannot query the IBM PowerVC APIs directly,
@@ -282,9 +282,10 @@
 # The volume creation task requires the above task to define the parameter
 # which contains the calculated unique device names.
 - name: Provision Virtual Disk volumes for IBM PowerVM VM filesystems
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_provision_host_single_volumes
   openstack.cloud.volume:
-    auth: "{{ openstack_auth_delegate }}"
+    auth: "{{ __sap_vm_provision_task_ibmpowervm_openstack_auth_delegate }}"
     validate_certs: false # Allow Self-Signed Certificate
     state: present
     name: "{{ inventory_hostname }}-vol_{{ vol_item.name }}"
@@ -307,8 +308,10 @@
     - vol_item.size > 0
 
 - name: Attach Virtual Disk volumes to the IBM PowerVM VM
+  no_log: "{{ __sap_vm_provision_no_log }}"
+  register: __sap_vm_provision_task_provision_host_single_volume_attachments
   openstack.cloud.server_volume:
-    auth: "{{ openstack_auth_delegate }}"
+    auth: "{{ __sap_vm_provision_task_ibmpowervm_openstack_auth_delegate }}"
     validate_certs: false # Allow Self-Signed Certificate
     state: present
     server: "{{ inventory_hostname }}"
@@ -322,8 +325,9 @@
   delay: 5
 
 - name: Re-scan IBM PowerVM VM SCSI Bus
-  ansible.builtin.command: "/usr/bin/rescan-scsi-bus.sh"
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_os_rescan_scsi_bus_output
+  ansible.builtin.command: "/usr/bin/rescan-scsi-bus.sh"
   changed_when: __sap_vm_provision_task_os_rescan_scsi_bus_output.rc != 0
   remote_user: root
   become: true
@@ -341,9 +345,10 @@
 
 
 - name: Check VM status
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_provision_host_single_info
   openstack.cloud.server_info:
-    auth: "{{ openstack_auth_delegate }}"
+    auth: "{{ __sap_vm_provision_task_ibmpowervm_openstack_auth_delegate }}"
     validate_certs: false # Allow Self-Signed Certificate
     name: "{{ inventory_hostname }}"
 

--- a/roles/sap_vm_provision/tasks/platform_ansible/ibmpowervm_vm/execute_provision.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/ibmpowervm_vm/execute_provision.yml
@@ -24,23 +24,23 @@
 - name: Check if VM exists
   register: __sap_vm_provision_task_provision_host_single_check_exists
   openstack.cloud.server_info:
-    auth: "{{ __sap_vm_provision_task_ibmpowervm_openstack_auth_delegate }}"
-    validate_certs: false # Allow Self-Signed Certificate
     name: "{{ inventory_hostname }}"
+    validate_certs: false # Allow Self-Signed Certificate
+    auth: "{{ __sap_vm_provision_task_ibmpowervm_openstack_auth_delegate }}"
 
 - name: Check OS Image available in IBM PowerVM
   register: __sap_vm_provision_task_ibmpowervm_os_image_info
   openstack.cloud.image_info:
-    auth: "{{ __sap_vm_provision_task_ibmpowervm_openstack_auth_delegate }}"
-    validate_certs: false # Allow Self-Signed Certificate
     image: "{{ sap_vm_provision_ibmpowervm_vm_host_os_image }}"
+    validate_certs: false # Allow Self-Signed Certificate
+    auth: "{{ __sap_vm_provision_task_ibmpowervm_openstack_auth_delegate }}"
 
 - name: Check network available in IBM PowerVM
   register: __sap_vm_provision_task_ibmpowervm_network
   openstack.cloud.networks_info:
-    auth: "{{ __sap_vm_provision_task_ibmpowervm_openstack_auth }}"
-    validate_certs: false # Allow Self-Signed Certificate
     name: "{{ sap_vm_provision_ibmpowervm_network_name }}"
+    validate_certs: false # Allow Self-Signed Certificate
+    auth: "{{ __sap_vm_provision_task_ibmpowervm_openstack_auth }}"
 
 
 # VM creation block:
@@ -56,8 +56,6 @@
     - name: Create IBM PowerVM Compute Template
       register: __sap_vm_provision_task_ibmpowervm_compute_template
       openstack.cloud.compute_flavor:
-        auth: "{{ __sap_vm_provision_task_ibmpowervm_openstack_auth }}"
-        validate_certs: false # Allow Self-Signed Certificate
 
         state: present
         name: "{{ inventory_hostname }}-compute-template"
@@ -102,12 +100,13 @@
           "powervm:secure_boot": 0 # "Disabled"
           "powervm:srr_capability": "false" # Disable the Simplified Remote Restart
 
+        validate_certs: false # Allow Self-Signed Certificate
+        auth: "{{ __sap_vm_provision_task_ibmpowervm_openstack_auth }}"
+
 
     - name: Provision IBM PowerVM vNIC (Network Port)
       register: __sap_vm_provision_task_provision_host_single_vnic
       openstack.cloud.port:
-        auth: "{{ __sap_vm_provision_task_ibmpowervm_openstack_auth }}"
-        validate_certs: false # Allow Self-Signed Certificate
         state: present
         name: "{{ inventory_hostname }}-vnic0"
         network: "{{ sap_vm_provision_ibmpowervm_network_name }}"
@@ -130,12 +129,12 @@
               }]) -%}
           {%- endif -%}
           {{ vnic_config[0] }}
+        validate_certs: false # Allow Self-Signed Certificate
+        auth: "{{ __sap_vm_provision_task_ibmpowervm_openstack_auth }}"
 
     - name: Provision IBM PowerVM Virtual Machine (LPAR)
       register: __sap_vm_provision_task_provision_host_single
       openstack.cloud.server:
-        auth: "{{ __sap_vm_provision_task_ibmpowervm_openstack_auth }}"
-        validate_certs: false # Allow Self-Signed Certificate
 
         ## Virtual Machine target Hypervisor definition
         availability_zone: "{{ sap_vm_provision_ibmpowervm_host_group_name }}" # IBM PowerVM Hypervisor Cluster Host Group Name
@@ -165,6 +164,9 @@
           hostname: "{{ inventory_hostname }}"
         #userdata: | # cloud-init userdata
 
+        validate_certs: false # Allow Self-Signed Certificate
+        auth: "{{ __sap_vm_provision_task_ibmpowervm_openstack_auth }}"
+
       # Report VM provisioning complete, only after status is Active (not Building)
       # If provisioning error occurs (e.g. 'Could not find image XYZ with exclude (deprecated)') then
       # will show error as 'The conditional check __sap_vm_provision_task_provision_host_single.server.status == "ACTIVE" failed
@@ -179,10 +181,9 @@
 - name: Collect info on IBM PowerVM vNIC (Network Port)
   register: __sap_vm_provision_task_provision_host_single_vnic
   openstack.cloud.port_info:
-    auth: "{{ __sap_vm_provision_task_ibmpowervm_openstack_auth }}"
-    validate_certs: false # Allow Self-Signed Certificate
     name: "{{ inventory_hostname }}-vnic0"
-
+    validate_certs: false # Allow Self-Signed Certificate
+    auth: "{{ __sap_vm_provision_task_ibmpowervm_openstack_auth }}"
 
 - name: Create fact for delegate host IP
   ansible.builtin.set_fact:
@@ -285,8 +286,6 @@
   no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_provision_host_single_volumes
   openstack.cloud.volume:
-    auth: "{{ __sap_vm_provision_task_ibmpowervm_openstack_auth_delegate }}"
-    validate_certs: false # Allow Self-Signed Certificate
     state: present
     name: "{{ inventory_hostname }}-vol_{{ vol_item.name }}"
     # availability_zone: ""
@@ -298,6 +297,8 @@
     volume_type: "{{ sap_vm_provision_ibmpowervm_storage_template_name }}"
     is_multiattach: false
     is_bootable: false
+    validate_certs: false # Allow Self-Signed Certificate
+    auth: "{{ __sap_vm_provision_task_ibmpowervm_openstack_auth }}"
   loop: "{{ filesystem_volume_map }}"
   loop_control:
     loop_var: vol_item
@@ -311,11 +312,11 @@
   no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_provision_host_single_volume_attachments
   openstack.cloud.server_volume:
-    auth: "{{ __sap_vm_provision_task_ibmpowervm_openstack_auth_delegate }}"
-    validate_certs: false # Allow Self-Signed Certificate
     state: present
     server: "{{ inventory_hostname }}"
     volume: "{{ virtual_disk_item.volume.id }}"
+    validate_certs: false # Allow Self-Signed Certificate
+    auth: "{{ __sap_vm_provision_task_ibmpowervm_openstack_auth }}"
   loop: "{{ __sap_vm_provision_task_provision_host_single_volumes.results }}"
   loop_control:
     loop_var: virtual_disk_item
@@ -348,9 +349,9 @@
   no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_provision_host_single_info
   openstack.cloud.server_info:
-    auth: "{{ __sap_vm_provision_task_ibmpowervm_openstack_auth_delegate }}"
-    validate_certs: false # Allow Self-Signed Certificate
     name: "{{ inventory_hostname }}"
+    validate_certs: false # Allow Self-Signed Certificate
+    auth: "{{ __sap_vm_provision_task_ibmpowervm_openstack_auth }}"
 
 # Note: openstack.cloud.server_info Ansible Module can provide:
 # servers[0].metadata.original_host / servers[0].compute_host / servers[0].hypervisor_hostname for IBM PowerVM HMC System 'Machine Type Machine Serial' (MTMS)

--- a/roles/sap_vm_provision/tasks/platform_ansible/ibmpowervm_vm/execute_provision.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/ibmpowervm_vm/execute_provision.yml
@@ -22,7 +22,7 @@
     - not inventory_hostname in lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan].keys()
 
 - name: Check if VM exists
-  register: register_check_vm_exists
+  register: __sap_vm_provision_task_provision_host_single_check_exists
   openstack.cloud.server_info:
     auth: "{{ openstack_auth_delegate }}"
     validate_certs: false # Allow Self-Signed Certificate
@@ -48,8 +48,8 @@
 #
 - name: Block that provisions the VM
   when:
-    - register_check_vm_exists.servers is defined
-    - register_check_vm_exists.servers | length == 0
+    - __sap_vm_provision_task_provision_host_single_check_exists.servers is defined
+    - __sap_vm_provision_task_provision_host_single_check_exists.servers | length == 0
   block:
 
     # See documented IBM PowerVM Compute Template (OpenStack Flavor) extra specs - https://www.ibm.com/docs/en/powervc-cloud/latest?topic=apis-flavors-extra-specs
@@ -203,7 +203,7 @@
     timeout: 600
 
 - name: Collect only facts about hardware
-  register: host_disks_info
+  register: __sap_vm_provision_task_ansible_facts_host_disks_info
   ansible.builtin.setup:
     gather_subset:
       - hardware
@@ -222,14 +222,14 @@
 
 #- name: Debug Ansible Facts devices used list
 #  ansible.builtin.debug:
-#    msg: "{{ host_disks_info.ansible_facts.ansible_device_links.ids.keys() | list }}"
+#    msg: "{{ __sap_vm_provision_task_ansible_facts_host_disks_info.ansible_facts.ansible_device_links.ids.keys() | list }}"
 
 
 - name: Set fact for available storage volume device names
   ansible.builtin.set_fact:
     available_volumes: |-
       {% set letters = 'bcdefghijklmnopqrstuvwxyz' %}
-      {% set ansible_facts_devices_used_list = host_disks_info.ansible_facts.ansible_device_links.ids.keys() | list %}
+      {% set ansible_facts_devices_used_list = __sap_vm_provision_task_ansible_facts_host_disks_info.ansible_facts.ansible_device_links.ids.keys() | list %}
       {% set volumes = [] %}
       {%- for letter in letters -%}
         {% for device in ansible_facts_devices_used_list -%}
@@ -323,8 +323,8 @@
 
 - name: Re-scan IBM PowerVM VM SCSI Bus
   ansible.builtin.command: "/usr/bin/rescan-scsi-bus.sh"
-  register: rescan_scsi_bus_output
-  changed_when: rescan_scsi_bus_output.rc != 0
+  register: __sap_vm_provision_task_os_rescan_scsi_bus_output
+  changed_when: __sap_vm_provision_task_os_rescan_scsi_bus_output.rc != 0
   remote_user: root
   become: true
   become_user: root

--- a/roles/sap_vm_provision/tasks/platform_ansible/ibmpowervm_vm/execute_provision.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/ibmpowervm_vm/execute_provision.yml
@@ -132,7 +132,7 @@
           {{ vnic_config[0] }}
 
     - name: Provision IBM PowerVM Virtual Machine (LPAR)
-      register: register_provisioned_host_single
+      register: __sap_vm_provision_task_provision_host_single
       openstack.cloud.server:
         auth: "{{ openstack_auth }}"
         validate_certs: false # Allow Self-Signed Certificate
@@ -167,9 +167,9 @@
 
       # Report VM provisioning complete, only after status is Active (not Building)
       # If provisioning error occurs (e.g. 'Could not find image XYZ with exclude (deprecated)') then
-      # will show error as 'The conditional check register_provisioned_host_single.server.status == "ACTIVE" failed
+      # will show error as 'The conditional check __sap_vm_provision_task_provision_host_single.server.status == "ACTIVE" failed
       # and the actual error will be hidden unless the 'until' is commented-out
-      until: register_provisioned_host_single.server.status is defined and register_provisioned_host_single.server.status == "ACTIVE"
+      until: __sap_vm_provision_task_provision_host_single.server.status is defined and __sap_vm_provision_task_provision_host_single.server.status == "ACTIVE"
       retries: 120
       delay: 5
 
@@ -304,7 +304,7 @@
   when:
     - vol_item.fstype is defined
     - vol_item.size > 0
-  register: volume_provisioning
+  register: __sap_vm_provision_task_provision_host_single_volumes
 
 - name: Attach Virtual Disk volumes to the IBM PowerVM VM
   openstack.cloud.server_volume:
@@ -313,7 +313,7 @@
     state: present
     server: "{{ inventory_hostname }}"
     volume: "{{ virtual_disk_item.volume.id }}"
-  loop: "{{ volume_provisioning.results }}"
+  loop: "{{ __sap_vm_provision_task_provision_host_single_volumes.results }}"
   loop_control:
     loop_var: virtual_disk_item
     index_var: virtual_disk_item_index
@@ -341,7 +341,7 @@
 
 
 - name: Check VM status
-  register: register_provisioned_host_single_info
+  register: __sap_vm_provision_task_provision_host_single_info
   openstack.cloud.server_info:
     auth: "{{ openstack_auth_delegate }}"
     validate_certs: false # Allow Self-Signed Certificate
@@ -355,8 +355,8 @@
 
 - name: Append loop value to register
   ansible.builtin.set_fact:
-    register_provisioned_host_single: "{{ register_provisioned_host_single_info.servers[0] | combine( { 'host_node' : inventory_hostname } , { 'sap_host_type' : lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][scaleout_origin_host_spec | default(inventory_hostname)].sap_host_type } , { 'sap_system_type' : (lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][scaleout_origin_host_spec | default(inventory_hostname)].sap_system_type | default('')) } ) }}"
+    __sap_vm_provision_task_provision_host_single: "{{ __sap_vm_provision_task_provision_host_single_info.servers[0] | combine( { 'host_node' : inventory_hostname } , { 'sap_host_type' : lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][scaleout_origin_host_spec | default(inventory_hostname)].sap_host_type } , { 'sap_system_type' : (lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][scaleout_origin_host_spec | default(inventory_hostname)].sap_system_type | default('')) } ) }}"
 
 - name: Append output to merged register
   ansible.builtin.set_fact:
-    register_provisioned_host_all: "{{ register_provisioned_host_all + [register_provisioned_host_single] }}"
+    register_provisioned_host_all: "{{ register_provisioned_host_all + [__sap_vm_provision_task_provision_host_single] }}"

--- a/roles/sap_vm_provision/tasks/platform_ansible/ibmpowervm_vm/execute_provision.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/ibmpowervm_vm/execute_provision.yml
@@ -36,11 +36,11 @@
     image: "{{ sap_vm_provision_ibmpowervm_vm_host_os_image }}"
 
 - name: Check network available in IBM PowerVM
+  register: register_ibmpowervm_available_network
   openstack.cloud.networks_info:
     auth: "{{ openstack_auth }}"
     validate_certs: false # Allow Self-Signed Certificate
     name: "{{ sap_vm_provision_ibmpowervm_network_name }}"
-  register: register_ibmpowervm_available_network
 
 
 # VM creation block:
@@ -282,6 +282,7 @@
 # The volume creation task requires the above task to define the parameter
 # which contains the calculated unique device names.
 - name: Provision Virtual Disk volumes for IBM PowerVM VM filesystems
+  register: __sap_vm_provision_task_provision_host_single_volumes
   openstack.cloud.volume:
     auth: "{{ openstack_auth_delegate }}"
     validate_certs: false # Allow Self-Signed Certificate
@@ -304,7 +305,6 @@
   when:
     - vol_item.fstype is defined
     - vol_item.size > 0
-  register: __sap_vm_provision_task_provision_host_single_volumes
 
 - name: Attach Virtual Disk volumes to the IBM PowerVM VM
   openstack.cloud.server_volume:

--- a/roles/sap_vm_provision/tasks/platform_ansible/kubevirt_vm/execute_main.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/kubevirt_vm/execute_main.yml
@@ -33,12 +33,12 @@
 #     context: "{{ default(lookup('env', 'K8S_AUTH_CONTEXT')) | default(omit) }}"
 
 - name: Provision hosts to KubeVirt
-  register: register_provisioned_hosts
+  register: __sap_vm_provision_task_provision_host_all_run
   ansible.builtin.include_tasks:
     file: "{{ 'platform_' + sap_vm_provision_iac_type }}/{{ sap_vm_provision_iac_platform }}/execute_provision.yml"
 
 - name: Add hosts provisioned to the Ansible Inventory
-  register: register_add_hosts
+  register: __sap_vm_provision_task_provision_host_all_add
   ansible.builtin.add_host:
     name: "{{ add_item[0].host_node }}"
     groups: "{{ add_item[0].sap_system_type + '_' if (add_item[0].sap_system_type != '') }}{{ add_item[0].sap_host_type }}"
@@ -65,7 +65,7 @@
     file: common/set_ansible_vars.yml
 
   #  - ansible.builtin.debug:
-  #      var: register_add_hosts.results
+  #      var: __sap_vm_provision_task_provision_host_all_add.results
 
 - name: Ansible Task block to execute on target inventory hosts
   delegate_to: "{{ inventory_hostname }}"

--- a/roles/sap_vm_provision/tasks/platform_ansible/kubevirt_vm/execute_main.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/kubevirt_vm/execute_main.yml
@@ -60,7 +60,7 @@
     groups_merged_list: "{{ [ [ groups['hana_primary'] | default([]) ] , [ groups['hana_secondary'] | default([]) ] , [ groups['nwas_ascs'] | default([]) ] , [ groups['nwas_ers'] | default([]) ] , [ groups['nwas_pas'] | default([]) ] , [ groups['nwas_aas'] | default([]) ] ] | flatten | select() }}"
 
 - name: Set Ansible Vars
-  register: register_set_ansible_vars
+  register: __sap_vm_provision_task_ansible_vars_set
   ansible.builtin.include_tasks:
     file: common/set_ansible_vars.yml
 
@@ -84,26 +84,26 @@
         name: "{{ inventory_hostname_short }}"
 
     - name: Set /etc/hosts
-      register: register_etc_hosts_file
+      register: __sap_vm_provision_task_os_etc_hosts
       ansible.builtin.include_tasks:
         file: common/set_etc_hosts.yml
 
     - name: Set /etc/hosts for HA
-      register: register_etc_hosts_file_ha
+      register: __sap_vm_provision_task_os_etc_hosts_ha
       ansible.builtin.include_tasks:
         file: common/set_etc_hosts_ha.yml
       when:
         - (groups["hana_secondary"] is defined and (groups["hana_secondary"] | length>0)) or (groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0)) or (groups["anydb_secondary"] is defined and (groups["anydb_secondary"] | length>0))
 
     - name: Set /etc/hosts for Scale-Out
-      register: register_etc_hosts_file_scaleout
+      register: __sap_vm_provision_task_os_etc_hosts_scaleout
       ansible.builtin.include_tasks:
         file: common/set_etc_hosts_scaleout.yml
       when:
         - (groups["hana_primary"] is defined and (groups["hana_primary"] | length>0)) and (sap_hana_scaleout_active_coordinator is defined or sap_hana_scaleout_active_worker is defined or sap_hana_scaleout_standby is defined)
 
     - name: Set vars for sap_storage_setup Ansible Role
-      register: register_ansible_vars_storage
+      register: __sap_vm_provision_task_ansible_vars_storage
       ansible.builtin.include_tasks:
         file: common/set_ansible_vars_storage.yml
 

--- a/roles/sap_vm_provision/tasks/platform_ansible/kubevirt_vm/execute_main.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/kubevirt_vm/execute_main.yml
@@ -44,7 +44,6 @@
     #     context: "{{ default(lookup('env', 'K8S_AUTH_CONTEXT')) | default(omit) }}"
 
     - name: Provision hosts to KubeVirt
-      no_log: "{{ __sap_vm_provision_no_log }}"
       register: __sap_vm_provision_task_provision_host_all_run
       ansible.builtin.include_tasks:
         file: "{{ 'platform_' + sap_vm_provision_iac_type }}/{{ sap_vm_provision_iac_platform }}/execute_provision.yml"

--- a/roles/sap_vm_provision/tasks/platform_ansible/kubevirt_vm/execute_main.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/kubevirt_vm/execute_main.yml
@@ -1,71 +1,106 @@
 ---
 
-- name: Set fact to hold loop variables from include_tasks
-  ansible.builtin.set_fact:
-    register_provisioned_host_all: []
+- name: Ansible Task block for looped provisioning of KubeVirt Virtual Machines
+  any_errors_fatal: true
+  # Using environment, no_log is ineffective and log will show 'EXEC /bin/sh -c 'ENV_VAR=value python3 /AnsiballZ_ansible_module_name.py && sleep 0'
+  # Therefore do not use environment for secrets, use only for non-sensitive values as this will reduce Ansible Task parameters.
+  # environment:
+  block:
 
-- name: Set fact for auth - defaults
-  ansible.builtin.set_fact:
-    api_version: "kubevirt.io/v1"
-    validate_certs: "{{ default(lookup('env', 'K8S_AUTH_VERIFY_SSL')) | default(false) }}"
-    persist_config: "{{ default(lookup('env', 'K8S_AUTH_PERSIST_CONFIG')) | default(true) }}"
-    host: "{{ sap_vm_provision_kubevirt_cluster_url | default(lookup('env', 'K8S_AUTH_HOST')) | default(omit) }}" # Target Hypervisor Node
+    - name: Set fact to hold loop variables from include_tasks
+      ansible.builtin.set_fact:
+        register_provisioned_host_all: []
 
-- name: Set fact for auth - Kubeconfig
-  ansible.builtin.set_fact:
-    kubeconfig: "{{ sap_vm_provision_kubevirt_kubeconfig_path | default(lookup('env', 'K8S_AUTH_KUBECONFIG')) | default(lookup('env', 'KUBECONFIG')) | default(omit) }}"
+    - name: Set fact for auth - defaults
+      ansible.builtin.set_fact:
+        api_version: "kubevirt.io/v1"
+        validate_certs: "{{ default(lookup('env', 'K8S_AUTH_VERIFY_SSL')) | default(false) }}"
+        persist_config: "{{ default(lookup('env', 'K8S_AUTH_PERSIST_CONFIG')) | default(true) }}"
+        host: "{{ sap_vm_provision_kubevirt_cluster_url | default(lookup('env', 'K8S_AUTH_HOST')) | default(omit) }}" # Target Hypervisor Node
 
-- name: Set fact for auth - API Key
-  ansible.builtin.set_fact:
-    api_key: "{{ sap_vm_provision_kubevirt_api_key | default(lookup('env', 'K8S_AUTH_API_KEY')) | default(omit) }}"
-  when: kubeconfig is defined
+    - name: Set fact for auth - Kubeconfig
+      no_log: "{{ __sap_vm_provision_no_log }}"
+      ansible.builtin.set_fact:
+        kubeconfig: "{{ sap_vm_provision_kubevirt_kubeconfig_path | default(lookup('env', 'K8S_AUTH_KUBECONFIG')) | default(lookup('env', 'KUBECONFIG')) | default(omit) }}"
 
-- name: Set fact for auth - Username and Passwords
-  ansible.builtin.set_fact:
-    username: "{{ sap_vm_provision_kubevirt_username | default(lookup('env', 'K8S_AUTH_USERNAME')) | default(omit) }}"
-    password: "{{ sap_vm_provision_kubevirt_username | default(lookup('env', 'K8S_AUTH_PASSWORD')) | default(omit) }}"
+    - name: Set fact for auth - API Key
+      no_log: "{{ __sap_vm_provision_no_log }}"
+      ansible.builtin.set_fact:
+        api_key: "{{ sap_vm_provision_kubevirt_api_key | default(lookup('env', 'K8S_AUTH_API_KEY')) | default(omit) }}"
+      when: kubeconfig is defined
 
-# - name: Set fact for auth - Alternative
-#   ansible.builtin.set_fact:
-#     ca_cert: "{{ default(lookup('env', 'K8S_AUTH_SSL_CA_CERT')) | default(omit) }}"
-#     client_cert: "{{ default(lookup('env', 'K8S_AUTH_CERT_FILE')) | default(omit) }}"
-#     client_key: "{{ default(lookup('env', 'K8S_AUTH_KEY_FILE')) | default(omit) }}"
-#     context: "{{ default(lookup('env', 'K8S_AUTH_CONTEXT')) | default(omit) }}"
+    - name: Set fact for auth - Username and Passwords
+      no_log: "{{ __sap_vm_provision_no_log }}"
+      ansible.builtin.set_fact:
+        username: "{{ sap_vm_provision_kubevirt_username | default(lookup('env', 'K8S_AUTH_USERNAME')) | default(omit) }}"
+        password: "{{ sap_vm_provision_kubevirt_username | default(lookup('env', 'K8S_AUTH_PASSWORD')) | default(omit) }}"
 
-- name: Provision hosts to KubeVirt
-  register: __sap_vm_provision_task_provision_host_all_run
-  ansible.builtin.include_tasks:
-    file: "{{ 'platform_' + sap_vm_provision_iac_type }}/{{ sap_vm_provision_iac_platform }}/execute_provision.yml"
+    # - name: Set fact for auth - Alternative
+    #   no_log: "{{ __sap_vm_provision_no_log }}"
+    #   ansible.builtin.set_fact:
+    #     ca_cert: "{{ default(lookup('env', 'K8S_AUTH_SSL_CA_CERT')) | default(omit) }}"
+    #     client_cert: "{{ default(lookup('env', 'K8S_AUTH_CERT_FILE')) | default(omit) }}"
+    #     client_key: "{{ default(lookup('env', 'K8S_AUTH_KEY_FILE')) | default(omit) }}"
+    #     context: "{{ default(lookup('env', 'K8S_AUTH_CONTEXT')) | default(omit) }}"
 
-- name: Add hosts provisioned to the Ansible Inventory
-  register: __sap_vm_provision_task_provision_host_all_add
-  ansible.builtin.add_host:
-    name: "{{ add_item[0].host_node }}"
-    groups: "{{ add_item[0].sap_system_type + '_' if (add_item[0].sap_system_type != '') }}{{ add_item[0].sap_host_type }}"
-    ansible_host: "{{ add_item[0].reported_devices[0].ips[0].address }}"
-    ansible_user: "root"
-    ansible_ssh_private_key_file: "{{ sap_vm_provision_ssh_host_private_key_file_path }}"
-    ansible_ssh_common_args: -o ConnectTimeout=180 -o ControlMaster=auto -o ControlPersist=3600s -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ForwardX11=no
-  loop: "{{ ansible_play_hosts | map('extract', hostvars, 'register_provisioned_host_all')  }}"
-  loop_control:
-    label: "{{ add_item[0].host_node }}"
-    loop_var: add_item
+    - name: Provision hosts to KubeVirt
+      no_log: "{{ __sap_vm_provision_no_log }}"
+      register: __sap_vm_provision_task_provision_host_all_run
+      ansible.builtin.include_tasks:
+        file: "{{ 'platform_' + sap_vm_provision_iac_type }}/{{ sap_vm_provision_iac_platform }}/execute_provision.yml"
+
+    - name: Add hosts provisioned to the Ansible Inventory
+      register: __sap_vm_provision_task_provision_host_all_add
+      ansible.builtin.add_host:
+        name: "{{ add_item[0].host_node }}"
+        groups: "{{ add_item[0].sap_system_type + '_' if (add_item[0].sap_system_type != '') }}{{ add_item[0].sap_host_type }}"
+        ansible_host: "{{ add_item[0].reported_devices[0].ips[0].address }}"
+        ansible_user: "root"
+        ansible_ssh_private_key_file: "{{ sap_vm_provision_ssh_host_private_key_file_path }}"
+        ansible_ssh_common_args: -o ConnectTimeout=180 -o ControlMaster=auto -o ControlPersist=3600s -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ForwardX11=no
+      loop: "{{ ansible_play_hosts | map('extract', hostvars, 'register_provisioned_host_all')  }}"
+      loop_control:
+        label: "{{ add_item[0].host_node }}"
+        loop_var: add_item
 
 
 # Cannot override any variables from extravars input, see https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_variables.html#understanding-variable-precedence
 # Ensure no default value exists for any prompted variable before execution of Ansible Playbook
 
-- name: Set fact to hold all inventory hosts in all groups
-  ansible.builtin.set_fact:
-    groups_merged_list: "{{ [ [ groups['hana_primary'] | default([]) ] , [ groups['hana_secondary'] | default([]) ] , [ groups['nwas_ascs'] | default([]) ] , [ groups['nwas_ers'] | default([]) ] , [ groups['nwas_pas'] | default([]) ] , [ groups['nwas_aas'] | default([]) ] ] | flatten | select() }}"
+    - name: Set fact to hold all inventory hosts in all groups
+      ansible.builtin.set_fact:
+        groups_merged_list: "{{ [ [ groups['hana_primary'] | default([]) ] , [ groups['hana_secondary'] | default([]) ] , [ groups['nwas_ascs'] | default([]) ] , [ groups['nwas_ers'] | default([]) ] , [ groups['nwas_pas'] | default([]) ] , [ groups['nwas_aas'] | default([]) ] ] | flatten | select() }}"
 
-- name: Set Ansible Vars
-  register: __sap_vm_provision_task_ansible_vars_set
-  ansible.builtin.include_tasks:
-    file: common/set_ansible_vars.yml
+    - name: Set Ansible Vars
+      register: __sap_vm_provision_task_ansible_vars_set
+      ansible.builtin.include_tasks:
+        file: common/set_ansible_vars.yml
 
   #  - ansible.builtin.debug:
   #      var: __sap_vm_provision_task_provision_host_all_add.results
+
+  rescue:
+    # This requires no_log set on each Ansible Task, and not set on the Ansible Task Block
+    # This requires an Ansible Task Block containing the Ansible Tasks for calling
+    # Infrastructure Platform APIs (via Ansible Modules)
+    - name: Show errors in task outputs
+      ansible.builtin.fail:
+        msg: "{{ lookup('ansible.builtin.vars', loop_item) }}"
+      loop:
+        - __sap_vm_provision_task_provision_host_all_run
+        - __sap_vm_provision_task_provision_host_single
+        - __sap_vm_provision_task_provision_host_single_info
+        - __sap_vm_provision_task_ansible_facts_host_disks_info
+        - __sap_vm_provision_task_provision_host_all_add
+      loop_control:
+        loop_var: loop_item
+        index_var: loop_item_index
+        label: "{{ 'Variable No. ' + (loop_item_index | string) }}"
+      when:
+        - lookup('ansible.builtin.vars', loop_item, default='') | length > 0
+        - not lookup('ansible.builtin.vars', loop_item, default='') is skipped
+        - lookup('ansible.builtin.vars', loop_item, default='') is failed
+
 
 - name: Ansible Task block to execute on target inventory hosts
   delegate_to: "{{ inventory_hostname }}"

--- a/roles/sap_vm_provision/tasks/platform_ansible/kubevirt_vm/execute_provision.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/kubevirt_vm/execute_provision.yml
@@ -146,6 +146,8 @@
 
 
 - name: Provision KubeVirt Virtual Machine
+  no_log: "{{ __sap_vm_provision_no_log }}"
+  register: __sap_vm_provision_task_provision_host_single
   kubevirt.core.kubevirt_vm:
     api_version: "{{ api_version | default(omit) }}"
     validate_certs: "{{ validate_certs | default(omit) }}"
@@ -233,6 +235,7 @@
 
 
 - name: Check VM status
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_provision_host_single_info
   kubevirt.core.kubevirt_vm_info:
     name: "{{ inventory_hostname }}"

--- a/roles/sap_vm_provision/tasks/platform_ansible/kubevirt_vm/execute_provision.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/kubevirt_vm/execute_provision.yml
@@ -245,7 +245,7 @@
 
 
 - name: Collect only facts about hardware
-  register: host_disks_info
+  register: __sap_vm_provision_task_ansible_facts_host_disks_info
   ansible.builtin.setup:
     gather_subset:
       - hardware
@@ -263,7 +263,7 @@
 
 #- name: Debug Ansible Facts devices used list
 #  ansible.builtin.debug:
-#    msg: "{{ host_disks_info.ansible_facts.ansible_device_links.ids.keys() | list }}"
+#    msg: "{{ __sap_vm_provision_task_ansible_facts_host_disks_info.ansible_facts.ansible_device_links.ids.keys() | list }}"
 
 
 - name: Append loop value to register

--- a/roles/sap_vm_provision/tasks/platform_ansible/kubevirt_vm/execute_provision.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/kubevirt_vm/execute_provision.yml
@@ -233,7 +233,7 @@
 
 
 - name: Check VM status
-  register: register_provisioned_host_single_info
+  register: __sap_vm_provision_task_provision_host_single_info
   kubevirt.core.kubevirt_vm_info:
     name: "{{ inventory_hostname }}"
     namespace: "{{ sap_vm_provision_kubevirt_target_namespace }}"
@@ -241,7 +241,7 @@
 
 - name: Create fact for delegate host IP
   ansible.builtin.set_fact:
-    provisioned_private_ip: "{{ register_provisioned_host_single_info.spec.UNKNOWN_VARIABLE_FOR_PRIVATE_IP_HERE }}"
+    provisioned_private_ip: "{{ __sap_vm_provision_task_provision_host_single_info.spec.UNKNOWN_VARIABLE_FOR_PRIVATE_IP_HERE }}"
 
 
 - name: Collect only facts about hardware
@@ -268,8 +268,8 @@
 
 - name: Append loop value to register
   ansible.builtin.set_fact:
-    register_provisioned_host_single: "{{ register_provisioned_host_single_info.spec.UKNOWN_VARIABLE_HERE | combine( { 'host_node' : inventory_hostname } , { 'sap_host_type' : lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][scaleout_origin_host_spec | default(inventory_hostname)].sap_host_type } , { 'sap_system_type' : (lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][scaleout_origin_host_spec | default(inventory_hostname)].sap_system_type | default('')) } ) }}"
+    __sap_vm_provision_task_provision_host_single: "{{ __sap_vm_provision_task_provision_host_single_info.spec.UKNOWN_VARIABLE_HERE | combine( { 'host_node' : inventory_hostname } , { 'sap_host_type' : lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][scaleout_origin_host_spec | default(inventory_hostname)].sap_host_type } , { 'sap_system_type' : (lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][scaleout_origin_host_spec | default(inventory_hostname)].sap_system_type | default('')) } ) }}"
 
 - name: Append output to merged register
   ansible.builtin.set_fact:
-    register_provisioned_host_all: "{{ register_provisioned_host_all + [register_provisioned_host_single] }}"
+    register_provisioned_host_all: "{{ register_provisioned_host_all + [__sap_vm_provision_task_provision_host_single] }}"

--- a/roles/sap_vm_provision/tasks/platform_ansible/kubevirt_vm/execute_provision.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/kubevirt_vm/execute_provision.yml
@@ -149,6 +149,8 @@
   no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_provision_host_single
   kubevirt.core.kubevirt_vm:
+
+    ## Hypervisor Control Plane definition and credentials
     api_version: "{{ api_version | default(omit) }}"
     validate_certs: "{{ validate_certs | default(omit) }}"
     persist_config: "{{ persist_config | default(omit) }}"

--- a/roles/sap_vm_provision/tasks/platform_ansible/msazure_vm/execute_main.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/msazure_vm/execute_main.yml
@@ -36,7 +36,7 @@
         __sap_vm_provision_msazure_private_dns_auto_register_records: "{{ (__sap_vm_provision_msazure_private_dns_virtual_network_links.virtualnetworklinks | selectattr('virtual_network.id', 'search', sap_vm_provision_msazure_vnet_name))[0].registration_enabled }}"
 
     - name: Provision hosts to MS Azure
-      register: register_provisioned_hosts
+      register: __sap_vm_provision_task_provision_host_all_run
       ansible.builtin.include_tasks:
         file: "{{ 'platform_' + sap_vm_provision_iac_type }}/{{ sap_vm_provision_iac_platform }}/execute_provision.yml"
         apply:
@@ -48,7 +48,7 @@
             AZURE_SECRET: "{{ sap_vm_provision_msazure_app_client_secret }}"
 
     - name: Add hosts provisioned to the Ansible Inventory
-      register: register_add_hosts
+      register: __sap_vm_provision_task_provision_host_all_add
       ansible.builtin.add_host:
         name: "{{ add_item[0].host_node }}"
         groups: "{{ add_item[0].sap_system_type + '_' if (add_item[0].sap_system_type != '') }}{{ add_item[0].sap_host_type }}"
@@ -87,7 +87,7 @@
       when: not __sap_vm_provision_msazure_private_dns_auto_register_records
 
   #  - ansible.builtin.debug:
-  #      var: register_add_hosts.results
+  #      var: __sap_vm_provision_task_provision_host_all_add.results
 
 - name: Ansible Task block to execute on target inventory hosts
   delegate_to: "{{ inventory_hostname }}"

--- a/roles/sap_vm_provision/tasks/platform_ansible/msazure_vm/execute_main.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/msazure_vm/execute_main.yml
@@ -17,19 +17,19 @@
     # We cannot assume Resource Group if the SSH Public Key is managed by Administrators
     # Therefore use without any parameter to retrieve list of all SSH Public Keys and filter in Ansible
     - name: Get all SSH Public Keys in MS Azure
-      azure.azcollection.azure_rm_sshpublickey_info:
       register: __sap_vm_provision_msazure_key_pair_name_ssh_host_public_keys
+      azure.azcollection.azure_rm_sshpublickey_info:
 
     - name: Set fact for selected SSH Public Key in MS Azure
       ansible.builtin.set_fact:
         __sap_vm_provision_msazure_key_pair_name_ssh_host_public_key_value: "{{ (__sap_vm_provision_msazure_key_pair_name_ssh_host_public_keys.ssh_keys | selectattr('name', '==', sap_vm_provision_msazure_key_pair_name_ssh_host_public_key))[0].public_key }}"
 
     - name: Get Private DNS Zone Virtual Network Links
+      register: __sap_vm_provision_msazure_private_dns_virtual_network_links
       azure.azcollection.azure_rm_privatednszonelink_info:
         # DNS may exist in separate Resource Group. Use empty string var (or default false if undefined) to evaluate to false boolean, and use Python or logic operator
         resource_group: "{{ (sap_vm_provision_msazure_private_dns_resource_group_name | default(false)) or sap_vm_provision_msazure_resource_group_name }}"
         zone_name: "{{ sap_vm_provision_dns_root_domain }}"
-      register: __sap_vm_provision_msazure_private_dns_virtual_network_links
 
     - name: Set boolean fact for Auto Registration of DNS Records from Private DNS Zone Virtual Network Link
       ansible.builtin.set_fact:

--- a/roles/sap_vm_provision/tasks/platform_ansible/msazure_vm/execute_main.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/msazure_vm/execute_main.yml
@@ -1,12 +1,15 @@
 ---
 
 - name: Ansible Task block for looped provisioning of MS Azure VMs
+  any_errors_fatal: true
+  # Using environment, no_log is ineffective and log will show 'EXEC /bin/sh -c 'ENV_VAR=value python3 /AnsiballZ_ansible_module_name.py && sleep 0'
+  # Therefore do not use environment for secrets, use only for non-sensitive values as this will reduce Ansible Task parameters.
   environment:
     ANSIBLE_AZURE_AUTH_SOURCE: "env"
-    AZURE_SUBSCRIPTION_ID: "{{ sap_vm_provision_msazure_subscription_id }}"
-    AZURE_TENANT: "{{ sap_vm_provision_msazure_tenant_id }}"
-    AZURE_CLIENT_ID: "{{ sap_vm_provision_msazure_app_client_id }}"
-    AZURE_SECRET: "{{ sap_vm_provision_msazure_app_client_secret }}"
+    # AZURE_SUBSCRIPTION_ID: "{{ sap_vm_provision_msazure_subscription_id }}"
+    # AZURE_TENANT: "{{ sap_vm_provision_msazure_tenant_id }}"
+    # AZURE_CLIENT_ID: "{{ sap_vm_provision_msazure_app_client_id }}"
+    # AZURE_SECRET: "{{ sap_vm_provision_msazure_app_client_secret }}"
   block:
 
     - name: Set fact to hold loop variables from include_tasks
@@ -17,19 +20,31 @@
     # We cannot assume Resource Group if the SSH Public Key is managed by Administrators
     # Therefore use without any parameter to retrieve list of all SSH Public Keys and filter in Ansible
     - name: Get all SSH Public Keys in MS Azure
+      no_log: "{{ __sap_vm_provision_no_log }}"
       register: __sap_vm_provision_msazure_key_pair_name_ssh_host_public_keys
       azure.azcollection.azure_rm_sshpublickey_info:
+        # Azure credentials
+        subscription_id: "{{ sap_vm_provision_msazure_subscription_id }}"
+        tenant: "{{ sap_vm_provision_msazure_tenant_id }}"
+        client_id: "{{ sap_vm_provision_msazure_app_client_id }}"
+        secret: "{{ sap_vm_provision_msazure_app_client_secret }}"
 
     - name: Set fact for selected SSH Public Key in MS Azure
       ansible.builtin.set_fact:
         __sap_vm_provision_msazure_key_pair_name_ssh_host_public_key_value: "{{ (__sap_vm_provision_msazure_key_pair_name_ssh_host_public_keys.ssh_keys | selectattr('name', '==', sap_vm_provision_msazure_key_pair_name_ssh_host_public_key))[0].public_key }}"
 
     - name: Get Private DNS Zone Virtual Network Links
+      no_log: "{{ __sap_vm_provision_no_log }}"
       register: __sap_vm_provision_msazure_private_dns_virtual_network_links
       azure.azcollection.azure_rm_privatednszonelink_info:
         # DNS may exist in separate Resource Group. Use empty string var (or default false if undefined) to evaluate to false boolean, and use Python or logic operator
         resource_group: "{{ (sap_vm_provision_msazure_private_dns_resource_group_name | default(false)) or sap_vm_provision_msazure_resource_group_name }}"
         zone_name: "{{ sap_vm_provision_dns_root_domain }}"
+        # Azure credentials
+        subscription_id: "{{ sap_vm_provision_msazure_subscription_id }}"
+        tenant: "{{ sap_vm_provision_msazure_tenant_id }}"
+        client_id: "{{ sap_vm_provision_msazure_app_client_id }}"
+        secret: "{{ sap_vm_provision_msazure_app_client_secret }}"
 
     - name: Set boolean fact for Auto Registration of DNS Records from Private DNS Zone Virtual Network Link
       ansible.builtin.set_fact:
@@ -42,10 +57,10 @@
         apply:
           environment:
             ANSIBLE_AZURE_AUTH_SOURCE: "env"
-            AZURE_SUBSCRIPTION_ID: "{{ sap_vm_provision_msazure_subscription_id }}"
-            AZURE_TENANT: "{{ sap_vm_provision_msazure_tenant_id }}"
-            AZURE_CLIENT_ID: "{{ sap_vm_provision_msazure_app_client_id }}"
-            AZURE_SECRET: "{{ sap_vm_provision_msazure_app_client_secret }}"
+        #     AZURE_SUBSCRIPTION_ID: "{{ sap_vm_provision_msazure_subscription_id }}"
+        #     AZURE_TENANT: "{{ sap_vm_provision_msazure_tenant_id }}"
+        #     AZURE_CLIENT_ID: "{{ sap_vm_provision_msazure_app_client_id }}"
+        #     AZURE_SECRET: "{{ sap_vm_provision_msazure_app_client_secret }}"
 
     - name: Add hosts provisioned to the Ansible Inventory
       register: __sap_vm_provision_task_provision_host_all_add
@@ -76,6 +91,7 @@
 
     # Create "A" (IPv4 Address) Resource Record to map IPv4 address as hostname / subdomain of the root domain name
     - name: Ansible MS Azure Private DNS Records for hosts
+      no_log: "{{ __sap_vm_provision_no_log }}"
       azure.azcollection.azure_rm_privatednsrecordset:
         # DNS may exist in separate Resource Group. Use empty string var (or default false if undefined) to evaluate to false boolean, and use Python or logic operator
         resource_group: "{{ (sap_vm_provision_msazure_private_dns_resource_group_name | default(false)) or sap_vm_provision_msazure_resource_group_name }}"
@@ -84,10 +100,43 @@
         record_type: A
         records:
           - entry: "{{ hostvars[inventory_hostname].ansible_host }}"
+        # Azure credentials
+        subscription_id: "{{ sap_vm_provision_msazure_subscription_id }}"
+        tenant: "{{ sap_vm_provision_msazure_tenant_id }}"
+        client_id: "{{ sap_vm_provision_msazure_app_client_id }}"
+        secret: "{{ sap_vm_provision_msazure_app_client_secret }}"
       when: not __sap_vm_provision_msazure_private_dns_auto_register_records
 
   #  - ansible.builtin.debug:
   #      var: __sap_vm_provision_task_provision_host_all_add.results
+
+  rescue:
+    # This requires no_log set on each Ansible Task, and not set on the Ansible Task Block
+    # This requires an Ansible Task Block containing the Ansible Tasks for calling
+    # Infrastructure Platform APIs (via Ansible Modules)
+    - name: Show errors in task outputs
+      ansible.builtin.fail:
+        msg: "{{ lookup('ansible.builtin.vars', loop_item) }}"
+      loop:
+        - __sap_vm_provision_msazure_key_pair_name_ssh_host_public_keys
+        - __sap_vm_provision_msazure_private_dns_virtual_network_links
+        - __sap_vm_provision_task_provision_host_all_run
+        - __sap_vm_provision_task_provision_host_single_vnic_info
+        - __sap_vm_provision_task_provision_host_single_vnic
+        - __sap_vm_provision_task_provision_host_single
+        - __sap_vm_provision_task_provision_host_single_info
+        - __sap_vm_provision_task_ansible_facts_host_disks_info
+        - __sap_vm_provision_task_provision_host_single_volumes
+        - __sap_vm_provision_task_provision_host_all_add
+      loop_control:
+        loop_var: loop_item
+        index_var: loop_item_index
+        label: "{{ 'Variable No. ' + (loop_item_index | string) }}"
+      when:
+        - lookup('ansible.builtin.vars', loop_item, default='') | length > 0
+        - not lookup('ansible.builtin.vars', loop_item, default='') is skipped
+        - lookup('ansible.builtin.vars', loop_item, default='') is failed
+
 
 - name: Ansible Task block to execute on target inventory hosts
   delegate_to: "{{ inventory_hostname }}"
@@ -155,25 +204,28 @@
 
     # Ensure Primary Active Network Interface is used for Linux Pacemaker configuration (e.g. eth0), see documentation for Accelerated Networking
     - name: Identify Primary Active Network Interface
-      register: __msazure_primary_active_vnic
+      register: __sap_vm_provision_task_os_primary_active_vnic
       ansible.builtin.shell: |
         set -o pipefail && ip route show default 0.0.0.0/0 | awk '/default/ {print $5}'
 
     - name: Set facts on each host - Primary Active Network Interface for HA/DR
       ansible.builtin.set_fact:
-        sap_ha_pacemaker_cluster_vip_client_interface: "{{ __msazure_primary_active_vnic.stdout }}"
-      when: __msazure_primary_active_vnic is defined
+        sap_ha_pacemaker_cluster_vip_client_interface: "{{ __sap_vm_provision_task_os_primary_active_vnic.stdout }}"
+      when: __sap_vm_provision_task_os_primary_active_vnic is defined
 
 
 - name: Ansible Task block for provisioning of High Availability resources for MS Azure VMs
   delegate_to: localhost
+  any_errors_fatal: true
   run_once: true
+  # Using environment, no_log is ineffective and log will show 'EXEC /bin/sh -c 'ENV_VAR=value python3 /AnsiballZ_ansible_module_name.py && sleep 0'
+  # Therefore do not use environment for secrets, use only for non-sensitive values as this will reduce Ansible Task parameters.
   environment:
     ANSIBLE_AZURE_AUTH_SOURCE: "env"
-    AZURE_SUBSCRIPTION_ID: "{{ sap_vm_provision_msazure_subscription_id }}"
-    AZURE_TENANT: "{{ sap_vm_provision_msazure_tenant_id }}"
-    AZURE_CLIENT_ID: "{{ sap_vm_provision_msazure_app_client_id }}"
-    AZURE_SECRET: "{{ sap_vm_provision_msazure_app_client_secret }}"
+    # AZURE_SUBSCRIPTION_ID: "{{ sap_vm_provision_msazure_subscription_id }}"
+    # AZURE_TENANT: "{{ sap_vm_provision_msazure_tenant_id }}"
+    # AZURE_CLIENT_ID: "{{ sap_vm_provision_msazure_app_client_id }}"
+    # AZURE_SECRET: "{{ sap_vm_provision_msazure_app_client_secret }}"
   when:
     - sap_ha_pacemaker_cluster_msazure_resource_group is defined
     - (groups["hana_secondary"] is defined and (groups["hana_secondary"] | length>0)) or (groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0)) or (groups["anydb_secondary"] is defined and (groups["anydb_secondary"] | length>0))
@@ -185,7 +237,39 @@
         apply:
           environment:
             ANSIBLE_AZURE_AUTH_SOURCE: "env"
-            AZURE_SUBSCRIPTION_ID: "{{ sap_vm_provision_msazure_subscription_id }}"
-            AZURE_TENANT: "{{ sap_vm_provision_msazure_tenant_id }}"
-            AZURE_CLIENT_ID: "{{ sap_vm_provision_msazure_app_client_id }}"
-            AZURE_SECRET: "{{ sap_vm_provision_msazure_app_client_secret }}"
+            # AZURE_SUBSCRIPTION_ID: "{{ sap_vm_provision_msazure_subscription_id }}"
+            # AZURE_TENANT: "{{ sap_vm_provision_msazure_tenant_id }}"
+            # AZURE_CLIENT_ID: "{{ sap_vm_provision_msazure_app_client_id }}"
+            # AZURE_SECRET: "{{ sap_vm_provision_msazure_app_client_secret }}"
+
+  rescue:
+    # This requires no_log set on each Ansible Task, and not set on the Ansible Task Block
+    # This requires an Ansible Task Block containing the Ansible Tasks for calling
+    # Infrastructure Platform APIs (via Ansible Modules)
+    - name: Show errors in task outputs
+      ansible.builtin.fail:
+        msg: "{{ lookup('ansible.builtin.vars', loop_item) }}"
+      loop:
+        - __sap_vm_provision_msazure_vnet_subnet_rt_info
+        - __sap_vm_provision_msazure_vnet_subnet_rt_route_sap_hana
+        - __sap_vm_provision_msazure_vnet_subnet_rt_route_sap_netweaver_ascs
+        - __sap_vm_provision_msazure_vnet_subnet_rt_route_sap_netweaver_ers
+        - __sap_vm_provision_msazure_vnet_subnet_rt_route_sap_netweaver_pas
+        - __sap_vm_provision_msazure_vnet_subnet_rt_route_sap_netweaver_aas
+        - __sap_vm_provision_msazure_iam_role_fencing
+        - __sap_vm_provision_msazure_vm_info_collect
+        - __sap_vm_provision_msazure_vnet_subnet_info
+        - __sap_vm_provision_msazure_lb1a_info
+        - __sap_vm_provision_msazure_lb1b_info
+        - __sap_vm_provision_msazure_lb2_info
+        - __sap_vm_provision_task_provision_host_single_vnic1
+        - __sap_vm_provision_task_provision_host_single_vnic1
+        - __sap_vm_provision_task_provision_host_single_vnic2
+      loop_control:
+        loop_var: loop_item
+        index_var: loop_item_index
+        label: "{{ 'Variable No. ' + (loop_item_index | string) }}"
+      when:
+        - lookup('ansible.builtin.vars', loop_item, default='') | length > 0
+        - not lookup('ansible.builtin.vars', loop_item, default='') is skipped
+        - lookup('ansible.builtin.vars', loop_item, default='') is failed

--- a/roles/sap_vm_provision/tasks/platform_ansible/msazure_vm/execute_main.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/msazure_vm/execute_main.yml
@@ -263,7 +263,6 @@
         - __sap_vm_provision_msazure_lb1b_info
         - __sap_vm_provision_msazure_lb2_info
         - __sap_vm_provision_task_provision_host_single_vnic1
-        - __sap_vm_provision_task_provision_host_single_vnic1
         - __sap_vm_provision_task_provision_host_single_vnic2
       loop_control:
         loop_var: loop_item

--- a/roles/sap_vm_provision/tasks/platform_ansible/msazure_vm/execute_main.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/msazure_vm/execute_main.yml
@@ -70,7 +70,7 @@
         groups_merged_list: "{{ [ [ groups['hana_primary'] | default([]) ] , [ groups['hana_secondary'] | default([]) ] , [ groups['nwas_ascs'] | default([]) ] , [ groups['nwas_ers'] | default([]) ] , [ groups['nwas_pas'] | default([]) ] , [ groups['nwas_aas'] | default([]) ] ] | flatten | select() }}"
 
     - name: Set Ansible Vars
-      register: register_set_ansible_vars
+      register: __sap_vm_provision_task_ansible_vars_set
       ansible.builtin.include_tasks:
         file: common/set_ansible_vars.yml
 
@@ -106,26 +106,26 @@
         name: "{{ inventory_hostname_short }}"
 
     - name: Set /etc/hosts
-      register: register_etc_hosts_file
+      register: __sap_vm_provision_task_os_etc_hosts
       ansible.builtin.include_tasks:
         file: common/set_etc_hosts.yml
 
     - name: Set /etc/hosts for HA
-      register: register_etc_hosts_file_ha
+      register: __sap_vm_provision_task_os_etc_hosts_ha
       ansible.builtin.include_tasks:
         file: common/set_etc_hosts_ha.yml
       when:
         - (groups["hana_secondary"] is defined and (groups["hana_secondary"] | length>0)) or (groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0)) or (groups["anydb_secondary"] is defined and (groups["anydb_secondary"] | length>0))
 
     - name: Set /etc/hosts for Scale-Out
-      register: register_etc_hosts_file_scaleout
+      register: __sap_vm_provision_task_os_etc_hosts_scaleout
       ansible.builtin.include_tasks:
         file: common/set_etc_hosts_scaleout.yml
       when:
         - (groups["hana_primary"] is defined and (groups["hana_primary"] | length>0)) and (sap_hana_scaleout_active_coordinator is defined or sap_hana_scaleout_active_worker is defined or sap_hana_scaleout_standby is defined)
 
     - name: Set vars for sap_storage_setup Ansible Role
-      register: register_ansible_vars_storage
+      register: __sap_vm_provision_task_ansible_vars_storage
       ansible.builtin.include_tasks:
         file: common/set_ansible_vars_storage.yml
 

--- a/roles/sap_vm_provision/tasks/platform_ansible/msazure_vm/execute_provision.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/msazure_vm/execute_provision.yml
@@ -71,7 +71,7 @@
     name: "{{ inventory_hostname }}"
 
 - name: Read MS Azure VM attached disks information
-  register: api_host_disks_info
+  register: api___sap_vm_provision_task_ansible_facts_host_disks_info
   azure.azcollection.azure_rm_manageddisk_info:
     managed_by: "{{ api_host_info.vms[0].id }}"
 
@@ -92,7 +92,7 @@
     delegate_sap_vm_provision_ssh_host_private_key_file_path: "{{ sap_vm_provision_ssh_host_private_key_file_path }}"
 
 - name: Collect only facts about hardware
-  register: host_disks_info
+  register: __sap_vm_provision_task_ansible_facts_host_disks_info
   ansible.builtin.setup:
     gather_subset:
       - hardware
@@ -111,14 +111,14 @@
 
 #- name: Debug Ansible Facts devices used list
 #  ansible.builtin.debug:
-#    msg: "{{ host_disks_info.ansible_facts.ansible_device_links.ids.keys() | list }}"
+#    msg: "{{ __sap_vm_provision_task_ansible_facts_host_disks_info.ansible_facts.ansible_device_links.ids.keys() | list }}"
 
 
 - name: Set fact for available storage volume device names
   ansible.builtin.set_fact:
     available_volumes: |-
       {% set letters = 'bcdefghijklmnopqrstuvwxyz' %}
-      {% set ansible_facts_devices_used_list = host_disks_info.ansible_facts.ansible_device_links.ids.keys() | list %}
+      {% set ansible_facts_devices_used_list = __sap_vm_provision_task_ansible_facts_host_disks_info.ansible_facts.ansible_device_links.ids.keys() | list %}
       {% set volumes = [] %}
       {%- for letter in letters -%}
         {% for device in ansible_facts_devices_used_list -%}
@@ -242,7 +242,7 @@
         path: /etc/ssh/sshd_config
         regexp: '(^PermitRootLogin no)'
         replace: 'PermitRootLogin yes'
-      register: sshd_config
+      register: __sap_vm_provision_task_os_sshd_config
 
     - name: Reload sshd service
       ansible.builtin.service:

--- a/roles/sap_vm_provision/tasks/platform_ansible/msazure_vm/execute_provision.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/msazure_vm/execute_provision.yml
@@ -238,11 +238,11 @@
         replace: 'ssh-rsa'
 
     - name: Permit root login
+      register: __sap_vm_provision_task_os_sshd_config
       ansible.builtin.replace:
         path: /etc/ssh/sshd_config
         regexp: '(^PermitRootLogin no)'
         replace: 'PermitRootLogin yes'
-      register: __sap_vm_provision_task_os_sshd_config
 
     - name: Reload sshd service
       ansible.builtin.service:

--- a/roles/sap_vm_provision/tasks/platform_ansible/msazure_vm/execute_provision.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/msazure_vm/execute_provision.yml
@@ -171,6 +171,7 @@
 # The volume creation task requires the above task to define the parameter
 # which contains the calculated unique device names.
 - name: Provision Azure Managed Disk volumes for Azure VM filesystems
+  register: __sap_vm_provision_task_provision_host_single_volumes
   azure.azcollection.azure_rm_manageddisk:
     resource_group: "{{ sap_vm_provision_msazure_resource_group_name }}"
     location: "{{ sap_vm_provision_msazure_location_region }}"
@@ -189,7 +190,6 @@
   when:
     - vol_item.fstype is defined
     - vol_item.size > 0
-  register: __sap_vm_provision_task_provision_host_single_volumes
   failed_when: "(__sap_vm_provision_task_provision_host_single_volumes.msg is defined) and ('already exists' not in __sap_vm_provision_task_provision_host_single_volumes.msg)"
 
 

--- a/roles/sap_vm_provision/tasks/platform_ansible/msazure_vm/execute_provision.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/msazure_vm/execute_provision.yml
@@ -65,15 +65,15 @@
 
 
 - name: Read MS Azure VM information
-  register: api_host_info
+  register: __sap_vm_provision_task_provision_host_single_info
   azure.azcollection.azure_rm_virtualmachine_info:
     resource_group: "{{ sap_vm_provision_msazure_resource_group_name }}"
     name: "{{ inventory_hostname }}"
 
 - name: Read MS Azure VM attached disks information
-  register: api___sap_vm_provision_task_ansible_facts_host_disks_info
+  register: __sap_vm_provision_task_ansible_facts_host_disks_info
   azure.azcollection.azure_rm_manageddisk_info:
-    managed_by: "{{ api_host_info.vms[0].id }}"
+    managed_by: "{{ __sap_vm_provision_task_provision_host_single_info.vms[0].id }}"
 
 
 - name: Create fact for delegate host IP

--- a/roles/sap_vm_provision/tasks/platform_ansible/msazure_vm/execute_provision.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/msazure_vm/execute_provision.yml
@@ -15,19 +15,26 @@
     - not inventory_hostname in lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan].keys()
 
 - name: Verify if network interface for MS Azure VM already exists (i.e. re-run)
-  register: register_provisioned_vnic_info
+  no_log: "{{ __sap_vm_provision_no_log }}"
+  register: __sap_vm_provision_task_provision_host_single_vnic_info
   azure.azcollection.azure_rm_networkinterface_info:
     resource_group: "{{ sap_vm_provision_msazure_resource_group_name }}"
     name: "{{ inventory_hostname }}-nic"
+    # Azure credentials
+    subscription_id: "{{ sap_vm_provision_msazure_subscription_id }}"
+    tenant: "{{ sap_vm_provision_msazure_tenant_id }}"
+    client_id: "{{ sap_vm_provision_msazure_app_client_id }}"
+    secret: "{{ sap_vm_provision_msazure_app_client_secret }}"
 
 - name: Provision network interface for MS Azure VM
-  register: register_provisioned_vnic
+  no_log: "{{ __sap_vm_provision_no_log }}"
+  register: __sap_vm_provision_task_provision_host_single_vnic
   azure.azcollection.azure_rm_networkinterface:
     resource_group: "{{ sap_vm_provision_msazure_resource_group_name }}"
     location: "{{ sap_vm_provision_msazure_location_region }}"
     name: "{{ inventory_hostname }}-nic"
     virtual_network: "{{ sap_vm_provision_msazure_vnet_name }}"
-    subnet_name: "{{ sap_vm_provision_msazure_vnet_subnet_name }}"
+    subnet_name: "{{ sap_vm_provision___sap_vm_provision_msazure_vnet_subnet_name }}"
     create_with_security_group: false
     ip_configurations:
       - name: "{{ inventory_hostname }}-nic-ipconfig"
@@ -35,9 +42,15 @@
         #private_ip_allocation_method: "Static" # When static, must define the specific IP Address
     enable_accelerated_networking: true
     enable_ip_forwarding: "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][scaleout_origin_host_spec | default(inventory_hostname)].disable_ip_anti_spoofing }}" # When disable the Anti IP Spoofing = true, then Enable IP Forwarding = true
-  when: not (register_provisioned_vnic_info.networkinterfaces | length) > 0
+    # Azure credentials
+    subscription_id: "{{ sap_vm_provision_msazure_subscription_id }}"
+    tenant: "{{ sap_vm_provision_msazure_tenant_id }}"
+    client_id: "{{ sap_vm_provision_msazure_app_client_id }}"
+    secret: "{{ sap_vm_provision_msazure_app_client_secret }}"
+  when: not (__sap_vm_provision_task_provision_host_single_vnic_info.networkinterfaces | length) > 0
 
 - name: Provision MS Azure VM
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_provision_host_single
   azure.azcollection.azure_rm_virtualmachine:
     resource_group: "{{ sap_vm_provision_msazure_resource_group_name }}"
@@ -62,18 +75,35 @@
       type: SystemAssigned
     state: "present"
     started: true
+    # Azure credentials
+    subscription_id: "{{ sap_vm_provision_msazure_subscription_id }}"
+    tenant: "{{ sap_vm_provision_msazure_tenant_id }}"
+    client_id: "{{ sap_vm_provision_msazure_app_client_id }}"
+    secret: "{{ sap_vm_provision_msazure_app_client_secret }}"
 
 
 - name: Read MS Azure VM information
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_provision_host_single_info
   azure.azcollection.azure_rm_virtualmachine_info:
     resource_group: "{{ sap_vm_provision_msazure_resource_group_name }}"
     name: "{{ inventory_hostname }}"
+    # Azure credentials
+    subscription_id: "{{ sap_vm_provision_msazure_subscription_id }}"
+    tenant: "{{ sap_vm_provision_msazure_tenant_id }}"
+    client_id: "{{ sap_vm_provision_msazure_app_client_id }}"
+    secret: "{{ sap_vm_provision_msazure_app_client_secret }}"
 
 - name: Read MS Azure VM attached disks information
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_ansible_facts_host_disks_info
   azure.azcollection.azure_rm_manageddisk_info:
     managed_by: "{{ __sap_vm_provision_task_provision_host_single_info.vms[0].id }}"
+    # Azure credentials
+    subscription_id: "{{ sap_vm_provision_msazure_subscription_id }}"
+    tenant: "{{ sap_vm_provision_msazure_tenant_id }}"
+    client_id: "{{ sap_vm_provision_msazure_app_client_id }}"
+    secret: "{{ sap_vm_provision_msazure_app_client_secret }}"
 
 
 - name: Create fact for delegate host IP
@@ -171,6 +201,7 @@
 # The volume creation task requires the above task to define the parameter
 # which contains the calculated unique device names.
 - name: Provision Azure Managed Disk volumes for Azure VM filesystems
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_provision_host_single_volumes
   azure.azcollection.azure_rm_manageddisk:
     resource_group: "{{ sap_vm_provision_msazure_resource_group_name }}"
@@ -182,6 +213,11 @@
         resource_group: "{{ sap_vm_provision_msazure_resource_group_name }}"
     # Premium SSD size (P), Standard SSD size (E), Standard HDD size (S)
     storage_account_type: "{% if vol_item.type | regex_search('^P.*') %}Premium_LRS{% elif vol_item.type | regex_search('^E.*') %}StandardSSD_LRS{% elif vol_item.type | regex_search('^S.*') %}Standard_LRS{% else %}StandardSSD_LRS{% endif %}" # Standard_LRS, StandardSSD_LRS, Premium_LRS, UltraSSD_LRS
+    # Azure credentials
+    subscription_id: "{{ sap_vm_provision_msazure_subscription_id }}"
+    tenant: "{{ sap_vm_provision_msazure_tenant_id }}"
+    client_id: "{{ sap_vm_provision_msazure_app_client_id }}"
+    secret: "{{ sap_vm_provision_msazure_app_client_secret }}"
   loop: "{{ filesystem_volume_map }}"
   loop_control:
     loop_var: vol_item

--- a/roles/sap_vm_provision/tasks/platform_ansible/msazure_vm/execute_provision.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/msazure_vm/execute_provision.yml
@@ -38,7 +38,7 @@
   when: not (register_provisioned_vnic_info.networkinterfaces | length) > 0
 
 - name: Provision MS Azure VM
-  register: register_provisioned_host_single
+  register: __sap_vm_provision_task_provision_host_single
   azure.azcollection.azure_rm_virtualmachine:
     resource_group: "{{ sap_vm_provision_msazure_resource_group_name }}"
     location: "{{ sap_vm_provision_msazure_location_region }}"
@@ -78,7 +78,7 @@
 
 - name: Create fact for delegate host IP
   ansible.builtin.set_fact:
-    provisioned_private_ip: "{{ register_provisioned_host_single.ansible_facts.azure_vm.network_profile.network_interfaces[0].properties.ip_configurations[0].private_ip_address }}"
+    provisioned_private_ip: "{{ __sap_vm_provision_task_provision_host_single.ansible_facts.azure_vm.network_profile.network_interfaces[0].properties.ip_configurations[0].private_ip_address }}"
 
 
 - name: Copy facts to delegate host
@@ -189,20 +189,20 @@
   when:
     - vol_item.fstype is defined
     - vol_item.size > 0
-  register: volume_provisioning
-  failed_when: "(volume_provisioning.msg is defined) and ('already exists' not in volume_provisioning.msg)"
+  register: __sap_vm_provision_task_provision_host_single_volumes
+  failed_when: "(__sap_vm_provision_task_provision_host_single_volumes.msg is defined) and ('already exists' not in __sap_vm_provision_task_provision_host_single_volumes.msg)"
 
 
 - name: Add host facts
   ansible.builtin.set_fact:
     filesystem_volume_map: "{{ filesystem_volume_map }}"
-    volume_provisioning: "{{ volume_provisioning }}"
+    __sap_vm_provision_task_provision_host_single_volumes: "{{ __sap_vm_provision_task_provision_host_single_volumes }}"
   delegate_to: "{{ inventory_hostname }}"
   delegate_facts: true
 
 - name: Create fact for delegate host IP
   ansible.builtin.set_fact:
-    provisioned_private_ip: "{{ register_provisioned_host_single.ansible_facts.azure_vm.network_profile.network_interfaces[0].properties.ip_configurations[0].private_ip_address }}"
+    provisioned_private_ip: "{{ __sap_vm_provision_task_provision_host_single.ansible_facts.azure_vm.network_profile.network_interfaces[0].properties.ip_configurations[0].private_ip_address }}"
 
 - name: Copy facts to delegate host
   delegate_to: "{{ provisioned_private_ip }}"
@@ -213,7 +213,7 @@
     delegate_sap_vm_provision_bastion_ssh_port: "{{ sap_vm_provision_bastion_ssh_port }}"
     delegate_sap_vm_provision_ssh_bastion_private_key_file_path: "{{ sap_vm_provision_ssh_bastion_private_key_file_path }}"
     delegate_sap_vm_provision_ssh_host_private_key_file_path: "{{ sap_vm_provision_ssh_host_private_key_file_path }}"
-    delegate_private_ip: "{{ register_provisioned_host_single.ansible_facts.azure_vm.network_profile.network_interfaces[0].properties.ip_configurations[0].private_ip_address }}"
+    delegate_private_ip: "{{ __sap_vm_provision_task_provision_host_single.ansible_facts.azure_vm.network_profile.network_interfaces[0].properties.ip_configurations[0].private_ip_address }}"
     delegate_hostname: "{{ inventory_hostname }}"
     delegate_sap_vm_provision_dns_root_domain_name: "{{ sap_vm_provision_dns_root_domain }}"
 
@@ -256,8 +256,8 @@
 
 - name: Append loop value to register
   ansible.builtin.set_fact:
-    register_provisioned_host_single: "{{ register_provisioned_host_single | combine( { 'host_node' : inventory_hostname } , { 'sap_host_type' : lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][scaleout_origin_host_spec | default(inventory_hostname)].sap_host_type } , { 'sap_system_type' : (lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][scaleout_origin_host_spec | default(inventory_hostname)].sap_system_type | default('')) } ) }}"
+    __sap_vm_provision_task_provision_host_single: "{{ __sap_vm_provision_task_provision_host_single | combine( { 'host_node' : inventory_hostname } , { 'sap_host_type' : lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][scaleout_origin_host_spec | default(inventory_hostname)].sap_host_type } , { 'sap_system_type' : (lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][scaleout_origin_host_spec | default(inventory_hostname)].sap_system_type | default('')) } ) }}"
 
 - name: Append output to merged register
   ansible.builtin.set_fact:
-    register_provisioned_host_all: "{{ register_provisioned_host_all + [register_provisioned_host_single] }}"
+    register_provisioned_host_all: "{{ register_provisioned_host_all + [__sap_vm_provision_task_provision_host_single] }}"

--- a/roles/sap_vm_provision/tasks/platform_ansible/msazure_vm/execute_setup_ha.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/msazure_vm/execute_setup_ha.yml
@@ -1,12 +1,13 @@
 ---
 
 # - name: Gather information about MS Azure Route Table for the VNet Subnet
+#   register: msazure_vnet_subnet_rt_info
 #   azure.azcollection.azure_rm_routetable_info:
 #     resource_group: "{{ sap_vm_provision_msazure_resource_group_name }}"
 #     name: "name-here"
-#   register: msazure_vnet_subnet_rt_info
 
 # - name: Ansible MS Azure Route Table append route for SAP HANA HA
+#   register: msazure_vnet_subnet_rt_route_sap_hana
 #   azure.azcollection.azure_rm_route:
 #     resource_group: "{{ sap_vm_provision_msazure_resource_group_name }}"
 #     route_table_name: "{{ msazure_vnet_subnet_rt_info.route_tables[0].id }}"
@@ -17,7 +18,6 @@
 #   loop: "{{ (groups['hana_primary'] | default([])) }}"
 #   loop_control:
 #     loop_var: host_node
-#   register: msazure_vnet_subnet_rt_route_sap_hana
 #   when:
 #     - groups["hana_secondary"] is defined and (groups["hana_secondary"] | length>0)
 
@@ -38,6 +38,7 @@
 
 
 # - name: Ansible MS Azure Route Table append route for SAP NetWeaver ASCS HA
+#   register: msazure_vnet_subnet_rt_route_sap_netweaver_ascs
 #   azure.azcollection.azure_rm_route:
 #     resource_group: "{{ sap_vm_provision_msazure_resource_group_name }}"
 #     route_table_name: "{{ msazure_vnet_subnet_rt_info.route_tables[0].id }}"
@@ -48,7 +49,6 @@
 #   loop: "{{ (groups['nwas_ascs'] | default([])) }}"
 #   loop_control:
 #     loop_var: host_node
-#   register: msazure_vnet_subnet_rt_route_sap_netweaver_ascs
 #   when:
 #     - groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0)
 
@@ -69,6 +69,7 @@
 
 
 # - name: Ansible MS Azure Route Table append route for SAP NetWeaver ERS HA
+#   register: msazure_vnet_subnet_rt_route_sap_netweaver_ers
 #   azure.azcollection.azure_rm_route:
 #     resource_group: "{{ sap_vm_provision_msazure_resource_group_name }}"
 #     route_table_name: "{{ msazure_vnet_subnet_rt_info.route_tables[0].id }}"
@@ -79,7 +80,6 @@
 #   loop: "{{ (groups['nwas_ers'] | default([])) }}"
 #   loop_control:
 #     loop_var: host_node
-#   register: msazure_vnet_subnet_rt_route_sap_netweaver_ers
 #   when:
 #     - groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0)
 
@@ -102,6 +102,7 @@
 ## For HA of PAS and AAS, if required
 
 #    - name: Ansible MS Azure Route Table append route for SAP NetWeaver PAS HA
+#      register: msazure_vnet_subnet_rt_route_sap_netweaver_pas
 #      azure.azcollection.azure_rm_route:
 #        resource_group: "{{ sap_vm_provision_msazure_resource_group_name }}"
 #        route_table_name: "{{ msazure_vnet_subnet_rt_info.route_tables[0].id }}"
@@ -112,7 +113,6 @@
 #      loop: "{{ (groups['nwas_pas'] | default([])) }}"
 #      loop_control:
 #        loop_var: host_node
-#      register: msazure_vnet_subnet_rt_route_sap_netweaver_pas
 #      when:
 #        - groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0)
 
@@ -133,6 +133,7 @@
 
 
 # - name: Ansible MS Azure Route Table append route for SAP NetWeaver AAS HA
+#   register: msazure_vnet_subnet_rt_route_sap_netweaver_aas
 #   azure.azcollection.azure_rm_route:
 #     resource_group: "{{ sap_vm_provision_msazure_resource_group_name }}"
 #     route_table_name: "{{ msazure_vnet_subnet_rt_info.route_tables[0].id }}"
@@ -143,7 +144,6 @@
 #   loop: "{{ (groups['nwas_aas'] | default([])) }}"
 #   loop_control:
 #     loop_var: host_node
-#   register: msazure_vnet_subnet_rt_route_sap_netweaver_aas
 #   when:
 #     - groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0)
 
@@ -164,6 +164,7 @@
 
 
 - name: MS Azure IAM Role - Definition
+  register: msazure_iam_role_fencing
   azure.azcollection.azure_rm_roledefinition:
     name: "Linux Fence Agent Role"
     description: "Allows to power-off and start virtual machines"
@@ -178,15 +179,14 @@
       # - data_actions:
       # - not_actions:
       # - not_data_actions:
-  register: msazure_iam_role_fencing
 
 - name: MS Azure - GenericRestClient call to Virtual Machine API to identify Managed Service Identity (MSI)
+  register: msazure_vm_info_collect
   azure.azcollection.azure_rm_resource_info:
     resource_group: "{{ sap_vm_provision_msazure_resource_group_name }}"
     provider: Compute
     resource_type: virtualMachines
     resource_name: "{{ host_node }}"
-  register: msazure_vm_info_collect
   loop: "{{ groups_merged_list }}"
   loop_control:
     loop_var: host_node
@@ -243,11 +243,11 @@
   block:
 
     - name: Gather MS Azure Subnet ID
+      register: msazure_vnet_subnet_info
       azure.azcollection.azure_rm_subnet_info:
         resource_group: "{{ sap_vm_provision_msazure_resource_group_name }}"
         virtual_network_name: "{{ sap_vm_provision_msazure_vnet_name }}"
         name: "{{ sap_vm_provision_msazure_vnet_subnet_name }}"
-      register: msazure_vnet_subnet_info
 
 
     - name: Define Ansible Variables for Azure Load Balancer - VIP for SAP HANA
@@ -436,6 +436,7 @@
         loop_var: rule_item
 
     - name: MS Azure Load Balancer (network L4) - Create NLB for SAP HANA with Virtual IP and Health Probe configuration
+      register: msazure_lb1a_info
       azure.azcollection.azure_rm_loadbalancer:
         resource_group: "{{ sap_vm_provision_msazure_resource_group_name }}"
         name: "lb-sap-hana-ha" # "lb-sap-ha"
@@ -446,9 +447,9 @@
         probes: "{{ (lb_probes1 | default([])) }}" # "{{ (lb_probes1 | default([])) + (lb_probes2 | default([])) }}"
         load_balancing_rules: "{{ (lb_rules1 | default([])) }}" # "{{ (lb_rules1 | default([])) + (lb_rules2 | default([])) }}"
       when: (groups["hana_secondary"] is defined and (groups["hana_secondary"]|length>0))
-      register: msazure_lb1a_info
 
     - name: MS Azure Load Balancer (network L4) - Create NLB for SAP AnyDB with Virtual IP and Health Probe configuration
+      register: msazure_lb1b_info
       azure.azcollection.azure_rm_loadbalancer:
         resource_group: "{{ sap_vm_provision_msazure_resource_group_name }}"
         name: "lb-sap-anydb-ha" # "lb-sap-ha"
@@ -459,7 +460,6 @@
         probes: "{{ (lb_probes1 | default([])) }}" # "{{ (lb_probes1 | default([])) + (lb_probes2 | default([])) }}"
         load_balancing_rules: "{{ (lb_rules1 | default([])) }}" # "{{ (lb_rules1 | default([])) + (lb_rules2 | default([])) }}"
       when: (groups["anydb_secondary"] is defined and (groups["anydb_secondary"]|length>0))
-      register: msazure_lb1b_info
 
     - name: MS Azure Load Balancer (network L4) - Define Ansible Variable of Load Balancer for Database Server
       ansible.builtin.set_fact:
@@ -467,6 +467,7 @@
       when: (groups["hana_secondary"] is defined and (groups["hana_secondary"]|length>0)) or (groups["anydb_secondary"] is defined and (groups["anydb_secondary"]|length>0))
 
     - name: MS Azure Load Balancer (network L4) - Create NLB for SAP NetWeaver with Virtual IP and Health Probe configuration
+      register: msazure_lb2_info
       azure.azcollection.azure_rm_loadbalancer:
         resource_group: "{{ sap_vm_provision_msazure_resource_group_name }}"
         name: "lb-sap-nwas-ha"
@@ -477,7 +478,6 @@
         probes: "{{ (lb_probes2 | default([])) }}"
         load_balancing_rules: "{{ (lb_rules2 | default([])) }}"
       when: (groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0))
-      register: msazure_lb2_info
 
     - name: Set fact to hold loop variables from include_tasks when SAP HANA HA
       ansible.builtin.set_fact:

--- a/roles/sap_vm_provision/tasks/platform_ansible/msazure_vm/execute_setup_ha.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/msazure_vm/execute_setup_ha.yml
@@ -1,20 +1,32 @@
 ---
 
 # - name: Gather information about MS Azure Route Table for the VNet Subnet
-#   register: msazure_vnet_subnet_rt_info
+#   register: __sap_vm_provision_msazure_vnet_subnet_rt_info
+#   no_log: "{{ __sap_vm_provision_no_log }}"
 #   azure.azcollection.azure_rm_routetable_info:
 #     resource_group: "{{ sap_vm_provision_msazure_resource_group_name }}"
 #     name: "name-here"
+#     # Azure credentials
+#     subscription_id: "{{ sap_vm_provision_msazure_subscription_id }}"
+#     tenant: "{{ sap_vm_provision_msazure_tenant_id }}"
+#     client_id: "{{ sap_vm_provision_msazure_app_client_id }}"
+#     secret: "{{ sap_vm_provision_msazure_app_client_secret }}"
 
 # - name: Ansible MS Azure Route Table append route for SAP HANA HA
-#   register: msazure_vnet_subnet_rt_route_sap_hana
+#   no_log: "{{ __sap_vm_provision_no_log }}"
+#   register: __sap_vm_provision_msazure_vnet_subnet_rt_route_sap_hana
 #   azure.azcollection.azure_rm_route:
 #     resource_group: "{{ sap_vm_provision_msazure_resource_group_name }}"
-#     route_table_name: "{{ msazure_vnet_subnet_rt_info.route_tables[0].id }}"
+#     route_table_name: "{{ __sap_vm_provision_msazure_vnet_subnet_rt_info.route_tables[0].id }}"
 #     name: "{{ sap_swpm_db_host }}-rt"
 #     address_prefix: "{{ sap_ha_pacemaker_cluster_vip_hana_primary_ip_address | default('192.168.1.90/32') }}"
 #     next_hop_type: "virtual_appliance"
 #     next_hop_ip_address: "{{ hostvars[host_node].ansible_host }}"
+#     # Azure credentials
+#     subscription_id: "{{ sap_vm_provision_msazure_subscription_id }}"
+#     tenant: "{{ sap_vm_provision_msazure_tenant_id }}"
+#     client_id: "{{ sap_vm_provision_msazure_app_client_id }}"
+#     secret: "{{ sap_vm_provision_msazure_app_client_secret }}"
 #   loop: "{{ (groups['hana_primary'] | default([])) }}"
 #   loop_control:
 #     loop_var: host_node
@@ -22,6 +34,7 @@
 #     - groups["hana_secondary"] is defined and (groups["hana_secondary"] | length>0)
 
 - name: Ansible MS Azure Private DNS Records for SAP HANA HA Virtual Hostname
+  no_log: "{{ __sap_vm_provision_no_log }}"
   azure.azcollection.azure_rm_privatednsrecordset:
     # DNS may exist in separate Resource Group. Use empty string var (or default false if undefined) to evaluate to false boolean, and use Python or logic operator
     resource_group: "{{ (sap_vm_provision_msazure_private_dns_resource_group_name | default(false)) or sap_vm_provision_msazure_resource_group_name }}"
@@ -30,6 +43,11 @@
     record_type: A
     records:
       - entry: "{{ (sap_ha_pacemaker_cluster_vip_hana_primary_ip_address | default('192.168.1.90/32')) | regex_replace('/.*', '') }}"
+    # Azure credentials
+    subscription_id: "{{ sap_vm_provision_msazure_subscription_id }}"
+    tenant: "{{ sap_vm_provision_msazure_tenant_id }}"
+    client_id: "{{ sap_vm_provision_msazure_app_client_id }}"
+    secret: "{{ sap_vm_provision_msazure_app_client_secret }}"
   loop: "{{ (groups['hana_primary'] | default([])) }}"
   loop_control:
     loop_var: host_node
@@ -38,14 +56,20 @@
 
 
 # - name: Ansible MS Azure Route Table append route for SAP NetWeaver ASCS HA
-#   register: msazure_vnet_subnet_rt_route_sap_netweaver_ascs
+#   no_log: "{{ __sap_vm_provision_no_log }}"
+#   register: __sap_vm_provision_msazure_vnet_subnet_rt_route_sap_netweaver_ascs
 #   azure.azcollection.azure_rm_route:
 #     resource_group: "{{ sap_vm_provision_msazure_resource_group_name }}"
-#     route_table_name: "{{ msazure_vnet_subnet_rt_info.route_tables[0].id }}"
+#     route_table_name: "{{ __sap_vm_provision_msazure_vnet_subnet_rt_info.route_tables[0].id }}"
 #     name: "{{ sap_swpm_ascs_instance_hostname }}-rt"
 #     address_prefix: "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_ascs_ip_address | default('192.168.2.10/32') }}"
 #     next_hop_type: "virtual_appliance"
 #     next_hop_ip_address: "{{ hostvars[host_node].ansible_host }}"
+#     # Azure credentials
+#     subscription_id: "{{ sap_vm_provision_msazure_subscription_id }}"
+#     tenant: "{{ sap_vm_provision_msazure_tenant_id }}"
+#     client_id: "{{ sap_vm_provision_msazure_app_client_id }}"
+#     secret: "{{ sap_vm_provision_msazure_app_client_secret }}"
 #   loop: "{{ (groups['nwas_ascs'] | default([])) }}"
 #   loop_control:
 #     loop_var: host_node
@@ -53,6 +77,7 @@
 #     - groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0)
 
 - name: Ansible MS Azure Private DNS Records for SAP NetWeaver ASCS HA Virtual Hostname
+  no_log: "{{ __sap_vm_provision_no_log }}"
   azure.azcollection.azure_rm_privatednsrecordset:
     # DNS may exist in separate Resource Group. Use empty string var (or default false if undefined) to evaluate to false boolean, and use Python or logic operator
     resource_group: "{{ (sap_vm_provision_msazure_private_dns_resource_group_name | default(false)) or sap_vm_provision_msazure_resource_group_name }}"
@@ -61,6 +86,11 @@
     record_type: A
     records:
       - entry: "{{ (sap_ha_pacemaker_cluster_vip_nwas_abap_ascs_ip_address | default('192.168.2.10/32')) | regex_replace('/.*', '') }}"
+    # Azure credentials
+    subscription_id: "{{ sap_vm_provision_msazure_subscription_id }}"
+    tenant: "{{ sap_vm_provision_msazure_tenant_id }}"
+    client_id: "{{ sap_vm_provision_msazure_app_client_id }}"
+    secret: "{{ sap_vm_provision_msazure_app_client_secret }}"
   loop: "{{ (groups['nwas_ascs'] | default([])) }}"
   loop_control:
     loop_var: host_node
@@ -69,14 +99,20 @@
 
 
 # - name: Ansible MS Azure Route Table append route for SAP NetWeaver ERS HA
-#   register: msazure_vnet_subnet_rt_route_sap_netweaver_ers
+#   no_log: "{{ __sap_vm_provision_no_log }}"
+#   register: __sap_vm_provision_msazure_vnet_subnet_rt_route_sap_netweaver_ers
 #   azure.azcollection.azure_rm_route:
 #     resource_group: "{{ sap_vm_provision_msazure_resource_group_name }}"
-#     route_table_name: "{{ msazure_vnet_subnet_rt_info.route_tables[0].id }}"
+#     route_table_name: "{{ __sap_vm_provision_msazure_vnet_subnet_rt_info.route_tables[0].id }}"
 #     name: "{{ sap_swpm_ers_instance_hostname }}-rt"
 #     address_prefix: "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_ers_ip_address | default('192.168.2.11/32') }}"
 #     next_hop_type: "virtual_appliance"
 #     next_hop_ip_address: "{{ hostvars[host_node].ansible_host }}"
+#     # Azure credentials
+#     subscription_id: "{{ sap_vm_provision_msazure_subscription_id }}"
+#     tenant: "{{ sap_vm_provision_msazure_tenant_id }}"
+#     client_id: "{{ sap_vm_provision_msazure_app_client_id }}"
+#     secret: "{{ sap_vm_provision_msazure_app_client_secret }}"
 #   loop: "{{ (groups['nwas_ers'] | default([])) }}"
 #   loop_control:
 #     loop_var: host_node
@@ -84,6 +120,7 @@
 #     - groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0)
 
 - name: Ansible MS Azure Private DNS Records for SAP NetWeaver ERS HA Virtual Hostname
+  no_log: "{{ __sap_vm_provision_no_log }}"
   azure.azcollection.azure_rm_privatednsrecordset:
     # DNS may exist in separate Resource Group. Use empty string var (or default false if undefined) to evaluate to false boolean, and use Python or logic operator
     resource_group: "{{ (sap_vm_provision_msazure_private_dns_resource_group_name | default(false)) or sap_vm_provision_msazure_resource_group_name }}"
@@ -92,6 +129,11 @@
     record_type: A
     records:
       - entry: "{{ (sap_ha_pacemaker_cluster_vip_nwas_abap_ers_ip_address | default('192.168.2.11/32')) | regex_replace('/.*', '') }}"
+    # Azure credentials
+    subscription_id: "{{ sap_vm_provision_msazure_subscription_id }}"
+    tenant: "{{ sap_vm_provision_msazure_tenant_id }}"
+    client_id: "{{ sap_vm_provision_msazure_app_client_id }}"
+    secret: "{{ sap_vm_provision_msazure_app_client_secret }}"
   loop: "{{ (groups['nwas_ers'] | default([])) }}"
   loop_control:
     loop_var: host_node
@@ -101,22 +143,29 @@
 
 ## For HA of PAS and AAS, if required
 
-#    - name: Ansible MS Azure Route Table append route for SAP NetWeaver PAS HA
-#      register: msazure_vnet_subnet_rt_route_sap_netweaver_pas
-#      azure.azcollection.azure_rm_route:
-#        resource_group: "{{ sap_vm_provision_msazure_resource_group_name }}"
-#        route_table_name: "{{ msazure_vnet_subnet_rt_info.route_tables[0].id }}"
-#        name: "{{ sap_swpm_pas_instance_hostname }}-rt"
-#        address_prefix: "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_pas_ip_address | default('192.168.2.12/32') }}"
-#        next_hop_type: "virtual_appliance"
-#        next_hop_ip_address: "{{ hostvars[host_node].ansible_host }}"
-#      loop: "{{ (groups['nwas_pas'] | default([])) }}"
-#      loop_control:
-#        loop_var: host_node
-#      when:
-#        - groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0)
+# - name: Ansible MS Azure Route Table append route for SAP NetWeaver PAS HA
+#   no_log: "{{ __sap_vm_provision_no_log }}"
+#   register: __sap_vm_provision_msazure_vnet_subnet_rt_route_sap_netweaver_pas
+#   azure.azcollection.azure_rm_route:
+#     resource_group: "{{ sap_vm_provision_msazure_resource_group_name }}"
+#     route_table_name: "{{ __sap_vm_provision_msazure_vnet_subnet_rt_info.route_tables[0].id }}"
+#     name: "{{ sap_swpm_pas_instance_hostname }}-rt"
+#     address_prefix: "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_pas_ip_address | default('192.168.2.12/32') }}"
+#     next_hop_type: "virtual_appliance"
+#     next_hop_ip_address: "{{ hostvars[host_node].ansible_host }}"
+#     # Azure credentials
+#     subscription_id: "{{ sap_vm_provision_msazure_subscription_id }}"
+#     tenant: "{{ sap_vm_provision_msazure_tenant_id }}"
+#     client_id: "{{ sap_vm_provision_msazure_app_client_id }}"
+#     secret: "{{ sap_vm_provision_msazure_app_client_secret }}"
+#   loop: "{{ (groups['nwas_pas'] | default([])) }}"
+#   loop_control:
+#     loop_var: host_node
+#   when:
+#     - groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0)
 
 # - name: Ansible MS Azure Private DNS Records for SAP NetWeaver PAS HA Virtual Hostname
+#   no_log: "{{ __sap_vm_provision_no_log }}"
 #   azure.azcollection.azure_rm_privatednsrecordset:
 #     # DNS may exist in separate Resource Group. Use empty string var (or default false if undefined) to evaluate to false boolean, and use Python or logic operator
 #     resource_group: "{{ (sap_vm_provision_msazure_private_dns_resource_group_name | default(false)) or sap_vm_provision_msazure_resource_group_name }}"
@@ -125,6 +174,11 @@
 #     record_type: A
 #     records:
 #       - entry: "{{ (sap_ha_pacemaker_cluster_vip_nwas_abap_pas_ip_address | default('192.168.2.12/32')) | regex_replace('/.*', '') }}"
+#     # Azure credentials
+#     subscription_id: "{{ sap_vm_provision_msazure_subscription_id }}"
+#     tenant: "{{ sap_vm_provision_msazure_tenant_id }}"
+#     client_id: "{{ sap_vm_provision_msazure_app_client_id }}"
+#     secret: "{{ sap_vm_provision_msazure_app_client_secret }}"
 #   loop: "{{ (groups['nwas_pas'] | default([])) }}"
 #   loop_control:
 #     loop_var: host_node
@@ -133,14 +187,20 @@
 
 
 # - name: Ansible MS Azure Route Table append route for SAP NetWeaver AAS HA
-#   register: msazure_vnet_subnet_rt_route_sap_netweaver_aas
+#   no_log: "{{ __sap_vm_provision_no_log }}"
+#   register: __sap_vm_provision_msazure_vnet_subnet_rt_route_sap_netweaver_aas
 #   azure.azcollection.azure_rm_route:
 #     resource_group: "{{ sap_vm_provision_msazure_resource_group_name }}"
-#     route_table_name: "{{ msazure_vnet_subnet_rt_info.route_tables[0].id }}"
+#     route_table_name: "{{ __sap_vm_provision_msazure_vnet_subnet_rt_info.route_tables[0].id }}"
 #     name: "{{ sap_swpm_aas_instance_hostname }}-rt"
 #     address_prefix: "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_aas_ip_address | default('192.168.2.13/32') }}"
 #     next_hop_type: "virtual_appliance"
 #     next_hop_ip_address: "{{ hostvars[host_node].ansible_host }}"
+#     # Azure credentials
+#     subscription_id: "{{ sap_vm_provision_msazure_subscription_id }}"
+#     tenant: "{{ sap_vm_provision_msazure_tenant_id }}"
+#     client_id: "{{ sap_vm_provision_msazure_app_client_id }}"
+#     secret: "{{ sap_vm_provision_msazure_app_client_secret }}"
 #   loop: "{{ (groups['nwas_aas'] | default([])) }}"
 #   loop_control:
 #     loop_var: host_node
@@ -148,6 +208,7 @@
 #     - groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0)
 
 # - name: Ansible MS Azure Private DNS Records for SAP NetWeaver AAS HA Virtual Hostname
+#   no_log: "{{ __sap_vm_provision_no_log }}"
 #   azure.azcollection.azure_rm_privatednsrecordset:
 #     # DNS may exist in separate Resource Group. Use empty string var (or default false if undefined) to evaluate to false boolean, and use Python or logic operator
 #     resource_group: "{{ (sap_vm_provision_msazure_private_dns_resource_group_name | default(false)) or sap_vm_provision_msazure_resource_group_name }}"
@@ -156,6 +217,11 @@
 #     record_type: A
 #     records:
 #       - entry: "{{ (sap_ha_pacemaker_cluster_vip_nwas_abap_aas_ip_address | default('192.168.2.13/32')) | regex_replace('/.*', '') }}"
+#     # Azure credentials
+#     subscription_id: "{{ sap_vm_provision_msazure_subscription_id }}"
+#     tenant: "{{ sap_vm_provision_msazure_tenant_id }}"
+#     client_id: "{{ sap_vm_provision_msazure_app_client_id }}"
+#     secret: "{{ sap_vm_provision_msazure_app_client_secret }}"
 #   loop: "{{ (groups['nwas_aas'] | default([])) }}"
 #   loop_control:
 #     loop_var: host_node
@@ -164,7 +230,8 @@
 
 
 - name: MS Azure IAM Role - Definition
-  register: msazure_iam_role_fencing
+  no_log: "{{ __sap_vm_provision_no_log }}"
+  register: __sap_vm_provision_msazure_iam_role_fencing
   azure.azcollection.azure_rm_roledefinition:
     name: "Linux Fence Agent Role"
     description: "Allows to power-off and start virtual machines"
@@ -179,27 +246,44 @@
       # - data_actions:
       # - not_actions:
       # - not_data_actions:
+    # Azure credentials
+    subscription_id: "{{ sap_vm_provision_msazure_subscription_id }}"
+    tenant: "{{ sap_vm_provision_msazure_tenant_id }}"
+    client_id: "{{ sap_vm_provision_msazure_app_client_id }}"
+    secret: "{{ sap_vm_provision_msazure_app_client_secret }}"
 
 - name: MS Azure - GenericRestClient call to Virtual Machine API to identify Managed Service Identity (MSI)
-  register: msazure_vm_info_collect
+  no_log: "{{ __sap_vm_provision_no_log }}"
+  register: __sap_vm_provision_msazure_vm_info_collect
   azure.azcollection.azure_rm_resource_info:
     resource_group: "{{ sap_vm_provision_msazure_resource_group_name }}"
     provider: Compute
     resource_type: virtualMachines
     resource_name: "{{ host_node }}"
+    # Azure credentials
+    subscription_id: "{{ sap_vm_provision_msazure_subscription_id }}"
+    tenant: "{{ sap_vm_provision_msazure_tenant_id }}"
+    client_id: "{{ sap_vm_provision_msazure_app_client_id }}"
+    secret: "{{ sap_vm_provision_msazure_app_client_secret }}"
   loop: "{{ groups_merged_list }}"
   loop_control:
     loop_var: host_node
 
 # Assign to the MSI Object ID (Service Principal ID)
 - name: MS Azure IAM Role - Assignment to MS Azure Managed Service Identity (MSI)
+  no_log: "{{ __sap_vm_provision_no_log }}"
   azure.azcollection.azure_rm_roleassignment:
     #auth_source: msi
     role_definition_id:
-      "{{ msazure_iam_role_fencing.id }}"
+      "{{ __sap_vm_provision_msazure_iam_role_fencing.id }}"
     scope: "/subscriptions/{{ sap_vm_provision_msazure_subscription_id }}"
     assignee_object_id: "{{ host_node.response[0].identity.principalId | default(none) }}"
-  loop: "{{ msazure_vm_info_collect.results }}"
+    # Azure credentials
+    subscription_id: "{{ sap_vm_provision_msazure_subscription_id }}"
+    tenant: "{{ sap_vm_provision_msazure_tenant_id }}"
+    client_id: "{{ sap_vm_provision_msazure_app_client_id }}"
+    secret: "{{ sap_vm_provision_msazure_app_client_secret }}"
+  loop: "{{ __sap_vm_provision_msazure_vm_info_collect.results }}"
   loop_control:
     loop_var: host_node
     label: "{{ host_node.response[0].name | default(none) }}" # Use default to avoid "Failed to template 'dict object' has no attribute 'response'"
@@ -243,12 +327,17 @@
   block:
 
     - name: Gather MS Azure Subnet ID
-      register: msazure_vnet_subnet_info
+      no_log: "{{ __sap_vm_provision_no_log }}"
+      register: __sap_vm_provision_msazure_vnet_subnet_info
       azure.azcollection.azure_rm_subnet_info:
         resource_group: "{{ sap_vm_provision_msazure_resource_group_name }}"
         virtual_network_name: "{{ sap_vm_provision_msazure_vnet_name }}"
-        name: "{{ sap_vm_provision_msazure_vnet_subnet_name }}"
-
+        name: "{{ sap_vm_provision___sap_vm_provision_msazure_vnet_subnet_name }}"
+      # Azure credentials
+      subscription_id: "{{ sap_vm_provision_msazure_subscription_id }}"
+      tenant: "{{ sap_vm_provision_msazure_tenant_id }}"
+      client_id: "{{ sap_vm_provision_msazure_app_client_id }}"
+      secret: "{{ sap_vm_provision_msazure_app_client_secret }}"
 
     - name: Define Ansible Variables for Azure Load Balancer - VIP for SAP HANA
       ansible.builtin.set_fact:
@@ -258,7 +347,7 @@
           name: "lb-vip-hana{{ vip_index_nr }}"
           private_ip_address: "{{ vip_item | regex_replace('/.*', '') }}"
           private_ip_allocation_method: "Static"
-          subnet: "{{ msazure_vnet_subnet_info.subnets[0].id }}"
+          subnet: "{{ __sap_vm_provision_msazure_vnet_subnet_info.subnets[0].id }}"
           zones: ["1", "2", "3"] # Zone-redundant
       when:
         - vip_item | length > 0
@@ -277,7 +366,7 @@
           name: "lb-vip-anydb{{ vip_index_nr }}"
           private_ip_address: "{{ vip_item | regex_replace('/.*', '') }}"
           private_ip_allocation_method: "Static"
-          subnet: "{{ msazure_vnet_subnet_info.subnets[0].id }}"
+          subnet: "{{ __sap_vm_provision_msazure_vnet_subnet_info.subnets[0].id }}"
           zones: ["1", "2", "3"] # Zone-redundant
       when:
         - vip_item | length > 0
@@ -296,7 +385,7 @@
           name: "lb-vip-nwas{{ vip_index_nr }}"
           private_ip_address: "{{ vip_item | regex_replace('/.*', '') }}"
           private_ip_allocation_method: "Static"
-          subnet: "{{ msazure_vnet_subnet_info.subnets[0].id }}"
+          subnet: "{{ __sap_vm_provision_msazure_vnet_subnet_info.subnets[0].id }}"
           zones: ["1", "2", "3"] # Zone-redundant
       when:
         - vip_item | length > 0
@@ -436,7 +525,8 @@
         loop_var: rule_item
 
     - name: MS Azure Load Balancer (network L4) - Create NLB for SAP HANA with Virtual IP and Health Probe configuration
-      register: msazure_lb1a_info
+      no_log: "{{ __sap_vm_provision_no_log }}"
+      register: __sap_vm_provision_msazure_lb1a_info
       azure.azcollection.azure_rm_loadbalancer:
         resource_group: "{{ sap_vm_provision_msazure_resource_group_name }}"
         name: "lb-sap-hana-ha" # "lb-sap-ha"
@@ -446,10 +536,16 @@
           - name: lb-backend-pool-hana
         probes: "{{ (lb_probes1 | default([])) }}" # "{{ (lb_probes1 | default([])) + (lb_probes2 | default([])) }}"
         load_balancing_rules: "{{ (lb_rules1 | default([])) }}" # "{{ (lb_rules1 | default([])) + (lb_rules2 | default([])) }}"
+        # Azure credentials
+        subscription_id: "{{ sap_vm_provision_msazure_subscription_id }}"
+        tenant: "{{ sap_vm_provision_msazure_tenant_id }}"
+        client_id: "{{ sap_vm_provision_msazure_app_client_id }}"
+        secret: "{{ sap_vm_provision_msazure_app_client_secret }}"
       when: (groups["hana_secondary"] is defined and (groups["hana_secondary"]|length>0))
 
     - name: MS Azure Load Balancer (network L4) - Create NLB for SAP AnyDB with Virtual IP and Health Probe configuration
-      register: msazure_lb1b_info
+      no_log: "{{ __sap_vm_provision_no_log }}"
+      register: __sap_vm_provision_msazure_lb1b_info
       azure.azcollection.azure_rm_loadbalancer:
         resource_group: "{{ sap_vm_provision_msazure_resource_group_name }}"
         name: "lb-sap-anydb-ha" # "lb-sap-ha"
@@ -459,15 +555,21 @@
           - name: lb-backend-pool-anydb
         probes: "{{ (lb_probes1 | default([])) }}" # "{{ (lb_probes1 | default([])) + (lb_probes2 | default([])) }}"
         load_balancing_rules: "{{ (lb_rules1 | default([])) }}" # "{{ (lb_rules1 | default([])) + (lb_rules2 | default([])) }}"
+        # Azure credentials
+        subscription_id: "{{ sap_vm_provision_msazure_subscription_id }}"
+        tenant: "{{ sap_vm_provision_msazure_tenant_id }}"
+        client_id: "{{ sap_vm_provision_msazure_app_client_id }}"
+        secret: "{{ sap_vm_provision_msazure_app_client_secret }}"
       when: (groups["anydb_secondary"] is defined and (groups["anydb_secondary"]|length>0))
 
     - name: MS Azure Load Balancer (network L4) - Define Ansible Variable of Load Balancer for Database Server
       ansible.builtin.set_fact:
-        msazure_lb1_info: "{{ msazure_lb1a_info if (groups['hana_secondary'] is defined and (groups['hana_secondary']|length>0)) else msazure_lb1b_info if (groups['anydb_secondary'] is defined and (groups['anydb_secondary']|length>0)) }}"
+        __sap_vm_provision_msazure_lb1_info: "{{ __sap_vm_provision_msazure_lb1a_info if (groups['hana_secondary'] is defined and (groups['hana_secondary']|length>0)) else __sap_vm_provision_msazure_lb1b_info if (groups['anydb_secondary'] is defined and (groups['anydb_secondary']|length>0)) }}"
       when: (groups["hana_secondary"] is defined and (groups["hana_secondary"]|length>0)) or (groups["anydb_secondary"] is defined and (groups["anydb_secondary"]|length>0))
 
     - name: MS Azure Load Balancer (network L4) - Create NLB for SAP NetWeaver with Virtual IP and Health Probe configuration
-      register: msazure_lb2_info
+      no_log: "{{ __sap_vm_provision_no_log }}"
+      register: __sap_vm_provision_msazure_lb2_info
       azure.azcollection.azure_rm_loadbalancer:
         resource_group: "{{ sap_vm_provision_msazure_resource_group_name }}"
         name: "lb-sap-nwas-ha"
@@ -477,31 +579,37 @@
           - name: lb-backend-pool-nwas-ascs
         probes: "{{ (lb_probes2 | default([])) }}"
         load_balancing_rules: "{{ (lb_rules2 | default([])) }}"
+        # Azure credentials
+        subscription_id: "{{ sap_vm_provision_msazure_subscription_id }}"
+        tenant: "{{ sap_vm_provision_msazure_tenant_id }}"
+        client_id: "{{ sap_vm_provision_msazure_app_client_id }}"
+        secret: "{{ sap_vm_provision_msazure_app_client_secret }}"
       when: (groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0))
 
     - name: Set fact to hold loop variables from include_tasks when SAP HANA HA
       ansible.builtin.set_fact:
-        lb_ha_sap_hana: "{{ msazure_lb1_info.state.backend_address_pools | selectattr('name', '==', 'lb-backend-pool-hana') | map(attribute='id') | first }}"
+        lb_ha_sap_hana: "{{ __sap_vm_provision_msazure_lb1_info.state.backend_address_pools | selectattr('name', '==', 'lb-backend-pool-hana') | map(attribute='id') | first }}"
       when: (groups["hana_secondary"] is defined and (groups["hana_secondary"]|length>0))
 
     - name: Set fact to hold loop variables from include_tasks when SAP AnyDB HA
       ansible.builtin.set_fact:
-        lb_ha_sap_anydb: "{{ msazure_lb1_info.state.backend_address_pools | selectattr('name', '==', 'lb-backend-pool-anydb') | map(attribute='id') | first }}"
+        lb_ha_sap_anydb: "{{ __sap_vm_provision_msazure_lb1_info.state.backend_address_pools | selectattr('name', '==', 'lb-backend-pool-anydb') | map(attribute='id') | first }}"
       when: (groups["anyb_secondary"] is defined and (groups["anydb_secondary"]|length>0))
 
     - name: Set fact to hold loop variables from include_tasks when SAP NetWeaver HA
       ansible.builtin.set_fact:
-        lb_ha_sap_nwas: "{{ msazure_lb2_info.state.backend_address_pools | selectattr('name', '==', 'lb-backend-pool-nwas-ascs') | map(attribute='id') | first }}"
+        lb_ha_sap_nwas: "{{ __sap_vm_provision_msazure_lb2_info.state.backend_address_pools | selectattr('name', '==', 'lb-backend-pool-nwas-ascs') | map(attribute='id') | first }}"
       when: (groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0))
 
     - name: Update network interfaces for MS Azure VM - for SAP HANA HA with load balancing
-      register: register_provisioned_vnic1
+      no_log: "{{ __sap_vm_provision_no_log }}"
+      register: __sap_vm_provision_task_provision_host_single_vnic1
       azure.azcollection.azure_rm_networkinterface:
         resource_group: "{{ sap_vm_provision_msazure_resource_group_name }}"
         location: "{{ sap_vm_provision_msazure_location_region }}"
         name: "{{ host_node }}-nic"
         virtual_network: "{{ sap_vm_provision_msazure_vnet_name }}"
-        subnet_name: "{{ sap_vm_provision_msazure_vnet_subnet_name }}"
+        subnet_name: "{{ sap_vm_provision___sap_vm_provision_msazure_vnet_subnet_name }}"
         create_with_security_group: false
         ip_configurations:
           - name: "{{ host_node }}-nic-ipconfig"
@@ -511,6 +619,11 @@
               - "{{ lb_ha_sap_hana }}"
         enable_accelerated_networking: true
         enable_ip_forwarding: "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][scaleout_origin_host_spec | default(inventory_hostname)].disable_ip_anti_spoofing }}" # When disable the Anti IP Spoofing = true, then Enable IP Forwarding = true
+        # Azure credentials
+        subscription_id: "{{ sap_vm_provision_msazure_subscription_id }}"
+        tenant: "{{ sap_vm_provision_msazure_tenant_id }}"
+        client_id: "{{ sap_vm_provision_msazure_app_client_id }}"
+        secret: "{{ sap_vm_provision_msazure_app_client_secret }}"
       loop: "{{ groups_merged_list }}"
       loop_control:
         loop_var: host_node
@@ -519,13 +632,14 @@
         - groups["hana_secondary"] is defined and (groups["hana_secondary"]|length>0)
 
     - name: Update network interfaces for MS Azure VM - for SAP AnyDB HA with load balancing
-      register: register_provisioned_vnic1
+      no_log: "{{ __sap_vm_provision_no_log }}"
+      register: __sap_vm_provision_task_provision_host_single_vnic1
       azure.azcollection.azure_rm_networkinterface:
         resource_group: "{{ sap_vm_provision_msazure_resource_group_name }}"
         location: "{{ sap_vm_provision_msazure_location_region }}"
         name: "{{ host_node }}-nic"
         virtual_network: "{{ sap_vm_provision_msazure_vnet_name }}"
-        subnet_name: "{{ sap_vm_provision_msazure_vnet_subnet_name }}"
+        subnet_name: "{{ sap_vm_provision___sap_vm_provision_msazure_vnet_subnet_name }}"
         create_with_security_group: false
         ip_configurations:
           - name: "{{ host_node }}-nic-ipconfig"
@@ -535,6 +649,11 @@
               - "{{ lb_ha_sap_anydb }}"
         enable_accelerated_networking: true
         enable_ip_forwarding: "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][scaleout_origin_host_spec | default(inventory_hostname)].disable_ip_anti_spoofing }}" # When disable the Anti IP Spoofing = true, then Enable IP Forwarding = true
+        # Azure credentials
+        subscription_id: "{{ sap_vm_provision_msazure_subscription_id }}"
+        tenant: "{{ sap_vm_provision_msazure_tenant_id }}"
+        client_id: "{{ sap_vm_provision_msazure_app_client_id }}"
+        secret: "{{ sap_vm_provision_msazure_app_client_secret }}"
       loop: "{{ groups_merged_list }}"
       loop_control:
         loop_var: host_node
@@ -543,13 +662,14 @@
         - groups["anydb_secondary"] is defined and (groups["anydb_secondary"]|length>0)
 
     - name: Update network interfaces for MS Azure VM - for SAP NetWeaver HA ASCS/ERS with load balancing
-      register: register_provisioned_vnic2
+      no_log: "{{ __sap_vm_provision_no_log }}"
+      register: __sap_vm_provision_task_provision_host_single_vnic2
       azure.azcollection.azure_rm_networkinterface:
         resource_group: "{{ sap_vm_provision_msazure_resource_group_name }}"
         location: "{{ sap_vm_provision_msazure_location_region }}"
         name: "{{ host_node }}-nic"
         virtual_network: "{{ sap_vm_provision_msazure_vnet_name }}"
-        subnet_name: "{{ sap_vm_provision_msazure_vnet_subnet_name }}"
+        subnet_name: "{{ sap_vm_provision___sap_vm_provision_msazure_vnet_subnet_name }}"
         create_with_security_group: false
         ip_configurations:
           - name: "{{ host_node }}-nic-ipconfig"
@@ -559,6 +679,11 @@
               - "{{ lb_ha_sap_nwas }}"
         enable_accelerated_networking: true
         enable_ip_forwarding: "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][scaleout_origin_host_spec | default(inventory_hostname)].disable_ip_anti_spoofing }}" # When disable the Anti IP Spoofing = true, then Enable IP Forwarding = true
+        # Azure credentials
+        subscription_id: "{{ sap_vm_provision_msazure_subscription_id }}"
+        tenant: "{{ sap_vm_provision_msazure_tenant_id }}"
+        client_id: "{{ sap_vm_provision_msazure_app_client_id }}"
+        secret: "{{ sap_vm_provision_msazure_app_client_secret }}"
       loop: "{{ groups_merged_list }}"
       loop_control:
         loop_var: host_node

--- a/roles/sap_vm_provision/tasks/platform_ansible/msazure_vm/post_deployment_execute.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/msazure_vm/post_deployment_execute.yml
@@ -45,11 +45,11 @@
       when: not sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ers_port is defined
 
     - name: Gather MS Azure Subnet ID
+      register: msazure_vnet_subnet_info
       azure.azcollection.azure_rm_subnet_info:
         resource_group: "{{ sap_vm_provision_msazure_resource_group_name }}"
         virtual_network_name: "{{ sap_vm_provision_msazure_vnet_name }}"
         name: "{{ sap_vm_provision_msazure_vnet_subnet_name }}"
-      register: msazure_vnet_subnet_info
 
 
     - name: Define Ansible Variables for Azure Load Balancer - VIP for SAP HANA
@@ -239,6 +239,7 @@
 
 
     - name: MS Azure Load Balancer (network L4) - Update NLB for SAP HANA with Virtual IP and Health Probe configuration
+      register: msazure_lb1_info
       azure.azcollection.azure_rm_loadbalancer:
         resource_group: "{{ sap_vm_provision_msazure_resource_group_name }}"
         name: "lb-sap-hana-ha" # "lb-sap-ha"
@@ -249,9 +250,9 @@
         probes: "{{ (lb_probes1 | default([])) }}" # "{{ (lb_probes1 | default([])) + (lb_probes2 | default([])) }}"
         load_balancing_rules: "{{ (lb_rules1 | default([])) }}" # "{{ (lb_rules1 | default([])) + (lb_rules2 | default([])) }}"
       when: (groups["hana_secondary"] is defined and (groups["hana_secondary"]|length>0))
-      register: msazure_lb1_info
 
     - name: MS Azure Load Balancer (network L4) - Update NLB for SAP AnyDB with Virtual IP and Health Probe configuration
+      register: msazure_lb1_info
       azure.azcollection.azure_rm_loadbalancer:
         resource_group: "{{ sap_vm_provision_msazure_resource_group_name }}"
         name: "lb-sap-anydb-ha" # "lb-sap-ha"
@@ -262,9 +263,9 @@
         probes: "{{ (lb_probes1 | default([])) }}" # "{{ (lb_probes1 | default([])) + (lb_probes2 | default([])) }}"
         load_balancing_rules: "{{ (lb_rules1 | default([])) }}" # "{{ (lb_rules1 | default([])) + (lb_rules2 | default([])) }}"
       when: (groups["anydb_secondary"] is defined and (groups["anydb_secondary"]|length>0))
-      register: msazure_lb1_info
 
     - name: MS Azure Load Balancer (network L4) - Update NLB for SAP NetWeaver with Virtual IP and Health Probe configuration
+      register: msazure_lb2_info
       azure.azcollection.azure_rm_loadbalancer:
         resource_group: "{{ sap_vm_provision_msazure_resource_group_name }}"
         name: "lb-sap-nwas-ha"
@@ -275,4 +276,3 @@
         probes: "{{ (lb_probes2 | default([])) }}"
         load_balancing_rules: "{{ (lb_rules2 | default([])) }}"
       when: (groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0))
-      register: msazure_lb2_info

--- a/roles/sap_vm_provision/tasks/platform_ansible/msazure_vm/post_deployment_execute.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/msazure_vm/post_deployment_execute.yml
@@ -45,12 +45,17 @@
       when: not sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ers_port is defined
 
     - name: Gather MS Azure Subnet ID
-      register: msazure_vnet_subnet_info
+      no_log: "{{ __sap_vm_provision_no_log }}"
+      register: __sap_vm_provision_msazure_vnet_subnet_info
       azure.azcollection.azure_rm_subnet_info:
         resource_group: "{{ sap_vm_provision_msazure_resource_group_name }}"
         virtual_network_name: "{{ sap_vm_provision_msazure_vnet_name }}"
-        name: "{{ sap_vm_provision_msazure_vnet_subnet_name }}"
-
+        name: "{{ sap_vm_provision___sap_vm_provision_msazure_vnet_subnet_name }}"
+        # Azure credentials
+        subscription_id: "{{ sap_vm_provision_msazure_subscription_id }}"
+        tenant: "{{ sap_vm_provision_msazure_tenant_id }}"
+        client_id: "{{ sap_vm_provision_msazure_app_client_id }}"
+        secret: "{{ sap_vm_provision_msazure_app_client_secret }}"
 
     - name: Define Ansible Variables for Azure Load Balancer - VIP for SAP HANA
       ansible.builtin.set_fact:
@@ -60,7 +65,7 @@
           name: "lb-vip-hana{{ vip_index_nr }}"
           private_ip_address: "{{ vip_item | regex_replace('/.*', '') }}"
           private_ip_allocation_method: "Static"
-          subnet: "{{ msazure_vnet_subnet_info.subnets[0].id }}"
+          subnet: "{{ __sap_vm_provision_msazure_vnet_subnet_info.subnets[0].id }}"
           zones: ["1", "2", "3"] # Zone-redundant
       when:
         - vip_item | length > 0
@@ -79,7 +84,7 @@
           name: "lb-vip-anydb{{ vip_index_nr }}"
           private_ip_address: "{{ vip_item | regex_replace('/.*', '') }}"
           private_ip_allocation_method: "Static"
-          subnet: "{{ msazure_vnet_subnet_info.subnets[0].id }}"
+          subnet: "{{ __sap_vm_provision_msazure_vnet_subnet_info.subnets[0].id }}"
           zones: ["1", "2", "3"] # Zone-redundant
       when:
         - vip_item | length > 0
@@ -98,7 +103,7 @@
           name: "lb-vip-nwas{{ vip_index_nr }}"
           private_ip_address: "{{ vip_item | regex_replace('/.*', '') }}"
           private_ip_allocation_method: "Static"
-          subnet: "{{ msazure_vnet_subnet_info.subnets[0].id }}"
+          subnet: "{{ __sap_vm_provision_msazure_vnet_subnet_info.subnets[0].id }}"
           zones: ["1", "2", "3"] # Zone-redundant
       when:
         - vip_item | length > 0
@@ -239,7 +244,8 @@
 
 
     - name: MS Azure Load Balancer (network L4) - Update NLB for SAP HANA with Virtual IP and Health Probe configuration
-      register: msazure_lb1_info
+      no_log: "{{ __sap_vm_provision_no_log }}"
+      register: __sap_vm_provision_msazure_lb1_info
       azure.azcollection.azure_rm_loadbalancer:
         resource_group: "{{ sap_vm_provision_msazure_resource_group_name }}"
         name: "lb-sap-hana-ha" # "lb-sap-ha"
@@ -249,10 +255,16 @@
           - name: lb-backend-pool-hana
         probes: "{{ (lb_probes1 | default([])) }}" # "{{ (lb_probes1 | default([])) + (lb_probes2 | default([])) }}"
         load_balancing_rules: "{{ (lb_rules1 | default([])) }}" # "{{ (lb_rules1 | default([])) + (lb_rules2 | default([])) }}"
+        # Azure credentials
+        subscription_id: "{{ sap_vm_provision_msazure_subscription_id }}"
+        tenant: "{{ sap_vm_provision_msazure_tenant_id }}"
+        client_id: "{{ sap_vm_provision_msazure_app_client_id }}"
+        secret: "{{ sap_vm_provision_msazure_app_client_secret }}"
       when: (groups["hana_secondary"] is defined and (groups["hana_secondary"]|length>0))
 
     - name: MS Azure Load Balancer (network L4) - Update NLB for SAP AnyDB with Virtual IP and Health Probe configuration
-      register: msazure_lb1_info
+      no_log: "{{ __sap_vm_provision_no_log }}"
+      register: __sap_vm_provision_msazure_lb1_info
       azure.azcollection.azure_rm_loadbalancer:
         resource_group: "{{ sap_vm_provision_msazure_resource_group_name }}"
         name: "lb-sap-anydb-ha" # "lb-sap-ha"
@@ -262,10 +274,16 @@
           - name: lb-backend-pool-anydb
         probes: "{{ (lb_probes1 | default([])) }}" # "{{ (lb_probes1 | default([])) + (lb_probes2 | default([])) }}"
         load_balancing_rules: "{{ (lb_rules1 | default([])) }}" # "{{ (lb_rules1 | default([])) + (lb_rules2 | default([])) }}"
+        # Azure credentials
+        subscription_id: "{{ sap_vm_provision_msazure_subscription_id }}"
+        tenant: "{{ sap_vm_provision_msazure_tenant_id }}"
+        client_id: "{{ sap_vm_provision_msazure_app_client_id }}"
+        secret: "{{ sap_vm_provision_msazure_app_client_secret }}"
       when: (groups["anydb_secondary"] is defined and (groups["anydb_secondary"]|length>0))
 
     - name: MS Azure Load Balancer (network L4) - Update NLB for SAP NetWeaver with Virtual IP and Health Probe configuration
-      register: msazure_lb2_info
+      no_log: "{{ __sap_vm_provision_no_log }}"
+      register: __sap_vm_provision_msazure_lb2_info
       azure.azcollection.azure_rm_loadbalancer:
         resource_group: "{{ sap_vm_provision_msazure_resource_group_name }}"
         name: "lb-sap-nwas-ha"
@@ -275,4 +293,9 @@
           - name: lb-backend-pool-nwas-ascs
         probes: "{{ (lb_probes2 | default([])) }}"
         load_balancing_rules: "{{ (lb_rules2 | default([])) }}"
+        # Azure credentials
+        subscription_id: "{{ sap_vm_provision_msazure_subscription_id }}"
+        tenant: "{{ sap_vm_provision_msazure_tenant_id }}"
+        client_id: "{{ sap_vm_provision_msazure_app_client_id }}"
+        secret: "{{ sap_vm_provision_msazure_app_client_secret }}"
       when: (groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0))

--- a/roles/sap_vm_provision/tasks/platform_ansible/ovirt_vm/execute_main.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/ovirt_vm/execute_main.yml
@@ -1,56 +1,90 @@
 ---
 
-- name: OVirt Authentication
-  register: ovirt_session
-  ovirt.ovirt.ovirt_auth:
-    insecure: "{{ sap_vm_provision_ovirt_engine_insecure_bool | default(true) }}"
-    url: "{{ sap_vm_provision_ovirt_engine_url | default(lookup('env', 'OVIRT_URL')) | default(omit) }}"
-    hostname: "{{ sap_vm_provision_ovirt_engine_fqdn | default(lookup('env', 'OVIRT_HOSTNAME')) | default(omit) }}"
-    username: "{{ sap_vm_provision_ovirt_engine_user | default(lookup('env', 'OVIRT_USERNAME')) | default(omit) }}"
-    password: "{{ sap_vm_provision_ovirt_engine_password | default(lookup('env', 'OVIRT_PASSWORD')) | default(omit) }}"
-    ca_file: "{{ sap_vm_provision_ovirt_engine_cafile | default(lookup('env', 'OVIRT_CAFILE')) | default(omit) }}"
-  when: ovirt_auth is undefined or not ovirt_auth
+- name: Ansible Task block for looped provisioning of OVirt Virtual Machines
+  any_errors_fatal: true
+  # Using environment, no_log is ineffective and log will show 'EXEC /bin/sh -c 'ENV_VAR=value python3 /AnsiballZ_ansible_module_name.py && sleep 0'
+  # Therefore do not use environment for secrets, use only for non-sensitive values as this will reduce Ansible Task parameters.
+  # environment:
+  block:
 
-- name: Set fact to hold loop variables from include_tasks
-  ansible.builtin.set_fact:
-    register_provisioned_host_all: []
+    - name: OVirt Authentication
+      no_log: "{{ __sap_vm_provision_no_log }}"
+      register: __sap_vm_provision_task_ovirt_session
+      ovirt.ovirt.ovirt_auth:
+        insecure: "{{ sap_vm_provision_ovirt_engine_insecure_bool | default(true) }}"
+        url: "{{ sap_vm_provision_ovirt_engine_url | default(lookup('env', 'OVIRT_URL')) | default(omit) }}"
+        hostname: "{{ sap_vm_provision_ovirt_engine_fqdn | default(lookup('env', 'OVIRT_HOSTNAME')) | default(omit) }}"
+        username: "{{ sap_vm_provision_ovirt_engine_user | default(lookup('env', 'OVIRT_USERNAME')) | default(omit) }}"
+        password: "{{ sap_vm_provision_ovirt_engine_password | default(lookup('env', 'OVIRT_PASSWORD')) | default(omit) }}"
+        ca_file: "{{ sap_vm_provision_ovirt_engine_cafile | default(lookup('env', 'OVIRT_CAFILE')) | default(omit) }}"
+      when: ovirt_auth is undefined or not ovirt_auth
 
-- name: Provision hosts to OVirt
-  register: __sap_vm_provision_task_provision_host_all_run
-  ansible.builtin.include_tasks:
-    file: "{{ 'platform_' + sap_vm_provision_iac_type }}/{{ sap_vm_provision_iac_platform }}/execute_provision.yml"
-  vars:
-    ovirt_auth: "{{ sap_vm_provision_ovirt_auth }}"
+    - name: Set fact to hold loop variables from include_tasks
+      ansible.builtin.set_fact:
+        register_provisioned_host_all: []
 
-- name: Add hosts provisioned to the Ansible Inventory
-  register: __sap_vm_provision_task_provision_host_all_add
-  ansible.builtin.add_host:
-    name: "{{ add_item[0].host_node }}"
-    groups: "{{ add_item[0].sap_system_type + '_' if (add_item[0].sap_system_type != '') }}{{ add_item[0].sap_host_type }}"
-    ansible_host: "{{ add_item[0].reported_devices[0].ips[0].address }}"
-    ansible_user: "root"
-    ansible_ssh_private_key_file: "{{ sap_vm_provision_ssh_host_private_key_file_path }}"
-    ansible_ssh_common_args: -o ConnectTimeout=180 -o ControlMaster=auto -o ControlPersist=3600s -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ForwardX11=no
-  loop: "{{ ansible_play_hosts | map('extract', hostvars, 'register_provisioned_host_all')  }}"
-  loop_control:
-    label: "{{ add_item[0].host_node }}"
-    loop_var: add_item
+    - name: Provision hosts to OVirt
+      register: __sap_vm_provision_task_provision_host_all_run
+      ansible.builtin.include_tasks:
+        file: "{{ 'platform_' + sap_vm_provision_iac_type }}/{{ sap_vm_provision_iac_platform }}/execute_provision.yml"
+      vars:
+        ovirt_auth: "{{ sap_vm_provision_ovirt_auth }}"
+
+    - name: Add hosts provisioned to the Ansible Inventory
+      register: __sap_vm_provision_task_provision_host_all_add
+      ansible.builtin.add_host:
+        name: "{{ add_item[0].host_node }}"
+        groups: "{{ add_item[0].sap_system_type + '_' if (add_item[0].sap_system_type != '') }}{{ add_item[0].sap_host_type }}"
+        ansible_host: "{{ add_item[0].reported_devices[0].ips[0].address }}"
+        ansible_user: "root"
+        ansible_ssh_private_key_file: "{{ sap_vm_provision_ssh_host_private_key_file_path }}"
+        ansible_ssh_common_args: -o ConnectTimeout=180 -o ControlMaster=auto -o ControlPersist=3600s -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ForwardX11=no
+      loop: "{{ ansible_play_hosts | map('extract', hostvars, 'register_provisioned_host_all')  }}"
+      loop_control:
+        label: "{{ add_item[0].host_node }}"
+        loop_var: add_item
 
 
 # Cannot override any variables from extravars input, see https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_variables.html#understanding-variable-precedence
 # Ensure no default value exists for any prompted variable before execution of Ansible Playbook
 
-- name: Set fact to hold all inventory hosts in all groups
-  ansible.builtin.set_fact:
-    groups_merged_list: "{{ [ [ groups['hana_primary'] | default([]) ] , [ groups['hana_secondary'] | default([]) ] , [ groups['nwas_ascs'] | default([]) ] , [ groups['nwas_ers'] | default([]) ] , [ groups['nwas_pas'] | default([]) ] , [ groups['nwas_aas'] | default([]) ] ] | flatten | select() }}"
+    - name: Set fact to hold all inventory hosts in all groups
+      ansible.builtin.set_fact:
+        groups_merged_list: "{{ [ [ groups['hana_primary'] | default([]) ] , [ groups['hana_secondary'] | default([]) ] , [ groups['nwas_ascs'] | default([]) ] , [ groups['nwas_ers'] | default([]) ] , [ groups['nwas_pas'] | default([]) ] , [ groups['nwas_aas'] | default([]) ] ] | flatten | select() }}"
 
-- name: Set Ansible Vars
-  register: __sap_vm_provision_task_ansible_vars_set
-  ansible.builtin.include_tasks:
-    file: common/set_ansible_vars.yml
+    - name: Set Ansible Vars
+      register: __sap_vm_provision_task_ansible_vars_set
+      ansible.builtin.include_tasks:
+        file: common/set_ansible_vars.yml
 
   #  - ansible.builtin.debug:
   #      var: __sap_vm_provision_task_provision_host_all_add.results
+
+  rescue:
+    # This requires no_log set on each Ansible Task, and not set on the Ansible Task Block
+    # This requires an Ansible Task Block containing the Ansible Tasks for calling
+    # Infrastructure Platform APIs (via Ansible Modules)
+    - name: Show errors in task outputs
+      ansible.builtin.fail:
+        msg: "{{ lookup('ansible.builtin.vars', loop_item) }}"
+      loop:
+        - __sap_vm_provision_task_provision_host_all_run
+        - __sap_vm_provision_task_provision_host_single_check_exists
+        - __sap_vm_provision_task_ovirt_os
+        - __sap_vm_provision_task_provision_host_single_boot_disk
+        - __sap_vm_provision_task_provision_host_single
+        - __sap_vm_provision_task_provision_host_single_info
+        - __sap_vm_provision_task_provision_host_single_volumes
+        - __sap_vm_provision_task_provision_host_all_add
+      loop_control:
+        loop_var: loop_item
+        index_var: loop_item_index
+        label: "{{ 'Variable No. ' + (loop_item_index | string) }}"
+      when:
+        - lookup('ansible.builtin.vars', loop_item, default='') | length > 0
+        - not lookup('ansible.builtin.vars', loop_item, default='') is skipped
+        - lookup('ansible.builtin.vars', loop_item, default='') is failed
+
 
 - name: Ansible Task block to execute on target inventory hosts
   delegate_to: "{{ inventory_hostname }}"

--- a/roles/sap_vm_provision/tasks/platform_ansible/ovirt_vm/execute_main.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/ovirt_vm/execute_main.yml
@@ -45,7 +45,7 @@
     groups_merged_list: "{{ [ [ groups['hana_primary'] | default([]) ] , [ groups['hana_secondary'] | default([]) ] , [ groups['nwas_ascs'] | default([]) ] , [ groups['nwas_ers'] | default([]) ] , [ groups['nwas_pas'] | default([]) ] , [ groups['nwas_aas'] | default([]) ] ] | flatten | select() }}"
 
 - name: Set Ansible Vars
-  register: register_set_ansible_vars
+  register: __sap_vm_provision_task_ansible_vars_set
   ansible.builtin.include_tasks:
     file: common/set_ansible_vars.yml
 
@@ -69,26 +69,26 @@
         name: "{{ inventory_hostname_short }}"
 
     - name: Set /etc/hosts
-      register: register_etc_hosts_file
+      register: __sap_vm_provision_task_os_etc_hosts
       ansible.builtin.include_tasks:
         file: common/set_etc_hosts.yml
 
     - name: Set /etc/hosts for HA
-      register: register_etc_hosts_file_ha
+      register: __sap_vm_provision_task_os_etc_hosts_ha
       ansible.builtin.include_tasks:
         file: common/set_etc_hosts_ha.yml
       when:
         - (groups["hana_secondary"] is defined and (groups["hana_secondary"] | length>0)) or (groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0)) or (groups["anydb_secondary"] is defined and (groups["anydb_secondary"] | length>0))
 
     - name: Set /etc/hosts for Scale-Out
-      register: register_etc_hosts_file_scaleout
+      register: __sap_vm_provision_task_os_etc_hosts_scaleout
       ansible.builtin.include_tasks:
         file: common/set_etc_hosts_scaleout.yml
       when:
         - (groups["hana_primary"] is defined and (groups["hana_primary"] | length>0)) and (sap_hana_scaleout_active_coordinator is defined or sap_hana_scaleout_active_worker is defined or sap_hana_scaleout_standby is defined)
 
     - name: Set vars for sap_storage_setup Ansible Role
-      register: register_ansible_vars_storage
+      register: __sap_vm_provision_task_ansible_vars_storage
       ansible.builtin.include_tasks:
         file: common/set_ansible_vars_storage.yml
 

--- a/roles/sap_vm_provision/tasks/platform_ansible/ovirt_vm/execute_main.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/ovirt_vm/execute_main.yml
@@ -1,6 +1,7 @@
 ---
 
 - name: OVirt Authentication
+  register: ovirt_session
   ovirt.ovirt.ovirt_auth:
     insecure: "{{ sap_vm_provision_ovirt_engine_insecure_bool | default(true) }}"
     url: "{{ sap_vm_provision_ovirt_engine_url | default(lookup('env', 'OVIRT_URL')) | default(omit) }}"
@@ -9,7 +10,6 @@
     password: "{{ sap_vm_provision_ovirt_engine_password | default(lookup('env', 'OVIRT_PASSWORD')) | default(omit) }}"
     ca_file: "{{ sap_vm_provision_ovirt_engine_cafile | default(lookup('env', 'OVIRT_CAFILE')) | default(omit) }}"
   when: ovirt_auth is undefined or not ovirt_auth
-  register: ovirt_session
 
 - name: Set fact to hold loop variables from include_tasks
   ansible.builtin.set_fact:

--- a/roles/sap_vm_provision/tasks/platform_ansible/ovirt_vm/execute_main.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/ovirt_vm/execute_main.yml
@@ -16,14 +16,14 @@
     register_provisioned_host_all: []
 
 - name: Provision hosts to OVirt
-  register: register_provisioned_hosts
+  register: __sap_vm_provision_task_provision_host_all_run
   ansible.builtin.include_tasks:
     file: "{{ 'platform_' + sap_vm_provision_iac_type }}/{{ sap_vm_provision_iac_platform }}/execute_provision.yml"
   vars:
     ovirt_auth: "{{ sap_vm_provision_ovirt_auth }}"
 
 - name: Add hosts provisioned to the Ansible Inventory
-  register: register_add_hosts
+  register: __sap_vm_provision_task_provision_host_all_add
   ansible.builtin.add_host:
     name: "{{ add_item[0].host_node }}"
     groups: "{{ add_item[0].sap_system_type + '_' if (add_item[0].sap_system_type != '') }}{{ add_item[0].sap_host_type }}"
@@ -50,7 +50,7 @@
     file: common/set_ansible_vars.yml
 
   #  - ansible.builtin.debug:
-  #      var: register_add_hosts.results
+  #      var: __sap_vm_provision_task_provision_host_all_add.results
 
 - name: Ansible Task block to execute on target inventory hosts
   delegate_to: "{{ inventory_hostname }}"

--- a/roles/sap_vm_provision/tasks/platform_ansible/ovirt_vm/execute_provision.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/ovirt_vm/execute_provision.yml
@@ -17,8 +17,8 @@
 - name: Check if VM exists
   register: __sap_vm_provision_task_provision_host_single_check_exists
   ovirt.ovirt.ovirt_vm_info:
-    auth: "{{ __sap_vm_provision_task_ovirt_session.ansible_facts.ovirt_auth }}"
     pattern: name={{ inventory_hostname }} and cluster={{ sap_vm_provision_ovirt_hypervisor_cluster_name }}
+    auth: "{{ __sap_vm_provision_task_ovirt_session.ansible_facts.ovirt_auth }}"
 
 
 # For later check if the provided OS name is actually available
@@ -40,12 +40,12 @@
     - name: For Kickstart, provision Virtual Disk boot volume
       register: __sap_vm_provision_task_provision_host_single_boot_disk
       ovirt.ovirt.ovirt_disk:
-        auth: "{{ __sap_vm_provision_task_ovirt_session.ansible_facts.ovirt_auth }}"
         name: "{{ inventory_hostname }}-vol_os"
         size: "{{ sap_vm_provision_ovirt_vm_kickstart_definition.boot_disk.size }}"
         format: "{{ sap_vm_provision_ovirt_vm_kickstart_definition.boot_disk.format }}"
         storage_domain: "{{ sap_vm_provision_ovirt_hypervisor_cluster_storage_domain_name }}" # Hypervisor Cluster's attached storage domain
         wait: true
+        auth: "{{ __sap_vm_provision_task_ovirt_session.ansible_facts.ovirt_auth }}"
       when:
         - sap_vm_provision_ovirt_vm_kickstart_definition is defined
         - sap_vm_provision_ovirt_vm_kickstart_definition | length > 0
@@ -74,7 +74,6 @@
     - name: Provision OVirt Virtual Machine
       register: __sap_vm_provision_task_provision_host_single
       ovirt.ovirt.ovirt_vm:
-        auth: "{{ __sap_vm_provision_task_ovirt_session.ansible_facts.ovirt_auth }}"
 
         ## Virtual Machine target Hypervisor definition
         cluster: "{{ sap_vm_provision_ovirt_hypervisor_cluster_name }}" # Hypervisor Cluster
@@ -148,6 +147,8 @@
         # UI option: "Rollback this configuration during reboots"
         volatile: true
 
+        auth: "{{ __sap_vm_provision_task_ovirt_session.ansible_facts.ovirt_auth }}"
+
       # Report VM back only after it is done creating the clone image.
       until: __sap_vm_provision_task_provision_host_single.vm.status != "image_locked"
       retries: 120
@@ -158,21 +159,20 @@
 
 - name: Start the VM, if not running
   ovirt.ovirt.ovirt_vm:
-    auth: "{{ __sap_vm_provision_task_ovirt_session.ansible_facts.ovirt_auth }}"
     name: "{{ inventory_hostname }}"
     state: running
+    auth: "{{ __sap_vm_provision_task_ovirt_session.ansible_facts.ovirt_auth }}"
 
 - name: Remove installation ISO from the config
   ovirt.ovirt.ovirt_vm:
-    auth: "{{ __sap_vm_provision_task_ovirt_session.ansible_facts.ovirt_auth }}"
     name: "{{ inventory_hostname }}"
     cd_iso: ""
+    auth: "{{ __sap_vm_provision_task_ovirt_session.ansible_facts.ovirt_auth }}"
   when: sap_vm_provision_ovirt_vm_kickstart_definition is defined
 
 - name: Check VM status
   register: __sap_vm_provision_task_provision_host_single_info
   ovirt.ovirt.ovirt_vm_info:
-    auth: "{{ __sap_vm_provision_task_ovirt_session.ansible_facts.ovirt_auth }}"
     pattern: name={{ inventory_hostname }} and cluster={{ sap_vm_provision_ovirt_hypervisor_cluster_name }}
     all_content: true
     fetch_nested: true
@@ -180,6 +180,7 @@
       - ips
       - name
       - applications
+    auth: "{{ __sap_vm_provision_task_ovirt_session.ansible_facts.ovirt_auth }}"
   # Allow for 15 minutes until the VM reports devices, which include the IP and
   # are required in following tasks.
   until: __sap_vm_provision_task_provision_host_single_info.ovirt_vms[0].reported_devices | length > 0
@@ -274,7 +275,6 @@
 - name: Provision Virtual Disk volumes for OVirt VM filesystems
   register: __sap_vm_provision_task_provision_host_single_volumes
   ovirt.ovirt.ovirt_disk:
-    auth: "{{ __sap_vm_provision_task_ovirt_session.ansible_facts.ovirt_auth }}"
     name: "{{ inventory_hostname }}-vol_{{ vol_item.name }}"
     vm_name: "{{ inventory_hostname }}"
     size: "{{ vol_item.size }}GiB"
@@ -283,6 +283,7 @@
     storage_domain: "{{ sap_vm_provision_ovirt_hypervisor_cluster_storage_domain_name }}" # Hypervisor Cluster's attached storage domain
     wait: true
     bootable: false
+    auth: "{{ __sap_vm_provision_task_ovirt_session.ansible_facts.ovirt_auth }}"
   loop: "{{ filesystem_volume_map }}"
   loop_control:
     loop_var: vol_item

--- a/roles/sap_vm_provision/tasks/platform_ansible/ovirt_vm/execute_provision.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/ovirt_vm/execute_provision.yml
@@ -17,15 +17,15 @@
 - name: Check if VM exists
   register: __sap_vm_provision_task_provision_host_single_check_exists
   ovirt.ovirt.ovirt_vm_info:
-    auth: "{{ ovirt_session.ansible_facts.ovirt_auth }}"
+    auth: "{{ __sap_vm_provision_task_ovirt_session.ansible_facts.ovirt_auth }}"
     pattern: name={{ inventory_hostname }} and cluster={{ sap_vm_provision_ovirt_hypervisor_cluster_name }}
 
 
 # For later check if the provided OS name is actually available
 - name: Check available OS names in OVirt
-  register: register_ovirt_available_os
+  register: __sap_vm_provision_task_ovirt_os
   ovirt.ovirt.ovirt_vm_os_info:
-    auth: "{{ ovirt_session.ansible_facts.ovirt_auth }}"
+    auth: "{{ __sap_vm_provision_task_ovirt_session.ansible_facts.ovirt_auth }}"
 
 
 # VM creation block:
@@ -38,9 +38,9 @@
   block:
 
     - name: For Kickstart, provision Virtual Disk boot volume
-      register: register_provisioned_boot_disk
+      register: __sap_vm_provision_task_provision_host_single_boot_disk
       ovirt.ovirt.ovirt_disk:
-        auth: "{{ ovirt_session.ansible_facts.ovirt_auth }}"
+        auth: "{{ __sap_vm_provision_task_ovirt_session.ansible_facts.ovirt_auth }}"
         name: "{{ inventory_hostname }}-vol_os"
         size: "{{ sap_vm_provision_ovirt_vm_kickstart_definition.boot_disk.size }}"
         format: "{{ sap_vm_provision_ovirt_vm_kickstart_definition.boot_disk.format }}"
@@ -51,16 +51,16 @@
         - sap_vm_provision_ovirt_vm_kickstart_definition | length > 0
         - sap_vm_provision_ovirt_vm_template_name is not defined or
           sap_vm_provision_ovirt_vm_template_name | length == 0
-      until: register_provisioned_boot_disk.disk.status == 'ok'
+      until: __sap_vm_provision_task_provision_host_single_boot_disk.disk.status == 'ok'
       retries: 600
 
     - name: Merge disk provisioning result with disk attachment definition
       ansible.builtin.set_fact:
-        merge_provisioned_boot_disk_fact: "{{ register_provisioned_boot_disk.disk | ansible.builtin.combine(sap_vm_provision_ovirt_vm_kickstart_definition.boot_disk) }}"
+        merge_provisioned_boot_disk_fact: "{{ __sap_vm_provision_task_provision_host_single_boot_disk.disk | ansible.builtin.combine(sap_vm_provision_ovirt_vm_kickstart_definition.boot_disk) }}"
       when:
         - sap_vm_provision_ovirt_vm_kickstart_definition is defined
         - sap_vm_provision_ovirt_vm_kickstart_definition | length > 0
-        - register_provisioned_boot_disk is defined
+        - __sap_vm_provision_task_provision_host_single_boot_disk is defined
 
     - name: Convert disk provisioning result to disk attachment list
       ansible.builtin.set_fact:
@@ -68,13 +68,13 @@
       when:
         - sap_vm_provision_ovirt_vm_kickstart_definition is defined
         - sap_vm_provision_ovirt_vm_kickstart_definition | length > 0
-        - register_provisioned_boot_disk is defined
+        - __sap_vm_provision_task_provision_host_single_boot_disk is defined
 
 
     - name: Provision OVirt Virtual Machine
       register: __sap_vm_provision_task_provision_host_single
       ovirt.ovirt.ovirt_vm:
-        auth: "{{ ovirt_session.ansible_facts.ovirt_auth }}"
+        auth: "{{ __sap_vm_provision_task_ovirt_session.ansible_facts.ovirt_auth }}"
 
         ## Virtual Machine target Hypervisor definition
         cluster: "{{ sap_vm_provision_ovirt_hypervisor_cluster_name }}" # Hypervisor Cluster
@@ -158,13 +158,13 @@
 
 - name: Start the VM, if not running
   ovirt.ovirt.ovirt_vm:
-    auth: "{{ ovirt_session.ansible_facts.ovirt_auth }}"
+    auth: "{{ __sap_vm_provision_task_ovirt_session.ansible_facts.ovirt_auth }}"
     name: "{{ inventory_hostname }}"
     state: running
 
 - name: Remove installation ISO from the config
   ovirt.ovirt.ovirt_vm:
-    auth: "{{ ovirt_session.ansible_facts.ovirt_auth }}"
+    auth: "{{ __sap_vm_provision_task_ovirt_session.ansible_facts.ovirt_auth }}"
     name: "{{ inventory_hostname }}"
     cd_iso: ""
   when: sap_vm_provision_ovirt_vm_kickstart_definition is defined
@@ -172,7 +172,7 @@
 - name: Check VM status
   register: __sap_vm_provision_task_provision_host_single_info
   ovirt.ovirt.ovirt_vm_info:
-    auth: "{{ ovirt_session.ansible_facts.ovirt_auth }}"
+    auth: "{{ __sap_vm_provision_task_ovirt_session.ansible_facts.ovirt_auth }}"
     pattern: name={{ inventory_hostname }} and cluster={{ sap_vm_provision_ovirt_hypervisor_cluster_name }}
     all_content: true
     fetch_nested: true
@@ -274,7 +274,7 @@
 - name: Provision Virtual Disk volumes for OVirt VM filesystems
   register: __sap_vm_provision_task_provision_host_single_volumes
   ovirt.ovirt.ovirt_disk:
-    auth: "{{ ovirt_session.ansible_facts.ovirt_auth }}"
+    auth: "{{ __sap_vm_provision_task_ovirt_session.ansible_facts.ovirt_auth }}"
     name: "{{ inventory_hostname }}-vol_{{ vol_item.name }}"
     vm_name: "{{ inventory_hostname }}"
     size: "{{ vol_item.size }}GiB"

--- a/roles/sap_vm_provision/tasks/platform_ansible/ovirt_vm/execute_provision.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/ovirt_vm/execute_provision.yml
@@ -23,9 +23,9 @@
 
 # For later check if the provided OS name is actually available
 - name: Check available OS names in OVirt
+  register: register_ovirt_available_os
   ovirt.ovirt.ovirt_vm_os_info:
     auth: "{{ ovirt_session.ansible_facts.ovirt_auth }}"
-  register: register_ovirt_available_os
 
 
 # VM creation block:
@@ -38,6 +38,7 @@
   block:
 
     - name: For Kickstart, provision Virtual Disk boot volume
+      register: register_provisioned_boot_disk
       ovirt.ovirt.ovirt_disk:
         auth: "{{ ovirt_session.ansible_facts.ovirt_auth }}"
         name: "{{ inventory_hostname }}-vol_os"
@@ -50,7 +51,6 @@
         - sap_vm_provision_ovirt_vm_kickstart_definition | length > 0
         - sap_vm_provision_ovirt_vm_template_name is not defined or
           sap_vm_provision_ovirt_vm_template_name | length == 0
-      register: register_provisioned_boot_disk
       until: register_provisioned_boot_disk.disk.status == 'ok'
       retries: 600
 
@@ -272,6 +272,7 @@
 # The volume creation task requires the above task to define the parameter
 # which contains the calculated unique device names.
 - name: Provision Virtual Disk volumes for OVirt VM filesystems
+  register: __sap_vm_provision_task_provision_host_single_volumes
   ovirt.ovirt.ovirt_disk:
     auth: "{{ ovirt_session.ansible_facts.ovirt_auth }}"
     name: "{{ inventory_hostname }}-vol_{{ vol_item.name }}"
@@ -290,7 +291,6 @@
   when:
     - vol_item.fstype is defined
     - vol_item.size > 0
-  register: __sap_vm_provision_task_provision_host_single_volumes
 
 
 - name: Append loop value to register

--- a/roles/sap_vm_provision/tasks/platform_ansible/ovirt_vm/execute_provision.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/ovirt_vm/execute_provision.yml
@@ -72,7 +72,7 @@
 
 
     - name: Provision OVirt Virtual Machine
-      register: register_provisioned_host_single
+      register: __sap_vm_provision_task_provision_host_single
       ovirt.ovirt.ovirt_vm:
         auth: "{{ ovirt_session.ansible_facts.ovirt_auth }}"
 
@@ -149,7 +149,7 @@
         volatile: true
 
       # Report VM back only after it is done creating the clone image.
-      until: register_provisioned_host_single.vm.status != "image_locked"
+      until: __sap_vm_provision_task_provision_host_single.vm.status != "image_locked"
       retries: 120
       delay: 5
 
@@ -170,7 +170,7 @@
   when: sap_vm_provision_ovirt_vm_kickstart_definition is defined
 
 - name: Check VM status
-  register: register_provisioned_host_single_info
+  register: __sap_vm_provision_task_provision_host_single_info
   ovirt.ovirt.ovirt_vm_info:
     auth: "{{ ovirt_session.ansible_facts.ovirt_auth }}"
     pattern: name={{ inventory_hostname }} and cluster={{ sap_vm_provision_ovirt_hypervisor_cluster_name }}
@@ -182,14 +182,14 @@
       - applications
   # Allow for 15 minutes until the VM reports devices, which include the IP and
   # are required in following tasks.
-  until: register_provisioned_host_single_info.ovirt_vms[0].reported_devices | length > 0
+  until: __sap_vm_provision_task_provision_host_single_info.ovirt_vms[0].reported_devices | length > 0
   retries: 180
   delay: 5
 
 
 - name: Create fact for delegate host IP
   ansible.builtin.set_fact:
-    provisioned_private_ip: "{{ register_provisioned_host_single_info.ovirt_vms[0].reported_devices[0].ips[0].address }}"
+    provisioned_private_ip: "{{ __sap_vm_provision_task_provision_host_single_info.ovirt_vms[0].reported_devices[0].ips[0].address }}"
 
 
 - name: Collect only facts about hardware
@@ -290,13 +290,13 @@
   when:
     - vol_item.fstype is defined
     - vol_item.size > 0
-  register: volume_provisioning
+  register: __sap_vm_provision_task_provision_host_single_volumes
 
 
 - name: Append loop value to register
   ansible.builtin.set_fact:
-    register_provisioned_host_single: "{{ register_provisioned_host_single_info.ovirt_vms[0] | combine( { 'host_node' : inventory_hostname } , { 'sap_host_type' : lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][scaleout_origin_host_spec | default(inventory_hostname)].sap_host_type } , { 'sap_system_type' : (lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][scaleout_origin_host_spec | default(inventory_hostname)].sap_system_type | default('')) } ) }}"
+    __sap_vm_provision_task_provision_host_single: "{{ __sap_vm_provision_task_provision_host_single_info.ovirt_vms[0] | combine( { 'host_node' : inventory_hostname } , { 'sap_host_type' : lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][scaleout_origin_host_spec | default(inventory_hostname)].sap_host_type } , { 'sap_system_type' : (lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][scaleout_origin_host_spec | default(inventory_hostname)].sap_system_type | default('')) } ) }}"
 
 - name: Append output to merged register
   ansible.builtin.set_fact:
-    register_provisioned_host_all: "{{ register_provisioned_host_all + [register_provisioned_host_single] }}"
+    register_provisioned_host_all: "{{ register_provisioned_host_all + [__sap_vm_provision_task_provision_host_single] }}"

--- a/roles/sap_vm_provision/tasks/platform_ansible/ovirt_vm/execute_provision.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/ovirt_vm/execute_provision.yml
@@ -15,7 +15,7 @@
     - not inventory_hostname in lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan].keys()
 
 - name: Check if VM exists
-  register: register_check_vm_exists
+  register: __sap_vm_provision_task_provision_host_single_check_exists
   ovirt.ovirt.ovirt_vm_info:
     auth: "{{ ovirt_session.ansible_facts.ovirt_auth }}"
     pattern: name={{ inventory_hostname }} and cluster={{ sap_vm_provision_ovirt_hypervisor_cluster_name }}
@@ -33,8 +33,8 @@
 #
 - name: Block that provisions the VM
   when:
-    - register_check_vm_exists.ovirt_vms is defined
-    - register_check_vm_exists.ovirt_vms | length == 0
+    - __sap_vm_provision_task_provision_host_single_check_exists.ovirt_vms is defined
+    - __sap_vm_provision_task_provision_host_single_check_exists.ovirt_vms | length == 0
   block:
 
     - name: For Kickstart, provision Virtual Disk boot volume
@@ -193,7 +193,7 @@
 
 
 - name: Collect only facts about hardware
-  register: host_disks_info
+  register: __sap_vm_provision_task_ansible_facts_host_disks_info
   ansible.builtin.setup:
     gather_subset:
       - hardware
@@ -211,14 +211,14 @@
 
 #- name: Debug Ansible Facts devices used list
 #  ansible.builtin.debug:
-#    msg: "{{ host_disks_info.ansible_facts.ansible_device_links.ids.keys() | list }}"
+#    msg: "{{ __sap_vm_provision_task_ansible_facts_host_disks_info.ansible_facts.ansible_device_links.ids.keys() | list }}"
 
 
 - name: Set fact for available storage volume device names
   ansible.builtin.set_fact:
     available_volumes: |-
       {% set letters = 'bcdefghijklmnopqrstuvwxyz' %}
-      {% set ansible_facts_devices_used_list = host_disks_info.ansible_facts.ansible_device_links.ids.keys() | list %}
+      {% set ansible_facts_devices_used_list = __sap_vm_provision_task_ansible_facts_host_disks_info.ansible_facts.ansible_device_links.ids.keys() | list %}
       {% set volumes = [] %}
       {%- for letter in letters -%}
         {% for device in ansible_facts_devices_used_list -%}

--- a/roles/sap_vm_provision/tasks/platform_ansible/vmware_vm/execute_main.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/vmware_vm/execute_main.yml
@@ -51,7 +51,7 @@
         groups_merged_list: "{{ [ [ groups['hana_primary'] | default([]) ] , [ groups['hana_secondary'] | default([]) ] , [ groups['nwas_ascs'] | default([]) ] , [ groups['nwas_ers'] | default([]) ] , [ groups['nwas_pas'] | default([]) ] , [ groups['nwas_aas'] | default([]) ] ] | flatten | select() }}"
 
     - name: Set Ansible Vars
-      register: register_set_ansible_vars
+      register: __sap_vm_provision_task_ansible_vars_set
       ansible.builtin.include_tasks:
         file: common/set_ansible_vars.yml
 
@@ -75,26 +75,26 @@
         name: "{{ inventory_hostname_short }}"
 
     - name: Set /etc/hosts
-      register: register_etc_hosts_file
+      register: __sap_vm_provision_task_os_etc_hosts
       ansible.builtin.include_tasks:
         file: common/set_etc_hosts.yml
 
     - name: Set /etc/hosts for HA
-      register: register_etc_hosts_file_ha
+      register: __sap_vm_provision_task_os_etc_hosts_ha
       ansible.builtin.include_tasks:
         file: common/set_etc_hosts_ha.yml
       when:
         - (groups["hana_secondary"] is defined and (groups["hana_secondary"] | length>0)) or (groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0)) or (groups["anydb_secondary"] is defined and (groups["anydb_secondary"] | length>0))
 
     - name: Set /etc/hosts for Scale-Out
-      register: register_etc_hosts_file_scaleout
+      register: __sap_vm_provision_task_os_etc_hosts_scaleout
       ansible.builtin.include_tasks:
         file: common/set_etc_hosts_scaleout.yml
       when:
         - (groups["hana_primary"] is defined and (groups["hana_primary"] | length>0)) and (sap_hana_scaleout_active_coordinator is defined or sap_hana_scaleout_active_worker is defined or sap_hana_scaleout_standby is defined)
 
     - name: Set vars for sap_storage_setup Ansible Role
-      register: register_ansible_vars_storage
+      register: __sap_vm_provision_task_ansible_vars_storage
       ansible.builtin.include_tasks:
         file: common/set_ansible_vars_storage.yml
 

--- a/roles/sap_vm_provision/tasks/platform_ansible/vmware_vm/execute_main.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/vmware_vm/execute_main.yml
@@ -30,7 +30,7 @@
       ansible.builtin.add_host:
         name: "{{ add_item[0].host_node }}"
         groups: "{{ add_item[0].sap_system_type + '_' if (add_item[0].sap_system_type != '') }}{{ add_item[0].sap_host_type }}"
-        ansible_host: "{{ add_item[0].vmware_vm_network_info.ansible_facts.ansible_default_ipv4.address }}"
+        ansible_host: "{{ add_item[0].__sap_vm_provision_task_vmware_vm_network_info.ansible_facts.ansible_default_ipv4.address }}"
         ansible_user: "root"
         ansible_ssh_private_key_file: "{{ sap_vm_provision_ssh_host_private_key_file_path }}"
         ansible_ssh_common_args: -o ConnectTimeout=180 -o ControlMaster=auto -o ControlPersist=3600s -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ForwardX11=no -o ProxyCommand='ssh -W %h:%p {{ sap_vm_provision_bastion_user }}@{{ sap_vm_provision_bastion_public_ip }} -p {{ sap_vm_provision_bastion_ssh_port }} -i {{ sap_vm_provision_ssh_bastion_private_key_file_path }} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
@@ -64,11 +64,20 @@
         msg: "{{ lookup('ansible.builtin.vars', loop_item) }}"
       loop:
         - __sap_vm_provision_task_provision_host_all_run
+        - __sap_vm_provision_task_vmware_vm_folder
+        - __sap_vm_provision_task_vmware_vm_cluster
+        - __sap_vm_provision_task_vmware_vm_cluster_host
+        - __sap_vm_provision_task_vmware_vm_cluster_datastore
+        - __sap_vm_provision_task_vmware_vm_content_library
+        - __sap_vm_provision_task_vmware_vm_content_library_items
         - __sap_vm_provision_task_provision_host_single_check_exists
-        - __sap_vm_provision_task_ovirt_os
-        - __sap_vm_provision_task_provision_host_single_boot_disk
         - __sap_vm_provision_task_provision_host_single
         - __sap_vm_provision_task_provision_host_single_info
+        - __sap_vm_provision_task_vmware_vm_power_info
+        - __sap_vm_provision_task_vmware_vm_info
+        - __sap_vm_provision_task_vmware_vm_nic_info
+        - __sap_vm_provision_task_ansible_facts_host_disks_info
+        - __sap_vm_provision_task_vmware_vm_network_info
         - __sap_vm_provision_task_provision_host_single_volumes
         - __sap_vm_provision_task_provision_host_all_add
       loop_control:

--- a/roles/sap_vm_provision/tasks/platform_ansible/vmware_vm/execute_main.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/vmware_vm/execute_main.yml
@@ -1,6 +1,10 @@
 ---
 
 - name: Ansible Task block for looped provisioning of VMware VMs
+  any_errors_fatal: true
+  # Using environment, no_log is ineffective and log will show 'EXEC /bin/sh -c 'ENV_VAR=value python3 /AnsiballZ_ansible_module_name.py && sleep 0'
+  # Therefore do not use environment for secrets, use only for non-sensitive values as this will reduce Ansible Task parameters.
+  # environment:
   block:
 
     - name: Set fact to hold loop variables from include_tasks
@@ -10,23 +14,16 @@
     # Use vmware.vmware_rest Ansible Collection for VMware vCenter REST API, for VMware vSphere 7.0.2+
     # Does not use community.vmware Ansible Collection for legacy pyvmomi Python Package for VMware vCenter SOAP API
 
-    # Use of environment avoids the need for variables in each Ansible Module call
-    # Hypervisor Control Plane credentials
-    # vcenter_hostname: "{{ sap_vm_provision_vmware_vcenter_hostname | default(lookup('env', 'VMWARE_HOST')) | default(omit) }}"
-    # vcenter_validate_certs: "{{ (sap_vm_provision_vmware_vcenter_validate_certs_bool | default(lookup('env', 'VMWARE_VALIDATE_CERTS'))) | bool | default(false) }}"
-    # vcenter_username: "{{ sap_vm_provision_vmware_vcenter_user | default(lookup('env', 'VMWARE_USER')) | default(omit) }}"
-    # vcenter_password: "{{ sap_vm_provision_vmware_vcenter_password | default(lookup('env', 'VMWARE_PASSWORD')) | default(omit) }}"
-
     - name: Provision hosts to VMware vSphere
       register: __sap_vm_provision_task_provision_host_all_run
       ansible.builtin.include_tasks:
         file: "{{ 'platform_' + sap_vm_provision_iac_type }}/{{ sap_vm_provision_iac_platform }}/execute_provision.yml"
-        apply:
-          environment:
-            VMWARE_HOST: "{{ sap_vm_provision_vmware_vcenter_hostname | default(lookup('env', 'VMWARE_HOST')) | default(omit) }}"
-            VMWARE_VALIDATE_CERTS: "{{ (sap_vm_provision_vmware_vcenter_validate_certs_bool | default(lookup('env', 'VMWARE_VALIDATE_CERTS'))) | bool | default(false) }}"
-            VMWARE_USER: "{{ sap_vm_provision_vmware_vcenter_user | default(lookup('env', 'VMWARE_USER')) | default(omit) }}"
-            VMWARE_PASSWORD: "{{ sap_vm_provision_vmware_vcenter_password | default(lookup('env', 'VMWARE_PASSWORD')) | default(omit) }}"
+        # apply:
+        #   environment:
+        #     VMWARE_HOST: "{{ sap_vm_provision_vmware_vcenter_hostname | default(lookup('env', 'VMWARE_HOST')) | default(omit) }}"
+        #     VMWARE_VALIDATE_CERTS: "{{ (sap_vm_provision_vmware_vcenter_validate_certs_bool | default(lookup('env', 'VMWARE_VALIDATE_CERTS'))) | bool | default(false) }}"
+        #     VMWARE_USER: "{{ sap_vm_provision_vmware_vcenter_user | default(lookup('env', 'VMWARE_USER')) | default(omit) }}"
+        #     VMWARE_PASSWORD: "{{ sap_vm_provision_vmware_vcenter_password | default(lookup('env', 'VMWARE_PASSWORD')) | default(omit) }}"
 
     - name: Add hosts provisioned to the Ansible Inventory
       register: __sap_vm_provision_task_provision_host_all_add
@@ -57,6 +54,32 @@
 
   #  - ansible.builtin.debug:
   #      var: __sap_vm_provision_task_provision_host_all_add.results
+
+  rescue:
+    # This requires no_log set on each Ansible Task, and not set on the Ansible Task Block
+    # This requires an Ansible Task Block containing the Ansible Tasks for calling
+    # Infrastructure Platform APIs (via Ansible Modules)
+    - name: Show errors in task outputs
+      ansible.builtin.fail:
+        msg: "{{ lookup('ansible.builtin.vars', loop_item) }}"
+      loop:
+        - __sap_vm_provision_task_provision_host_all_run
+        - __sap_vm_provision_task_provision_host_single_check_exists
+        - __sap_vm_provision_task_ovirt_os
+        - __sap_vm_provision_task_provision_host_single_boot_disk
+        - __sap_vm_provision_task_provision_host_single
+        - __sap_vm_provision_task_provision_host_single_info
+        - __sap_vm_provision_task_provision_host_single_volumes
+        - __sap_vm_provision_task_provision_host_all_add
+      loop_control:
+        loop_var: loop_item
+        index_var: loop_item_index
+        label: "{{ 'Variable No. ' + (loop_item_index | string) }}"
+      when:
+        - lookup('ansible.builtin.vars', loop_item, default='') | length > 0
+        - not lookup('ansible.builtin.vars', loop_item, default='') is skipped
+        - lookup('ansible.builtin.vars', loop_item, default='') is failed
+
 
 - name: Ansible Task block to execute on target inventory hosts
   delegate_to: "{{ inventory_hostname }}"

--- a/roles/sap_vm_provision/tasks/platform_ansible/vmware_vm/execute_main.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/vmware_vm/execute_main.yml
@@ -18,7 +18,7 @@
     # vcenter_password: "{{ sap_vm_provision_vmware_vcenter_password | default(lookup('env', 'VMWARE_PASSWORD')) | default(omit) }}"
 
     - name: Provision hosts to VMware vSphere
-      register: register_provisioned_hosts
+      register: __sap_vm_provision_task_provision_host_all_run
       ansible.builtin.include_tasks:
         file: "{{ 'platform_' + sap_vm_provision_iac_type }}/{{ sap_vm_provision_iac_platform }}/execute_provision.yml"
         apply:
@@ -29,7 +29,7 @@
             VMWARE_PASSWORD: "{{ sap_vm_provision_vmware_vcenter_password | default(lookup('env', 'VMWARE_PASSWORD')) | default(omit) }}"
 
     - name: Add hosts provisioned to the Ansible Inventory
-      register: register_add_hosts
+      register: __sap_vm_provision_task_provision_host_all_add
       ansible.builtin.add_host:
         name: "{{ add_item[0].host_node }}"
         groups: "{{ add_item[0].sap_system_type + '_' if (add_item[0].sap_system_type != '') }}{{ add_item[0].sap_host_type }}"
@@ -56,7 +56,7 @@
         file: common/set_ansible_vars.yml
 
   #  - ansible.builtin.debug:
-  #      var: register_add_hosts.results
+  #      var: __sap_vm_provision_task_provision_host_all_add.results
 
 - name: Ansible Task block to execute on target inventory hosts
   delegate_to: "{{ inventory_hostname }}"

--- a/roles/sap_vm_provision/tasks/platform_ansible/vmware_vm/execute_provision.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/vmware_vm/execute_provision.yml
@@ -55,19 +55,19 @@
     vmware_vm_template_id: "{{ (register_vmware_vm_content_library_items.value | selectattr('type', '==', 'vm-template') | selectattr('name', '==', sap_vm_provision_vmware_vm_template_name) | first).id }}"
 
 - name: Check if VM exists
-  register: register_check_vm_exists
+  register: __sap_vm_provision_task_provision_host_single_check_exists
   vmware.vmware_rest.vcenter_vm_info:
     names: "{{ inventory_hostname }}"
 
 
 - name: Set VM ID
-  when: not register_check_vm_exists.value | length == 0
+  when: not __sap_vm_provision_task_provision_host_single_check_exists.value | length == 0
   ansible.builtin.set_fact:
-    register_vmware_vm_cluster_host_id: "{{ register_check_vm_exists.value[0].vm }}" # VM ID
+    register_vmware_vm_cluster_host_id: "{{ __sap_vm_provision_task_provision_host_single_check_exists.value[0].vm }}" # VM ID
 
 - name: Check VM status
   register: __sap_vm_provision_task_provision_host_single_info
-  when: not register_check_vm_exists.value | length == 0
+  when: not __sap_vm_provision_task_provision_host_single_check_exists.value | length == 0
   vmware.vmware_rest.vcenter_vm:
     vm: "{{ register_vmware_vm_cluster_host_id }}" # VM ID
 
@@ -75,7 +75,7 @@
 # VM creation block:
 # This block is run when the VM does not exist yet.
 - name: Block that provisions the VM
-  when: register_check_vm_exists.value | length == 0
+  when: __sap_vm_provision_task_provision_host_single_check_exists.value | length == 0
   block:
 
     # Deploy a Virtual Machine from a VM Template in a Content Library
@@ -126,7 +126,7 @@
 
 
 - name: Set VM ID
-  when: register_check_vm_exists.value | length == 0
+  when: __sap_vm_provision_task_provision_host_single_check_exists.value | length == 0
   ansible.builtin.set_fact:
     register_vmware_vm_cluster_host_id: "{{ __sap_vm_provision_task_provision_host_single.value }}" # Returned from VM provision
 
@@ -260,7 +260,7 @@
 
 
 - name: Collect only facts about hardware
-  register: host_disks_info
+  register: __sap_vm_provision_task_ansible_facts_host_disks_info
   ansible.builtin.setup:
     gather_subset:
       - hardware
@@ -294,14 +294,14 @@
 
 #- name: Debug Ansible Facts devices used list
 #  ansible.builtin.debug:
-#    msg: "{{ host_disks_info.ansible_facts.ansible_device_links.ids.keys() | list }}"
+#    msg: "{{ __sap_vm_provision_task_ansible_facts_host_disks_info.ansible_facts.ansible_device_links.ids.keys() | list }}"
 
 
 - name: Set fact for available storage volume device names
   ansible.builtin.set_fact:
     available_volumes: |-
       {% set letters = 'bcdefghijklmnopqrstuvwxyz' %}
-      {% set ansible_facts_devices_used_list = host_disks_info.ansible_facts.ansible_device_links.ids.keys() | list %}
+      {% set ansible_facts_devices_used_list = __sap_vm_provision_task_ansible_facts_host_disks_info.ansible_facts.ansible_device_links.ids.keys() | list %}
       {% set volumes = [] %}
       {%- for letter in letters -%}
         {% for device in ansible_facts_devices_used_list -%}

--- a/roles/sap_vm_provision/tasks/platform_ansible/vmware_vm/execute_provision.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/vmware_vm/execute_provision.yml
@@ -66,7 +66,7 @@
     register_vmware_vm_cluster_host_id: "{{ register_check_vm_exists.value[0].vm }}" # VM ID
 
 - name: Check VM status
-  register: register_provisioned_host_single_info
+  register: __sap_vm_provision_task_provision_host_single_info
   when: not register_check_vm_exists.value | length == 0
   vmware.vmware_rest.vcenter_vm:
     vm: "{{ register_vmware_vm_cluster_host_id }}" # VM ID
@@ -81,7 +81,7 @@
     # Deploy a Virtual Machine from a VM Template in a Content Library
     # Doc: https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.vm_admin.doc/GUID-6EA309BC-9113-449C-B668-ACBB363485C3.html
     - name: Provision VMware Virtual Machine based upon the VM Template
-      register: register_provisioned_host_single
+      register: __sap_vm_provision_task_provision_host_single
       vmware.vmware_rest.vcenter_vmtemplate_libraryitems:
 
         ## Virtual Machine target Hypervisor definition
@@ -118,7 +118,7 @@
           # storage_policy:
 
       # # Report VM back only after it is done creating the clone image.
-      # until: register_provisioned_host_single.vm.status != "image_locked"
+      # until: __sap_vm_provision_task_provision_host_single.vm.status != "image_locked"
       # retries: 120
       # delay: 5
 
@@ -128,11 +128,11 @@
 - name: Set VM ID
   when: register_check_vm_exists.value | length == 0
   ansible.builtin.set_fact:
-    register_vmware_vm_cluster_host_id: "{{ register_provisioned_host_single.value }}" # Returned from VM provision
+    register_vmware_vm_cluster_host_id: "{{ __sap_vm_provision_task_provision_host_single.value }}" # Returned from VM provision
 
 
 - name: Check VM status
-  register: register_provisioned_host_single_info
+  register: __sap_vm_provision_task_provision_host_single_info
   vmware.vmware_rest.vcenter_vm:
     vm: "{{ register_vmware_vm_cluster_host_id }}"
 
@@ -141,7 +141,7 @@
 # Docs https://developer.vmware.com/docs/18555/GUID-75E27FA9-2E40-4CBF-BF3D-22DCFC8F11F7.html
 # >> The instance-id key is required. All other keys are optional.
 - name: Set cloud-init variables for customization specification
-  when: register_provisioned_host_single_info.value.power_state is defined and register_provisioned_host_single_info.value.power_state != "POWERED_ON"
+  when: __sap_vm_provision_task_provision_host_single_info.value.power_state is defined and __sap_vm_provision_task_provision_host_single_info.value.power_state != "POWERED_ON"
   ansible.builtin.set_fact:
     metadata_yaml:
       instance-id: "{{ inventory_hostname }}"
@@ -210,7 +210,7 @@
 # >> metadata as JSON/YAML, userdata as no compression or base64 encoding
 # Error 400 com.vmware.vapi.std.errors.not_allowed_in_current_state : if the virtual machine vm is not in a powered off state.
 - name: Apply customization specification to the VM in Powered Off state
-  when: register_provisioned_host_single_info.value.power_state is defined and register_provisioned_host_single_info.value.power_state != "POWERED_ON"
+  when: __sap_vm_provision_task_provision_host_single_info.value.power_state is defined and __sap_vm_provision_task_provision_host_single_info.value.power_state != "POWERED_ON"
   vmware.vmware_rest.vcenter_vm_guest_customization:
     vm: '{{ register_vmware_vm_cluster_host_id }}'
     configuration_spec:
@@ -371,14 +371,14 @@
   when:
     - vol_item.fstype is defined
     - vol_item.size > 0
-  register: volume_provisioning
-  failed_when: not volume_provisioning.value is defined and not 'already exists' in volume_provisioning.msg
+  register: __sap_vm_provision_task_provision_host_single_volumes
+  failed_when: not __sap_vm_provision_task_provision_host_single_volumes.value is defined and not 'already exists' in __sap_vm_provision_task_provision_host_single_volumes.msg
 
 
 - name: Append loop value to register
   ansible.builtin.set_fact:
-    register_provisioned_host_single: "{{ register_provisioned_host_single_info | combine( { 'host_node' : inventory_hostname } , { 'vmware_vm_network_info' : vmware_vm_network_info } , { 'sap_host_type' : lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][scaleout_origin_host_spec | default(inventory_hostname)].sap_host_type } , { 'sap_system_type' : (lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][scaleout_origin_host_spec | default(inventory_hostname)].sap_system_type | default('')) } ) }}"
+    __sap_vm_provision_task_provision_host_single: "{{ __sap_vm_provision_task_provision_host_single_info | combine( { 'host_node' : inventory_hostname } , { 'vmware_vm_network_info' : vmware_vm_network_info } , { 'sap_host_type' : lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][scaleout_origin_host_spec | default(inventory_hostname)].sap_host_type } , { 'sap_system_type' : (lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][scaleout_origin_host_spec | default(inventory_hostname)].sap_system_type | default('')) } ) }}"
 
 - name: Append output to merged register
   ansible.builtin.set_fact:
-    register_provisioned_host_all: "{{ register_provisioned_host_all + [register_provisioned_host_single] }}"
+    register_provisioned_host_all: "{{ register_provisioned_host_all + [__sap_vm_provision_task_provision_host_single] }}"

--- a/roles/sap_vm_provision/tasks/platform_ansible/vmware_vm/execute_provision.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/vmware_vm/execute_provision.yml
@@ -21,7 +21,7 @@
 
 - name: Identify VM Folder
   no_log: "{{ __sap_vm_provision_no_log }}"
-  register: register_vmware_vm_folder
+  register: __sap_vm_provision_task_vmware_vm_folder
   vmware.vmware_rest.vcenter_folder_info:
     names: "{{ sap_vm_provision_vmware_vm_folder_name }}"
     type: VIRTUAL_MACHINE
@@ -33,7 +33,7 @@
 
 - name: Identify Datacenter Cluster
   no_log: "{{ __sap_vm_provision_no_log }}"
-  register: register_vmware_vm_cluster
+  register: __sap_vm_provision_task_vmware_vm_cluster
   vmware.vmware_rest.vcenter_cluster_info:
     names: "{{ sap_vm_provision_vmware_vm_cluster_name }}"
     # Hypervisor Control Plane credentials
@@ -44,7 +44,7 @@
 
 - name: Identify Host in Datacenter Cluster
   no_log: "{{ __sap_vm_provision_no_log }}"
-  register: register_vmware_vm_cluster_host
+  register: __sap_vm_provision_task_vmware_vm_cluster_host
   vmware.vmware_rest.vcenter_host_info:
     names: "{{ sap_vm_provision_vmware_vm_cluster_host_name }}"
     # Hypervisor Control Plane credentials
@@ -55,7 +55,7 @@
 
 - name: Identify Datastore
   no_log: "{{ __sap_vm_provision_no_log }}"
-  register: register_vmware_vm_cluster_datastore
+  register: __sap_vm_provision_task_vmware_vm_cluster_datastore
   vmware.vmware_rest.vcenter_datastore_info:
     names: "{{ sap_vm_provision_vmware_vm_cluster_datastore_name }}"
     # Hypervisor Control Plane credentials
@@ -66,7 +66,7 @@
 
 - name: Identify Content Library (to store VM Template)
   no_log: "{{ __sap_vm_provision_no_log }}"
-  register: register_vmware_vm_content_library
+  register: __sap_vm_provision_task_vmware_vm_content_library
   vmware.vmware_rest.content_locallibrary:
     name: "{{ sap_vm_provision_vmware_vm_content_library_name }}"
     # Hypervisor Control Plane credentials
@@ -77,9 +77,9 @@
 
 - name: List all items in Content Library
   no_log: "{{ __sap_vm_provision_no_log }}"
-  register: register_vmware_vm_content_library_items
+  register: __sap_vm_provision_task_vmware_vm_content_library_items
   vmware.vmware_rest.content_library_item_info:
-    library_id: "{{ register_vmware_vm_content_library.id }}"
+    library_id: "{{ __sap_vm_provision_task_vmware_vm_content_library.id }}"
     # Hypervisor Control Plane credentials
     vcenter_hostname: "{{ sap_vm_provision_vmware_vcenter_hostname | default(lookup('env', 'VMWARE_HOST')) | default(omit) }}"
     vcenter_validate_certs: "{{ (sap_vm_provision_vmware_vcenter_validate_certs_bool | default(lookup('env', 'VMWARE_VALIDATE_CERTS'))) | bool | default(false) }}"
@@ -88,7 +88,7 @@
 
 - name: Identify VMware Template ID
   ansible.builtin.set_fact:
-    vmware_vm_template_id: "{{ (register_vmware_vm_content_library_items.value | selectattr('type', '==', 'vm-template') | selectattr('name', '==', sap_vm_provision_vmware_vm_template_name) | first).id }}"
+    vmware_vm_template_id: "{{ (__sap_vm_provision_task_vmware_vm_content_library_items.value | selectattr('type', '==', 'vm-template') | selectattr('name', '==', sap_vm_provision_vmware_vm_template_name) | first).id }}"
 
 - name: Check if VM exists
   no_log: "{{ __sap_vm_provision_no_log }}"
@@ -105,14 +105,14 @@
 - name: Set VM ID
   when: not __sap_vm_provision_task_provision_host_single_check_exists.value | length == 0
   ansible.builtin.set_fact:
-    register_vmware_vm_cluster_host_id: "{{ __sap_vm_provision_task_provision_host_single_check_exists.value[0].vm }}" # VM ID
+    __sap_vm_provision_task_vmware_vm_cluster_host_id: "{{ __sap_vm_provision_task_provision_host_single_check_exists.value[0].vm }}" # VM ID
 
 - name: Check VM status
   no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_provision_host_single_info
   when: not __sap_vm_provision_task_provision_host_single_check_exists.value | length == 0
   vmware.vmware_rest.vcenter_vm:
-    vm: "{{ register_vmware_vm_cluster_host_id }}" # VM ID
+    vm: "{{ __sap_vm_provision_task_vmware_vm_cluster_host_id }}" # VM ID
     # Hypervisor Control Plane credentials
     vcenter_hostname: "{{ sap_vm_provision_vmware_vcenter_hostname | default(lookup('env', 'VMWARE_HOST')) | default(omit) }}"
     vcenter_validate_certs: "{{ (sap_vm_provision_vmware_vcenter_validate_certs_bool | default(lookup('env', 'VMWARE_VALIDATE_CERTS'))) | bool | default(false) }}"
@@ -135,10 +135,10 @@
 
         ## Virtual Machine target Hypervisor definition
         placement:
-          folder: "{{ (register_vmware_vm_folder.value | first).folder }}"
+          folder: "{{ (__sap_vm_provision_task_vmware_vm_folder.value | first).folder }}"
           # resource_pool: ""
-          cluster: "{{ (register_vmware_vm_cluster.value | first).cluster }}"
-          host: "{{ (register_vmware_vm_cluster_host.value | first).host }}"
+          cluster: "{{ (__sap_vm_provision_task_vmware_vm_cluster.value | first).cluster }}"
+          host: "{{ (__sap_vm_provision_task_vmware_vm_cluster_host.value | first).host }}"
 
         ## Virtual Machine clone from VM Template definition
         template_library_item: '{{ vmware_vm_template_id }}' # ID of the Content Library Item with the source VM Template (not OVF) to be cloned and deployed
@@ -163,7 +163,7 @@
         ## Virtual Machine Storage configuration
         ## Boot Disk will be loaded to this datastore
         disk_storage:
-          datastore: "{{ (register_vmware_vm_cluster_datastore.value | first).datastore }}"
+          datastore: "{{ (__sap_vm_provision_task_vmware_vm_cluster_datastore.value | first).datastore }}"
           # storage_policy:
 
         ## Hypervisor Control Plane credentials
@@ -183,14 +183,14 @@
 - name: Set VM ID
   when: __sap_vm_provision_task_provision_host_single_check_exists.value | length == 0
   ansible.builtin.set_fact:
-    register_vmware_vm_cluster_host_id: "{{ __sap_vm_provision_task_provision_host_single.value }}" # Returned from VM provision
+    __sap_vm_provision_task_vmware_vm_cluster_host_id: "{{ __sap_vm_provision_task_provision_host_single.value }}" # Returned from VM provision
 
 
 - name: Check VM status
   no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_provision_host_single_info
   vmware.vmware_rest.vcenter_vm:
-    vm: "{{ register_vmware_vm_cluster_host_id }}"
+    vm: "{{ __sap_vm_provision_task_vmware_vm_cluster_host_id }}"
     # Hypervisor Control Plane credentials
     vcenter_hostname: "{{ sap_vm_provision_vmware_vcenter_hostname | default(lookup('env', 'VMWARE_HOST')) | default(omit) }}"
     vcenter_validate_certs: "{{ (sap_vm_provision_vmware_vcenter_validate_certs_bool | default(lookup('env', 'VMWARE_VALIDATE_CERTS'))) | bool | default(false) }}"
@@ -274,7 +274,7 @@
   no_log: "{{ __sap_vm_provision_no_log }}"
   when: __sap_vm_provision_task_provision_host_single_info.value.power_state is defined and __sap_vm_provision_task_provision_host_single_info.value.power_state != "POWERED_ON"
   vmware.vmware_rest.vcenter_vm_guest_customization:
-    vm: '{{ register_vmware_vm_cluster_host_id }}'
+    vm: '{{ __sap_vm_provision_task_vmware_vm_cluster_host_id }}'
     configuration_spec:
       cloud_config:
         type: CLOUDINIT
@@ -293,47 +293,47 @@
 
 - name: Ensure VM is Powered ON
   no_log: "{{ __sap_vm_provision_no_log }}"
-  register: register_vm_power_info
+  register: __sap_vm_provision_task_vmware_vm_power_info
   vmware.vmware_rest.vcenter_vm_power:
     state: start
-    vm: "{{ register_vmware_vm_cluster_host_id }}"
+    vm: "{{ __sap_vm_provision_task_vmware_vm_cluster_host_id }}"
     # Hypervisor Control Plane credentials
     vcenter_hostname: "{{ sap_vm_provision_vmware_vcenter_hostname | default(lookup('env', 'VMWARE_HOST')) | default(omit) }}"
     vcenter_validate_certs: "{{ (sap_vm_provision_vmware_vcenter_validate_certs_bool | default(lookup('env', 'VMWARE_VALIDATE_CERTS'))) | bool | default(false) }}"
     vcenter_username: "{{ sap_vm_provision_vmware_vcenter_user | default(lookup('env', 'VMWARE_USER')) | default(omit) }}"
     vcenter_password: "{{ sap_vm_provision_vmware_vcenter_password | default(lookup('env', 'VMWARE_PASSWORD')) | default(omit) }}"
   # Wait until VM is powered on
-  until: (register_vm_power_info.value.error_type is defined and register_vm_power_info.value.error_type == "ALREADY_IN_DESIRED_STATE")
+  until: (__sap_vm_provision_task_vmware_vm_power_info.value.error_type is defined and __sap_vm_provision_task_vmware_vm_power_info.value.error_type == "ALREADY_IN_DESIRED_STATE")
   retries: 15
   delay: 60
 
 - name: Show VM Information
   no_log: "{{ __sap_vm_provision_no_log }}"
-  register: register_vm_info
+  register: __sap_vm_provision_task_vmware_vm_info
   vmware.vmware_rest.vcenter_vm_info:
-    vm: '{{ register_vmware_vm_cluster_host_id }}'
+    vm: '{{ __sap_vm_provision_task_vmware_vm_cluster_host_id }}'
     # Hypervisor Control Plane credentials
     vcenter_hostname: "{{ sap_vm_provision_vmware_vcenter_hostname | default(lookup('env', 'VMWARE_HOST')) | default(omit) }}"
     vcenter_validate_certs: "{{ (sap_vm_provision_vmware_vcenter_validate_certs_bool | default(lookup('env', 'VMWARE_VALIDATE_CERTS'))) | bool | default(false) }}"
     vcenter_username: "{{ sap_vm_provision_vmware_vcenter_user | default(lookup('env', 'VMWARE_USER')) | default(omit) }}"
     vcenter_password: "{{ sap_vm_provision_vmware_vcenter_password | default(lookup('env', 'VMWARE_PASSWORD')) | default(omit) }}"
   # Wait until VM is powered on
-  until: register_vm_info.value.power_state == "POWERED_ON"
+  until: __sap_vm_provision_task_vmware_vm_info.value.power_state == "POWERED_ON"
   retries: 45
   delay: 20
 
 - name: Get guest networking information (wait until DHCP assigns IP Address for host)
   no_log: "{{ __sap_vm_provision_no_log }}"
-  register: register_vm_nic_info
+  register: __sap_vm_provision_task_vmware_vm_nic_info
   vmware.vmware_rest.vcenter_vm_guest_networking_interfaces_info:
-    vm: '{{ register_vmware_vm_cluster_host_id }}'
+    vm: '{{ __sap_vm_provision_task_vmware_vm_cluster_host_id }}'
     # Hypervisor Control Plane credentials
     vcenter_hostname: "{{ sap_vm_provision_vmware_vcenter_hostname | default(lookup('env', 'VMWARE_HOST')) | default(omit) }}"
     vcenter_validate_certs: "{{ (sap_vm_provision_vmware_vcenter_validate_certs_bool | default(lookup('env', 'VMWARE_VALIDATE_CERTS'))) | bool | default(false) }}"
     vcenter_username: "{{ sap_vm_provision_vmware_vcenter_user | default(lookup('env', 'VMWARE_USER')) | default(omit) }}"
     vcenter_password: "{{ sap_vm_provision_vmware_vcenter_password | default(lookup('env', 'VMWARE_PASSWORD')) | default(omit) }}"
   # Wait until VM Tools is running
-  until: (register_vm_nic_info.value.error_type | default("")) != "SERVICE_UNAVAILABLE" and (register_vm_nic_info.value[0].ip.ip_addresses | length) > 0
+  until: (__sap_vm_provision_task_vmware_vm_nic_info.value.error_type | default("")) != "SERVICE_UNAVAILABLE" and (__sap_vm_provision_task_vmware_vm_nic_info.value[0].ip.ip_addresses | length) > 0
   retries: 45
   delay: 20
 
@@ -341,7 +341,7 @@
 # Use IP Address from the preferred vNIC
 - name: Create fact for delegate host IP
   ansible.builtin.set_fact:
-    provisioned_private_ip: "{{ ((register_vm_nic_info.value | map(attribute='ip.ip_addresses')) | flatten | selectattr('state', '==', 'PREFERRED') | first).ip_address }}"
+    provisioned_private_ip: "{{ ((__sap_vm_provision_task_vmware_vm_nic_info.value | map(attribute='ip.ip_addresses')) | flatten | selectattr('state', '==', 'PREFERRED') | first).ip_address }}"
 
 
 - name: Collect only facts about hardware
@@ -359,7 +359,7 @@
     ansible_ssh_common_args: -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ForwardX11=no
 
 - name: Collect only facts about network
-  register: vmware_vm_network_info
+  register: __sap_vm_provision_task_vmware_vm_network_info
   ansible.builtin.setup:
     gather_subset:
       - default_ipv4
@@ -443,7 +443,7 @@
   no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_provision_host_single_volumes
   vmware.vmware_rest.vcenter_vm_hardware_disk:
-    vm: "{{ register_vmware_vm_cluster_host_id }}"
+    vm: "{{ __sap_vm_provision_task_vmware_vm_cluster_host_id }}"
     type: "{{ vol_item.type | upper }}"
     state: present
     label: "{{ vol_item.name }}"
@@ -468,7 +468,7 @@
 
 - name: Append loop value to register
   ansible.builtin.set_fact:
-    __sap_vm_provision_task_provision_host_single: "{{ __sap_vm_provision_task_provision_host_single_info | combine( { 'host_node' : inventory_hostname } , { 'vmware_vm_network_info' : vmware_vm_network_info } , { 'sap_host_type' : lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][scaleout_origin_host_spec | default(inventory_hostname)].sap_host_type } , { 'sap_system_type' : (lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][scaleout_origin_host_spec | default(inventory_hostname)].sap_system_type | default('')) } ) }}"
+    __sap_vm_provision_task_provision_host_single: "{{ __sap_vm_provision_task_provision_host_single_info | combine( { 'host_node' : inventory_hostname } , { '__sap_vm_provision_task_vmware_vm_network_info' : __sap_vm_provision_task_vmware_vm_network_info } , { 'sap_host_type' : lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][scaleout_origin_host_spec | default(inventory_hostname)].sap_host_type } , { 'sap_system_type' : (lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][scaleout_origin_host_spec | default(inventory_hostname)].sap_system_type | default('')) } ) }}"
 
 - name: Append output to merged register
   ansible.builtin.set_fact:

--- a/roles/sap_vm_provision/tasks/platform_ansible/vmware_vm/execute_provision.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/vmware_vm/execute_provision.yml
@@ -355,6 +355,7 @@
 # The volume creation task requires the above task to define the parameter
 # which contains the calculated unique device names.
 - name: Provision Virtual Disk volumes and attach to VM
+  register: __sap_vm_provision_task_provision_host_single_volumes
   vmware.vmware_rest.vcenter_vm_hardware_disk:
     vm: "{{ register_vmware_vm_cluster_host_id }}"
     type: "{{ vol_item.type | upper }}"
@@ -371,7 +372,6 @@
   when:
     - vol_item.fstype is defined
     - vol_item.size > 0
-  register: __sap_vm_provision_task_provision_host_single_volumes
   failed_when: not __sap_vm_provision_task_provision_host_single_volumes.value is defined and not 'already exists' in __sap_vm_provision_task_provision_host_single_volumes.msg
 
 

--- a/roles/sap_vm_provision/tasks/platform_ansible/vmware_vm/execute_provision.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/vmware_vm/execute_provision.yml
@@ -20,44 +20,86 @@
     - not inventory_hostname in lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan].keys()
 
 - name: Identify VM Folder
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: register_vmware_vm_folder
   vmware.vmware_rest.vcenter_folder_info:
     names: "{{ sap_vm_provision_vmware_vm_folder_name }}"
     type: VIRTUAL_MACHINE
+    # Hypervisor Control Plane credentials
+    vcenter_hostname: "{{ sap_vm_provision_vmware_vcenter_hostname | default(lookup('env', 'VMWARE_HOST')) | default(omit) }}"
+    vcenter_validate_certs: "{{ (sap_vm_provision_vmware_vcenter_validate_certs_bool | default(lookup('env', 'VMWARE_VALIDATE_CERTS'))) | bool | default(false) }}"
+    vcenter_username: "{{ sap_vm_provision_vmware_vcenter_user | default(lookup('env', 'VMWARE_USER')) | default(omit) }}"
+    vcenter_password: "{{ sap_vm_provision_vmware_vcenter_password | default(lookup('env', 'VMWARE_PASSWORD')) | default(omit) }}"
 
 - name: Identify Datacenter Cluster
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: register_vmware_vm_cluster
   vmware.vmware_rest.vcenter_cluster_info:
     names: "{{ sap_vm_provision_vmware_vm_cluster_name }}"
+    # Hypervisor Control Plane credentials
+    vcenter_hostname: "{{ sap_vm_provision_vmware_vcenter_hostname | default(lookup('env', 'VMWARE_HOST')) | default(omit) }}"
+    vcenter_validate_certs: "{{ (sap_vm_provision_vmware_vcenter_validate_certs_bool | default(lookup('env', 'VMWARE_VALIDATE_CERTS'))) | bool | default(false) }}"
+    vcenter_username: "{{ sap_vm_provision_vmware_vcenter_user | default(lookup('env', 'VMWARE_USER')) | default(omit) }}"
+    vcenter_password: "{{ sap_vm_provision_vmware_vcenter_password | default(lookup('env', 'VMWARE_PASSWORD')) | default(omit) }}"
 
 - name: Identify Host in Datacenter Cluster
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: register_vmware_vm_cluster_host
   vmware.vmware_rest.vcenter_host_info:
     names: "{{ sap_vm_provision_vmware_vm_cluster_host_name }}"
+    # Hypervisor Control Plane credentials
+    vcenter_hostname: "{{ sap_vm_provision_vmware_vcenter_hostname | default(lookup('env', 'VMWARE_HOST')) | default(omit) }}"
+    vcenter_validate_certs: "{{ (sap_vm_provision_vmware_vcenter_validate_certs_bool | default(lookup('env', 'VMWARE_VALIDATE_CERTS'))) | bool | default(false) }}"
+    vcenter_username: "{{ sap_vm_provision_vmware_vcenter_user | default(lookup('env', 'VMWARE_USER')) | default(omit) }}"
+    vcenter_password: "{{ sap_vm_provision_vmware_vcenter_password | default(lookup('env', 'VMWARE_PASSWORD')) | default(omit) }}"
 
 - name: Identify Datastore
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: register_vmware_vm_cluster_datastore
   vmware.vmware_rest.vcenter_datastore_info:
     names: "{{ sap_vm_provision_vmware_vm_cluster_datastore_name }}"
+    # Hypervisor Control Plane credentials
+    vcenter_hostname: "{{ sap_vm_provision_vmware_vcenter_hostname | default(lookup('env', 'VMWARE_HOST')) | default(omit) }}"
+    vcenter_validate_certs: "{{ (sap_vm_provision_vmware_vcenter_validate_certs_bool | default(lookup('env', 'VMWARE_VALIDATE_CERTS'))) | bool | default(false) }}"
+    vcenter_username: "{{ sap_vm_provision_vmware_vcenter_user | default(lookup('env', 'VMWARE_USER')) | default(omit) }}"
+    vcenter_password: "{{ sap_vm_provision_vmware_vcenter_password | default(lookup('env', 'VMWARE_PASSWORD')) | default(omit) }}"
 
 - name: Identify Content Library (to store VM Template)
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: register_vmware_vm_content_library
   vmware.vmware_rest.content_locallibrary:
     name: "{{ sap_vm_provision_vmware_vm_content_library_name }}"
+    # Hypervisor Control Plane credentials
+    vcenter_hostname: "{{ sap_vm_provision_vmware_vcenter_hostname | default(lookup('env', 'VMWARE_HOST')) | default(omit) }}"
+    vcenter_validate_certs: "{{ (sap_vm_provision_vmware_vcenter_validate_certs_bool | default(lookup('env', 'VMWARE_VALIDATE_CERTS'))) | bool | default(false) }}"
+    vcenter_username: "{{ sap_vm_provision_vmware_vcenter_user | default(lookup('env', 'VMWARE_USER')) | default(omit) }}"
+    vcenter_password: "{{ sap_vm_provision_vmware_vcenter_password | default(lookup('env', 'VMWARE_PASSWORD')) | default(omit) }}"
 
 - name: List all items in Content Library
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: register_vmware_vm_content_library_items
   vmware.vmware_rest.content_library_item_info:
     library_id: "{{ register_vmware_vm_content_library.id }}"
+    # Hypervisor Control Plane credentials
+    vcenter_hostname: "{{ sap_vm_provision_vmware_vcenter_hostname | default(lookup('env', 'VMWARE_HOST')) | default(omit) }}"
+    vcenter_validate_certs: "{{ (sap_vm_provision_vmware_vcenter_validate_certs_bool | default(lookup('env', 'VMWARE_VALIDATE_CERTS'))) | bool | default(false) }}"
+    vcenter_username: "{{ sap_vm_provision_vmware_vcenter_user | default(lookup('env', 'VMWARE_USER')) | default(omit) }}"
+    vcenter_password: "{{ sap_vm_provision_vmware_vcenter_password | default(lookup('env', 'VMWARE_PASSWORD')) | default(omit) }}"
 
 - name: Identify VMware Template ID
   ansible.builtin.set_fact:
     vmware_vm_template_id: "{{ (register_vmware_vm_content_library_items.value | selectattr('type', '==', 'vm-template') | selectattr('name', '==', sap_vm_provision_vmware_vm_template_name) | first).id }}"
 
 - name: Check if VM exists
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_provision_host_single_check_exists
   vmware.vmware_rest.vcenter_vm_info:
     names: "{{ inventory_hostname }}"
+    # Hypervisor Control Plane credentials
+    vcenter_hostname: "{{ sap_vm_provision_vmware_vcenter_hostname | default(lookup('env', 'VMWARE_HOST')) | default(omit) }}"
+    vcenter_validate_certs: "{{ (sap_vm_provision_vmware_vcenter_validate_certs_bool | default(lookup('env', 'VMWARE_VALIDATE_CERTS'))) | bool | default(false) }}"
+    vcenter_username: "{{ sap_vm_provision_vmware_vcenter_user | default(lookup('env', 'VMWARE_USER')) | default(omit) }}"
+    vcenter_password: "{{ sap_vm_provision_vmware_vcenter_password | default(lookup('env', 'VMWARE_PASSWORD')) | default(omit) }}"
 
 
 - name: Set VM ID
@@ -66,10 +108,16 @@
     register_vmware_vm_cluster_host_id: "{{ __sap_vm_provision_task_provision_host_single_check_exists.value[0].vm }}" # VM ID
 
 - name: Check VM status
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_provision_host_single_info
   when: not __sap_vm_provision_task_provision_host_single_check_exists.value | length == 0
   vmware.vmware_rest.vcenter_vm:
     vm: "{{ register_vmware_vm_cluster_host_id }}" # VM ID
+    # Hypervisor Control Plane credentials
+    vcenter_hostname: "{{ sap_vm_provision_vmware_vcenter_hostname | default(lookup('env', 'VMWARE_HOST')) | default(omit) }}"
+    vcenter_validate_certs: "{{ (sap_vm_provision_vmware_vcenter_validate_certs_bool | default(lookup('env', 'VMWARE_VALIDATE_CERTS'))) | bool | default(false) }}"
+    vcenter_username: "{{ sap_vm_provision_vmware_vcenter_user | default(lookup('env', 'VMWARE_USER')) | default(omit) }}"
+    vcenter_password: "{{ sap_vm_provision_vmware_vcenter_password | default(lookup('env', 'VMWARE_PASSWORD')) | default(omit) }}"
 
 
 # VM creation block:
@@ -81,6 +129,7 @@
     # Deploy a Virtual Machine from a VM Template in a Content Library
     # Doc: https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.vm_admin.doc/GUID-6EA309BC-9113-449C-B668-ACBB363485C3.html
     - name: Provision VMware Virtual Machine based upon the VM Template
+      no_log: "{{ __sap_vm_provision_no_log }}"
       register: __sap_vm_provision_task_provision_host_single
       vmware.vmware_rest.vcenter_vmtemplate_libraryitems:
 
@@ -117,6 +166,12 @@
           datastore: "{{ (register_vmware_vm_cluster_datastore.value | first).datastore }}"
           # storage_policy:
 
+        ## Hypervisor Control Plane credentials
+        vcenter_hostname: "{{ sap_vm_provision_vmware_vcenter_hostname | default(lookup('env', 'VMWARE_HOST')) | default(omit) }}"
+        vcenter_validate_certs: "{{ (sap_vm_provision_vmware_vcenter_validate_certs_bool | default(lookup('env', 'VMWARE_VALIDATE_CERTS'))) | bool | default(false) }}"
+        vcenter_username: "{{ sap_vm_provision_vmware_vcenter_user | default(lookup('env', 'VMWARE_USER')) | default(omit) }}"
+        vcenter_password: "{{ sap_vm_provision_vmware_vcenter_password | default(lookup('env', 'VMWARE_PASSWORD')) | default(omit) }}"
+
       # # Report VM back only after it is done creating the clone image.
       # until: __sap_vm_provision_task_provision_host_single.vm.status != "image_locked"
       # retries: 120
@@ -132,9 +187,15 @@
 
 
 - name: Check VM status
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_provision_host_single_info
   vmware.vmware_rest.vcenter_vm:
     vm: "{{ register_vmware_vm_cluster_host_id }}"
+    # Hypervisor Control Plane credentials
+    vcenter_hostname: "{{ sap_vm_provision_vmware_vcenter_hostname | default(lookup('env', 'VMWARE_HOST')) | default(omit) }}"
+    vcenter_validate_certs: "{{ (sap_vm_provision_vmware_vcenter_validate_certs_bool | default(lookup('env', 'VMWARE_VALIDATE_CERTS'))) | bool | default(false) }}"
+    vcenter_username: "{{ sap_vm_provision_vmware_vcenter_user | default(lookup('env', 'VMWARE_USER')) | default(omit) }}"
+    vcenter_password: "{{ sap_vm_provision_vmware_vcenter_password | default(lookup('env', 'VMWARE_PASSWORD')) | default(omit) }}"
 
 
 # Example https://cloudinit.readthedocs.io/en/23.4.1/reference/datasources/vmware.html#walkthrough-of-guestinfo-keys-transport
@@ -210,6 +271,7 @@
 # >> metadata as JSON/YAML, userdata as no compression or base64 encoding
 # Error 400 com.vmware.vapi.std.errors.not_allowed_in_current_state : if the virtual machine vm is not in a powered off state.
 - name: Apply customization specification to the VM in Powered Off state
+  no_log: "{{ __sap_vm_provision_no_log }}"
   when: __sap_vm_provision_task_provision_host_single_info.value.power_state is defined and __sap_vm_provision_task_provision_host_single_info.value.power_state != "POWERED_ON"
   vmware.vmware_rest.vcenter_vm_guest_customization:
     vm: '{{ register_vmware_vm_cluster_host_id }}'
@@ -222,31 +284,54 @@
       # linux_config:
     interfaces: []
     global_DNS_settings: {}
+    # Hypervisor Control Plane credentials
+    vcenter_hostname: "{{ sap_vm_provision_vmware_vcenter_hostname | default(lookup('env', 'VMWARE_HOST')) | default(omit) }}"
+    vcenter_validate_certs: "{{ (sap_vm_provision_vmware_vcenter_validate_certs_bool | default(lookup('env', 'VMWARE_VALIDATE_CERTS'))) | bool | default(false) }}"
+    vcenter_username: "{{ sap_vm_provision_vmware_vcenter_user | default(lookup('env', 'VMWARE_USER')) | default(omit) }}"
+    vcenter_password: "{{ sap_vm_provision_vmware_vcenter_password | default(lookup('env', 'VMWARE_PASSWORD')) | default(omit) }}"
 
 
 - name: Ensure VM is Powered ON
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: register_vm_power_info
   vmware.vmware_rest.vcenter_vm_power:
     state: start
     vm: "{{ register_vmware_vm_cluster_host_id }}"
+    # Hypervisor Control Plane credentials
+    vcenter_hostname: "{{ sap_vm_provision_vmware_vcenter_hostname | default(lookup('env', 'VMWARE_HOST')) | default(omit) }}"
+    vcenter_validate_certs: "{{ (sap_vm_provision_vmware_vcenter_validate_certs_bool | default(lookup('env', 'VMWARE_VALIDATE_CERTS'))) | bool | default(false) }}"
+    vcenter_username: "{{ sap_vm_provision_vmware_vcenter_user | default(lookup('env', 'VMWARE_USER')) | default(omit) }}"
+    vcenter_password: "{{ sap_vm_provision_vmware_vcenter_password | default(lookup('env', 'VMWARE_PASSWORD')) | default(omit) }}"
   # Wait until VM is powered on
   until: (register_vm_power_info.value.error_type is defined and register_vm_power_info.value.error_type == "ALREADY_IN_DESIRED_STATE")
   retries: 15
   delay: 60
 
 - name: Show VM Information
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: register_vm_info
   vmware.vmware_rest.vcenter_vm_info:
     vm: '{{ register_vmware_vm_cluster_host_id }}'
+    # Hypervisor Control Plane credentials
+    vcenter_hostname: "{{ sap_vm_provision_vmware_vcenter_hostname | default(lookup('env', 'VMWARE_HOST')) | default(omit) }}"
+    vcenter_validate_certs: "{{ (sap_vm_provision_vmware_vcenter_validate_certs_bool | default(lookup('env', 'VMWARE_VALIDATE_CERTS'))) | bool | default(false) }}"
+    vcenter_username: "{{ sap_vm_provision_vmware_vcenter_user | default(lookup('env', 'VMWARE_USER')) | default(omit) }}"
+    vcenter_password: "{{ sap_vm_provision_vmware_vcenter_password | default(lookup('env', 'VMWARE_PASSWORD')) | default(omit) }}"
   # Wait until VM is powered on
   until: register_vm_info.value.power_state == "POWERED_ON"
   retries: 45
   delay: 20
 
 - name: Get guest networking information (wait until DHCP assigns IP Address for host)
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: register_vm_nic_info
   vmware.vmware_rest.vcenter_vm_guest_networking_interfaces_info:
     vm: '{{ register_vmware_vm_cluster_host_id }}'
+    # Hypervisor Control Plane credentials
+    vcenter_hostname: "{{ sap_vm_provision_vmware_vcenter_hostname | default(lookup('env', 'VMWARE_HOST')) | default(omit) }}"
+    vcenter_validate_certs: "{{ (sap_vm_provision_vmware_vcenter_validate_certs_bool | default(lookup('env', 'VMWARE_VALIDATE_CERTS'))) | bool | default(false) }}"
+    vcenter_username: "{{ sap_vm_provision_vmware_vcenter_user | default(lookup('env', 'VMWARE_USER')) | default(omit) }}"
+    vcenter_password: "{{ sap_vm_provision_vmware_vcenter_password | default(lookup('env', 'VMWARE_PASSWORD')) | default(omit) }}"
   # Wait until VM Tools is running
   until: (register_vm_nic_info.value.error_type | default("")) != "SERVICE_UNAVAILABLE" and (register_vm_nic_info.value[0].ip.ip_addresses | length) > 0
   retries: 45
@@ -355,6 +440,7 @@
 # The volume creation task requires the above task to define the parameter
 # which contains the calculated unique device names.
 - name: Provision Virtual Disk volumes and attach to VM
+  no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_provision_host_single_volumes
   vmware.vmware_rest.vcenter_vm_hardware_disk:
     vm: "{{ register_vmware_vm_cluster_host_id }}"
@@ -364,6 +450,11 @@
     new_vmdk:
       name: "{{ inventory_hostname }}_{{ vol_item.name }}" # VMDK filename
       capacity: "{{ vol_item.size | human_to_bytes(default_unit='G') }}"
+    # Hypervisor Control Plane credentials
+    vcenter_hostname: "{{ sap_vm_provision_vmware_vcenter_hostname | default(lookup('env', 'VMWARE_HOST')) | default(omit) }}"
+    vcenter_validate_certs: "{{ (sap_vm_provision_vmware_vcenter_validate_certs_bool | default(lookup('env', 'VMWARE_VALIDATE_CERTS'))) | bool | default(false) }}"
+    vcenter_username: "{{ sap_vm_provision_vmware_vcenter_user | default(lookup('env', 'VMWARE_USER')) | default(omit) }}"
+    vcenter_password: "{{ sap_vm_provision_vmware_vcenter_password | default(lookup('env', 'VMWARE_PASSWORD')) | default(omit) }}"
   loop: "{{ filesystem_volume_map }}"
   loop_control:
     loop_var: vol_item


### PR DESCRIPTION
sap_vm_provision: nolog changes for all platforms to address #16 

This PR includes Ansible Role internal variables renamed, remove use of `environment:` and replace with `nolog: true` for each Ansible Module calling Infrastructure Platform APIs by using a new rescue block that will output errors (that no_log will otherwise hide).