### PR TITLE
sap_vm_provision: Azure compatibility update and fixes

### DIFF
--- a/roles/sap_vm_provision/PLATFORM_GUIDANCE.md
+++ b/roles/sap_vm_provision/PLATFORM_GUIDANCE.md
@@ -243,6 +243,51 @@ az role assignment create --assignee "$AZ_SERVICE_PRINCIPAL_ID" \
 az ad sp credential reset --name $AZ_CLIENT_ID
 ```
 
+It is recommended to create new Azure custom role with detailed actions to improve security.
+```json
+{
+    "properties": {
+        "roleName": "ansible-sap-automation",
+        "description": "Custom role for SAP LinuxLab ansible automation.",
+        "permissions": [
+            {
+                "actions": [
+                    "Microsoft.Authorization/roleAssignments/read",
+                    "Microsoft.Authorization/roleAssignments/write",
+                    "Microsoft.Authorization/roleDefinitions/read",
+                    "Microsoft.Authorization/roleDefinitions/write",
+                    "Microsoft.Compute/disks/read",
+                    "Microsoft.Compute/disks/write",
+                    "Microsoft.Compute/sshPublicKeys/read",
+                    "Microsoft.Compute/sshPublicKeys/write",
+                    "Microsoft.Compute/virtualMachines/instanceView/read",
+                    "Microsoft.Compute/virtualMachines/read",
+                    "Microsoft.Compute/virtualMachines/write",
+                    "Microsoft.Network/loadBalancers/backendAddressPools/join/action",
+                    "Microsoft.Network/loadBalancers/read",
+                    "Microsoft.Network/loadBalancers/write",
+                    "Microsoft.Network/networkInterfaces/join/action",
+                    "Microsoft.Network/networkInterfaces/read",
+                    "Microsoft.Network/networkInterfaces/write",
+                    "Microsoft.Network/networkSecurityGroups/read",
+                    "Microsoft.Network/privateDnsZones/A/read",
+                    "Microsoft.Network/privateDnsZones/A/write",
+                    "Microsoft.Network/privateDnsZones/read",
+                    "Microsoft.Network/privateDnsZones/virtualNetworkLinks/read",
+                    "Microsoft.Network/virtualNetworks/privateDnsZoneLinks/read",
+                    "Microsoft.Network/virtualNetworks/subnets/join/action",
+                    "Microsoft.Network/virtualNetworks/subnets/read",
+                    "Microsoft.Resources/subscriptions/resourceGroups/read",
+                ],
+                "notActions": [],
+                "dataActions": [],
+                "notDataActions": []
+            }
+        ]
+    }
+}
+```
+
 Note: MS Azure VMs provisioned will contain Hyper-V Hypervisor virtual interfaces using eth* on the OS, and when Accelerated Networking (AccelNet) is enabled for the MS Azure VM then the Mellanox SmartNIC/DPU SR-IOV Virtual Function (VF) may use enP* on the OS. For further information, see [MS Azure - How Accelerated Networking works](https://learn.microsoft.com/en-us/azure/virtual-network/accelerated-networking-how-it-works). During High Availability executions, failures may occur and may require additional variable 'sap_ha_pacemaker_cluster_vip_client_interface' to be defined.
 
 </details>

--- a/roles/sap_vm_provision/tasks/platform_ansible/aws_ec2_vs/execute_provision.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/aws_ec2_vs/execute_provision.yml
@@ -171,8 +171,8 @@
       ansible.builtin.replace:
         path: /root/.ssh/authorized_keys
         backup: true
-        regexp: '(^.*ssh-rsa)'
-        replace: 'ssh-rsa'
+        regexp: '(^.*ssh-)'  # Added support for ssh-ed25519
+        replace: 'ssh-'
 
     - name: Permit root login
       register: __sap_vm_provision_task_os_sshd_config

--- a/roles/sap_vm_provision/tasks/platform_ansible/msazure_vm/execute_main.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/msazure_vm/execute_main.yml
@@ -178,6 +178,10 @@
       ansible.builtin.include_tasks:
         file: common/set_ansible_vars_storage.yml
 
+    - name: Register Package Repositories for OS Images with Bring-Your-Own-Subscription (BYOS)
+      ansible.builtin.include_tasks:
+        file: common/register_os.yml
+
 
 - name: Ansible Task block to execute on target inventory hosts - High Availability
   delegate_to: "{{ inventory_hostname }}"

--- a/roles/sap_vm_provision/tasks/platform_ansible/msazure_vm/execute_provision.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/msazure_vm/execute_provision.yml
@@ -134,6 +134,9 @@
   vars:
     ansible_ssh_private_key_file: "{{ delegate_sap_vm_provision_ssh_host_private_key_file_path }}"
     ansible_ssh_common_args: -o ConnectTimeout=180 -o ControlMaster=auto -o ControlPersist=3600s -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ForwardX11=no -o ProxyCommand='ssh -W %h:%p {{ delegate_sap_vm_provision_bastion_user }}@{{ delegate_sap_vm_provision_bastion_public_ip }} -p {{ delegate_sap_vm_provision_bastion_ssh_port }} -i {{ delegate_sap_vm_provision_ssh_bastion_private_key_file_path }} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
+  # Ensure that VM has enough time to start before connecting
+  retries: 60
+  delay: 10
 
 #- name: Output disks
 #  ansible.builtin.debug:
@@ -270,8 +273,8 @@
       ansible.builtin.replace:
         path: /root/.ssh/authorized_keys
         backup: true
-        regexp: '(^.*ssh-rsa)'
-        replace: 'ssh-rsa'
+        regexp: '(^.*ssh-)'  # Added support for ssh-ed25519
+        replace: 'ssh-'
 
     - name: Permit root login
       register: __sap_vm_provision_task_os_sshd_config

--- a/roles/sap_vm_provision/tasks/platform_ansible/msazure_vm/execute_setup_ha.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/msazure_vm/execute_setup_ha.yml
@@ -258,7 +258,7 @@
   ignore_errors: true
 
   # Second attempt to create Role with last segment of Subscription ID
-- name: MS Azure IAM Role - Definition Subcription specific
+- name: MS Azure IAM Role - Definition Subscription specific
   when:
     - __sap_vm_provision_task_msazure_iam_role_fencing is defined
     - __sap_vm_provision_task_msazure_iam_role_fencing.failed

--- a/roles/sap_vm_provision/tasks/platform_ansible/msazure_vm/execute_setup_ha.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/msazure_vm/execute_setup_ha.yml
@@ -251,6 +251,39 @@
     tenant: "{{ sap_vm_provision_msazure_tenant_id }}"
     client_id: "{{ sap_vm_provision_msazure_app_client_id }}"
     secret: "{{ sap_vm_provision_msazure_app_client_secret }}"
+    state: present
+  # Custom Role can exist within different Subscriptions under same tenant
+  # Described in: https://github.com/Azure/azure-powershell/issues/4365#issuecomment-351171763
+  # Error is ignored and validated in next step
+  ignore_errors: true
+
+  # Second attempt to create Role with last segment of Subscription ID
+- name: MS Azure IAM Role - Definition Subcription specific
+  when:
+    - __sap_vm_provision_task_msazure_iam_role_fencing is defined
+    - __sap_vm_provision_task_msazure_iam_role_fencing.failed
+  no_log: "{{ __sap_vm_provision_no_log }}"
+  register: __sap_vm_provision_task_msazure_iam_role_fencing_sub
+  azure.azcollection.azure_rm_roledefinition:
+    name: "Linux Fence Agent Role {{ sap_vm_provision_msazure_subscription_id.split('-')[-1] }}"
+    description: "Allows to power-off and start virtual machines {{ sap_vm_provision_msazure_subscription_id.split('-')[-1] }}"
+    assignable_scopes:
+      - "/subscriptions/{{ sap_vm_provision_msazure_subscription_id }}"
+    permissions:
+      - actions:
+          - "Microsoft.Compute/*/read"
+          - "Microsoft.Compute/virtualMachines/powerOff/action"
+          - "Microsoft.Compute/virtualMachines/start/action"
+      # - data_actions:
+      # - not_actions:
+      # - not_data_actions:
+    # Azure credentials
+    subscription_id: "{{ sap_vm_provision_msazure_subscription_id }}"
+    tenant: "{{ sap_vm_provision_msazure_tenant_id }}"
+    client_id: "{{ sap_vm_provision_msazure_app_client_id }}"
+    secret: "{{ sap_vm_provision_msazure_app_client_secret }}"
+    state: present
+
 
 - name: MS Azure - GenericRestClient call to Virtual Machine API to identify Managed Service Identity (MSI)
   no_log: "{{ __sap_vm_provision_no_log }}"
@@ -275,7 +308,8 @@
   azure.azcollection.azure_rm_roleassignment:
     #auth_source: msi
     role_definition_id:
-      "{{ __sap_vm_provision_task_msazure_iam_role_fencing.id }}"
+      "{{ __sap_vm_provision_task_msazure_iam_role_fencing.id if __sap_vm_provision_task_msazure_iam_role_fencing.id is defined
+        else __sap_vm_provision_task_msazure_iam_role_fencing_sub.id }}"
     scope: "/subscriptions/{{ sap_vm_provision_msazure_subscription_id }}"
     assignee_object_id: "{{ host_node.response[0].identity.principalId | default(none) }}"
     # Azure credentials
@@ -439,7 +473,7 @@
         __probe_element:
           name: "{{ sap_vm_provision_ha_load_balancer_name_nwas + '-probe-hc-vip' + (sapinstance_index_nr | string) }}"
           protocol: Tcp
-          port: "{{ ('5555' + (sapinstance_index_nr + 1)) | string | int }}" # "{{ ('626' + sapinstance_item | string) | int }}"
+          port: "{{ ('5555' + (sapinstance_index_nr + 1) | string) | int }}" # "{{ ('626' + sapinstance_item | string) | int }}"
           interval: 5
           fail_count: 2
       when:

--- a/roles/sap_vm_provision/tasks/platform_ansible/msazure_vm/post_deployment_execute.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/msazure_vm/post_deployment_execute.yml
@@ -123,7 +123,7 @@
         lb_probes1: "{{ lb_probes1 | default([]) + [__probe_element] }}"
       vars:
         __probe_element:
-          name: "{{ sap_vm_provision_ha_load_balancer_name_hana + '-probe-hc-vip' + (sapinstance_index_nr | string) }}"
+          name: "{{ sap_vm_provision_ha_load_balancer_name_hana + '-probe-hc-vip' + (healthcheck_index_nr | string) }}"
           protocol: Tcp
           port: "{{ healthcheck_item }}"
           interval: 5
@@ -155,7 +155,7 @@
         lb_probes2: "{{ lb_probes2 | default([]) + [__probe_element] }}"
       vars:
         __probe_element:
-          name: "{{ sap_vm_provision_ha_load_balancer_name_nwas + '-probe-hc-vip' + (sapinstance_index_nr | string) }}"
+          name: "{{ sap_vm_provision_ha_load_balancer_name_nwas + '-probe-hc-vip' + (healthcheck_index_nr | string) }}"
           protocol: Tcp
           port: "{{ healthcheck_item }}"
           interval: 5


### PR DESCRIPTION
Scope:
1. Updated hardcoded `ssh-rsa` to `ssh-` to allow ssh-ed25519 support
2. Added second attempt for IAM Role creation to cover for bug https://github.com/Azure/azure-powershell/issues/4365#issuecomment-351171763 
3. Added retry loop to tasks that are fired too early, like gathering facts on newly built machine.
4. Fixed typos in AZ Load balancer loop vars
5. Updated Azure governance readme with detailed breakdown of Authentication actions, to offer more secure setup compared to privileged Contributor.
6. Added os_register task to Azure for BYOS registration.
7. Fixed loadbalancer STR<>INT  conflicting code

@sean-freeman I am creating this PR now so you are aware of changes, but I will continue with more testing on Azure in coming weeks.