### PR TITLE
sap_vm_provision: Fixes for netcat, /etc/hosts, register_os

### DIFF
--- a/roles/sap_vm_provision/tasks/common/set_etc_hosts_ha.yml
+++ b/roles/sap_vm_provision/tasks/common/set_etc_hosts_ha.yml
@@ -84,9 +84,13 @@
       loop:
         - "{{ sap_vm_provision_dynamic_inventory_nw_ascs_ip }}\t{{ sap_vm_provision_dynamic_inventory_nw_ascs_hostname }}.{{ ansible_domain }}\t{{ sap_vm_provision_dynamic_inventory_nw_ascs_hostname }}"
         - "{{ sap_vm_provision_dynamic_inventory_nw_ers_ip }}\t{{ sap_vm_provision_dynamic_inventory_nw_ers_hostname }}.{{ ansible_domain }}\t{{ sap_vm_provision_dynamic_inventory_nw_ers_hostname }}"
-        - "{{ sap_vm_provision_dynamic_inventory_nw_pas_ip }}\t{{ sap_vm_provision_dynamic_inventory_nw_pas_hostname }}.{{ ansible_domain }}\t{{ sap_vm_provision_dynamic_inventory_nw_pas_hostname }}"
+#        - "{{ sap_vm_provision_dynamic_inventory_nw_pas_ip }}\t{{ sap_vm_provision_dynamic_inventory_nw_pas_hostname }}.{{ ansible_domain }}\t{{ sap_vm_provision_dynamic_inventory_nw_pas_hostname }}"
+        # Allows to build ASCS ERS cluster without PAS if PAS details are not provided
+        - "{{ sap_vm_provision_dynamic_inventory_nw_pas_ip | string + '\t' + sap_vm_provision_dynamic_inventory_nw_pas_hostname + '.' + ansible_domain + '\t' + sap_vm_provision_dynamic_inventory_nw_pas_hostname 
+          if sap_vm_provision_dynamic_inventory_nw_pas_hostname is defined and sap_vm_provision_dynamic_inventory_nw_pas_ip is defined else ''}}"
       when:
         - (groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0))
+        - item != ''
 
     - name: Update /etc/hosts file with Virtual IPs for SAP NetWeaver HA - ASCS / ERS
       ansible.builtin.lineinfile:

--- a/roles/sap_vm_provision/tasks/platform_ansible/aws_ec2_vs/execute_main.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/aws_ec2_vs/execute_main.yml
@@ -151,6 +151,13 @@
       ansible.builtin.include_tasks:
         file: common/set_ansible_vars_storage.yml
 
+    - name: Register Web Forward Proxy
+      ansible.builtin.include_tasks:
+        file: common/register_proxy.yml
+
+    - name: Register Package Repositories
+      ansible.builtin.include_tasks:
+        file: common/register_os.yml
 
 - name: Ansible Task block for provisioning of High Availability resources for AWS EC2 instances
   delegate_to: localhost

--- a/roles/sap_vm_temp_vip/tasks/set_temp_vip_lb_listener.yml
+++ b/roles/sap_vm_temp_vip/tasks/set_temp_vip_lb_listener.yml
@@ -3,7 +3,7 @@
 - name: Install netcat and lsof utils
   ansible.builtin.package:
     name:
-      - nc
+      - "{{ 'netcat' if ansible_os_family == 'Suse' else 'nc' }}"
       - lsof
     state: present
 


### PR DESCRIPTION
PR adds fixes:

- register_os task that was missing in AWS
- conditional switch for nc versus netcat package based on os_family
- /etc/hosts will not be updated for ASCS ERS cluster with PAS details if PAS details are not provided