### PR TITLE
sap_vm_provision: AWS Fencing improvement, Scaleout fix, IAM role changes

### DIFF
--- a/roles/sap_vm_provision/defaults/main.yml
+++ b/roles/sap_vm_provision/defaults/main.yml
@@ -141,6 +141,10 @@ sap_vm_provision_aws_vpc_sg_names: "" # comma-separated, if ansible_to_terraform
 sap_vm_provision_aws_key_pair_name_ssh_host_public_key: ""
 sap_vm_provision_aws_placement_resource_name: "sap-placement-group-spread"
 sap_vm_provision_aws_placement_strategy_spread: false
+# Specify role/profile names to allow multiple clusters
+# Example for HANA HA: "HA-Role-Pacemaker-{{ sap_system_hana_db_sid }}"
+sap_vm_provision_aws_ha_iam_role: "HA-Role-Pacemaker"
+sap_vm_provision_aws_ha_iam_instance_profile: "HA-Instance-Profile-Pacemaker-Cluster"
 
 # Google Cloud
 sap_vm_provision_gcp_credentials_json: ""
@@ -186,7 +190,8 @@ sap_vm_provision_msazure_vnet_subnet_name: ""
 sap_vm_provision_msazure_key_pair_name_ssh_host_public_key: ""
 sap_vm_provision_msazure_placement_resource_name: "sap-availability-set-spread"
 sap_vm_provision_msazure_placement_strategy_spread: false
-
+# Specify role name for fence agent
+sap_vm_provision_msazure_ha_iam_role: "Linux Fence Agent Role"
 
 ####
 # Infrastructure Platform - Cloud Hyperscaler - High Availability resources

--- a/roles/sap_vm_provision/tasks/common/set_etc_hosts_scaleout.yml
+++ b/roles/sap_vm_provision/tasks/common/set_etc_hosts_scaleout.yml
@@ -31,7 +31,7 @@
         line: "{{ item }}"
         state: present
       loop:
-        - "# SAP HANA scale-out workers\n{% for host in (groups['hana_primary'] | reject('search', '0') | list) %}{% if (host != inventory_hostname_short) %}{{ hostvars[host]['ansible_host'] }}\t{{ hostvars[host]['ansible_fqdn'] }}\t{{ hostvars[host]['inventory_hostname_short'] }}\n{% endif %}{% endfor %}"
+        - "# SAP HANA scale-out workers\n{% for host in (groups['hana_primary'] | reject('regex', '0$') | list) %}{% if (host != inventory_hostname_short) %}{{ hostvars[host]['ansible_host'] }}\t{{ hostvars[host]['ansible_fqdn'] }}\t{{ hostvars[host]['inventory_hostname_short'] }}\n{% endif %}{% endfor %}"
       loop_control:
         label: "{{ inventory_hostname_short }}"
       when:
@@ -43,7 +43,7 @@
         line: "{{ item }}"
         state: present
       loop:
-        - "# SAP HANA scale-out workers\n{% for host in (groups['hana_primary'] | reject('search', '0') | list)[:-1] %}{% if (host != inventory_hostname_short) %}{{ hostvars[host]['ansible_host'] }}\t{{ hostvars[host]['ansible_fqdn'] }}\t{{ hostvars[host]['inventory_hostname_short'] }}\n{% endif %}{% endfor %}"
+        - "# SAP HANA scale-out workers\n{% for host in (groups['hana_primary'] | reject('regex', '0$') | list)[:-1] %}{% if (host != inventory_hostname_short) %}{{ hostvars[host]['ansible_host'] }}\t{{ hostvars[host]['ansible_fqdn'] }}\t{{ hostvars[host]['inventory_hostname_short'] }}\n{% endif %}{% endfor %}"
       loop_control:
         label: "{{ inventory_hostname_short }}"
       when: sap_vm_provision_calculate_sap_hana_scaleout_standby > 0

--- a/roles/sap_vm_provision/tasks/platform_ansible/aws_ec2_vs/execute_setup_ha.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/aws_ec2_vs/execute_setup_ha.yml
@@ -254,11 +254,18 @@
 #     - groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
 
 
-- name: AWS IAM Role - HA-Role-Pacemaker
+- name: AWS IAM Role - Prepare IAM Role name
+  ansible.builtin.set_fact:
+    __sap_vm_provision_aws_ha_iam_role:
+      "{{ sap_vm_provision_aws_ha_iam_role
+       if sap_vm_provision_aws_ha_iam_role is defined and sap_vm_provision_aws_ha_iam_role | length > 0
+       else 'HA-Role-Pacemaker' }}"
+
+- name: AWS IAM Role - {{ __sap_vm_provision_aws_ha_iam_role }}
   register: __sap_vm_provision_task_aws_iam_role_ha_pacemaker
   no_log: "{{ __sap_vm_provision_no_log }}"
   amazon.aws.iam_role:
-    name: "HA-Role-Pacemaker"
+    name: "{{ __sap_vm_provision_aws_ha_iam_role }}"
     assume_role_policy_document: |
       {
           "Version": "2012-10-17",
@@ -283,7 +290,7 @@
   amazon.aws.iam_policy:
     state: present
     iam_type: role
-    iam_name: "HA-Role-Pacemaker"
+    iam_name: "{{ __sap_vm_provision_aws_ha_iam_role }}"
     policy_name: "HA-Policy-DataProvider"
     policy_json: |
       {
@@ -319,7 +326,7 @@
   amazon.aws.iam_policy:
     state: present
     iam_type: role
-    iam_name: "HA-Role-Pacemaker"
+    iam_name: "{{ __sap_vm_provision_aws_ha_iam_role }}"
     policy_name: "HA-Policy-OverlayVirtualIPAgent"
     policy_json: |
       {
@@ -352,7 +359,7 @@
   amazon.aws.iam_policy:
     state: present
     iam_type: role
-    iam_name: "HA-Role-Pacemaker"
+    iam_name: "{{ __sap_vm_provision_aws_ha_iam_role }}"
     policy_name: "HA-Policy-STONITH-SAPHANA"
     policy_json: |
       {
@@ -374,11 +381,14 @@
                   "Action": [
                       "ec2:ModifyInstanceAttribute",
                       "ec2:StartInstances",
-                      "ec2:StopInstances"
+                      "ec2:StopInstances",
+                      "ec2:RebootInstances"
                   ],
                   "Resource": [
-                      "arn:aws:ec2:{{ sap_vm_provision_aws_region }}:{{ __sap_vm_provision_task_aws_account_info.account }}:instance/{{ hostvars[groups['hana_primary'][0]].ansible_host }}",
-                      "arn:aws:ec2:{{ sap_vm_provision_aws_region }}:{{ __sap_vm_provision_task_aws_account_info.account }}:instance/{{ hostvars[groups['hana_secondary'][0]].ansible_host }}"
+                      "arn:aws:ec2:{{ sap_vm_provision_aws_region }}:{{ __sap_vm_provision_task_aws_account_info.account }}:instance/{{
+                       hostvars[groups['hana_primary'][0]].__sap_vm_provision_task_provision_host_single_info.instances[0].instance_id }}",
+                      "arn:aws:ec2:{{ sap_vm_provision_aws_region }}:{{ __sap_vm_provision_task_aws_account_info.account }}:instance/{{
+                       hostvars[groups['hana_secondary'][0]].__sap_vm_provision_task_provision_host_single_info.instances[0].instance_id }}"
                   ]
               }
           ]
@@ -394,7 +404,7 @@
   amazon.aws.iam_policy:
     state: present
     iam_type: role
-    iam_name: "HA-Role-Pacemaker"
+    iam_name: "{{ __sap_vm_provision_aws_ha_iam_role }}"
     policy_name: "HA-Policy-STONITH-SAPANYDB"
     policy_json: |
       {
@@ -416,11 +426,14 @@
                   "Action": [
                       "ec2:ModifyInstanceAttribute",
                       "ec2:StartInstances",
-                      "ec2:StopInstances"
+                      "ec2:StopInstances",
+                      "ec2:RebootInstances"
                   ],
                   "Resource": [
-                      "arn:aws:ec2:{{ sap_vm_provision_aws_region }}:{{ __sap_vm_provision_task_aws_account_info.account }}:instance/{{ hostvars[groups['anydb_primary'][0]].ansible_host }}",
-                      "arn:aws:ec2:{{ sap_vm_provision_aws_region }}:{{ __sap_vm_provision_task_aws_account_info.account }}:instance/{{ hostvars[groups['anydb_secondary'][0]].ansible_host }}"
+                      "arn:aws:ec2:{{ sap_vm_provision_aws_region }}:{{ __sap_vm_provision_task_aws_account_info.account }}:instance/{{
+                       hostvars[groups['anydb_primary'][0]].__sap_vm_provision_task_provision_host_single_info.instances[0].instance_id }}",
+                      "arn:aws:ec2:{{ sap_vm_provision_aws_region }}:{{ __sap_vm_provision_task_aws_account_info.account }}:instance/{{
+                       hostvars[groups['anydb_secondary'][0]].__sap_vm_provision_task_provision_host_single_info.instances[0].instance_id }}"
                   ]
               }
           ]
@@ -436,7 +449,7 @@
   amazon.aws.iam_policy:
     state: present
     iam_type: role
-    iam_name: "HA-Role-Pacemaker"
+    iam_name: "{{ __sap_vm_provision_aws_ha_iam_role }}"
     policy_name: "HA-Policy-STONITH-SAPNWAS"
     policy_json: |
       {
@@ -461,8 +474,10 @@
                       "ec2:StopInstances"
                   ],
                   "Resource": [
-                      "arn:aws:ec2:{{ sap_vm_provision_aws_region }}:{{ __sap_vm_provision_task_aws_account_info.account }}:instance/{{ hostvars[groups['nwas_ascs'][0]].ansible_host }}",
-                      "arn:aws:ec2:{{ sap_vm_provision_aws_region }}:{{ __sap_vm_provision_task_aws_account_info.account }}:instance/{{ hostvars[groups['nwas_ers'][0]].ansible_host }}"
+                      "arn:aws:ec2:{{ sap_vm_provision_aws_region }}:{{ __sap_vm_provision_task_aws_account_info.account }}:instance/{{
+                       hostvars[groups['nwas_ascs'][0]].__sap_vm_provision_task_provision_host_single_info.instances[0].instance_id }}",
+                      "arn:aws:ec2:{{ sap_vm_provision_aws_region }}:{{ __sap_vm_provision_task_aws_account_info.account }}:instance/{{
+                       hostvars[groups['nwas_ers'][0]].__sap_vm_provision_task_provision_host_single_info.instances[0].instance_id }}"
                   ]
               }
           ]
@@ -470,6 +485,14 @@
     access_key: "{{ sap_vm_provision_aws_access_key }}"
     secret_key: "{{ sap_vm_provision_aws_secret_access_key }}"
   when: groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
+
+
+- name: AWS IAM Role - Prepare IAM Instance Profile name
+  ansible.builtin.set_fact:
+    __sap_vm_provision_aws_ha_iam_instance_profile:
+      "{{ sap_vm_provision_aws_ha_iam_instance_profile
+       if sap_vm_provision_aws_ha_iam_instance_profile is defined and sap_vm_provision_aws_ha_iam_instance_profile | length > 0
+       else 'HA-Instance-Profile-Pacemaker-Cluster' }}"
 
 # Equivalent to
 # aws iam create-instance-profile --instance-profile-name "HA-Instance-Profile-Pacemaker-Cluster"
@@ -479,8 +502,8 @@
   no_log: "{{ __sap_vm_provision_no_log }}"
   amazon.aws.iam_instance_profile:
     state: present
-    name: "HA-Instance-Profile-Pacemaker-Cluster"
-    role: "HA-Role-Pacemaker"
+    name: "{{ __sap_vm_provision_aws_ha_iam_instance_profile }}"
+    role: "{{ __sap_vm_provision_aws_ha_iam_role }}"
     path: "/"
     access_key: "{{ sap_vm_provision_aws_access_key }}"
     secret_key: "{{ sap_vm_provision_aws_secret_access_key }}"
@@ -491,7 +514,7 @@
   no_log: "{{ __sap_vm_provision_no_log }}"
   amazon.aws.ec2_instance:
     instance_ids: "{{ hostvars[host_node].ansible_board_asset_tag }}"
-    iam_instance_profile: "HA-Instance-Profile-Pacemaker-Cluster"
+    iam_instance_profile: "{{ __sap_vm_provision_aws_ha_iam_instance_profile }}"
     access_key: "{{ sap_vm_provision_aws_access_key }}"
     secret_key: "{{ sap_vm_provision_aws_secret_access_key }}"
   loop: "{{ [ [ groups['hana_primary'] | default([]) ] , [ groups['hana_secondary'] | default([]) ] ] | flatten | select() }}"
@@ -506,7 +529,7 @@
   no_log: "{{ __sap_vm_provision_no_log }}"
   amazon.aws.ec2_instance:
     instance_ids: "{{ hostvars[host_node].ansible_board_asset_tag }}"
-    iam_instance_profile: "HA-Instance-Profile-Pacemaker-Cluster"
+    iam_instance_profile: "{{ __sap_vm_provision_aws_ha_iam_instance_profile }}"
     access_key: "{{ sap_vm_provision_aws_access_key }}"
     secret_key: "{{ sap_vm_provision_aws_secret_access_key }}"
   loop: "{{ [ [ groups['anydb_primary'] | default([]) ] , [ groups['anydb_secondary'] | default([]) ] ] | flatten | select() }}"
@@ -521,7 +544,7 @@
   no_log: "{{ __sap_vm_provision_no_log }}"
   amazon.aws.ec2_instance:
     instance_ids: "{{ hostvars[host_node].ansible_board_asset_tag }}"
-    iam_instance_profile: "HA-Instance-Profile-Pacemaker-Cluster"
+    iam_instance_profile: "{{ __sap_vm_provision_aws_ha_iam_instance_profile }}"
     access_key: "{{ sap_vm_provision_aws_access_key }}"
     secret_key: "{{ sap_vm_provision_aws_secret_access_key }}"
   loop: "{{ [ [ groups['nwas_ascs'] | default([]) ] , [ groups['nwas_ers'] | default([]) ] , [ groups['nwas_pas'] | default([]) ] , [ groups['nwas_aas'] | default([]) ] ] | flatten | select() }}"

--- a/roles/sap_vm_provision/tasks/platform_ansible/aws_ec2_vs/execute_setup_ha.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/aws_ec2_vs/execute_setup_ha.yml
@@ -254,12 +254,20 @@
 #     - groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
 
 
+# Setup custom IAM Role name using sap_vm_provision_aws_ha_iam_role
 - name: AWS IAM Role - Prepare IAM Role name
   ansible.builtin.set_fact:
     __sap_vm_provision_aws_ha_iam_role:
       "{{ sap_vm_provision_aws_ha_iam_role
        if sap_vm_provision_aws_ha_iam_role is defined and sap_vm_provision_aws_ha_iam_role | length > 0
        else 'HA-Role-Pacemaker' }}"
+
+# Following IAM Roles, Policies and Instance Profiles are created based on:
+# https://documentation.suse.com/sbp/sap-15/html/SLES4SAP-hana-sr-guide-perfopt-15-aws/index.html#id-aws-roles-and-policies
+# https://docs.aws.amazon.com/sap/latest/sap-netweaver/sles-netweaver-ha-settings.html#stonith
+# https://access.redhat.com/articles/4175371#create-policies
+# https://docs.aws.amazon.com/sap/latest/sap-netweaver/rhel-netweaver-ha-settings.html#stonith
+# https://docs.aws.amazon.com/sap/latest/sap-hana/sap-hana-on-aws-cluster-configuration-prerequisites.html#sap-hana-on-aws-create-the-stonith-policy
 
 - name: AWS IAM Role - {{ __sap_vm_provision_aws_ha_iam_role }}
   register: __sap_vm_provision_task_aws_iam_role_ha_pacemaker

--- a/roles/sap_vm_provision/tasks/platform_ansible/msazure_vm/execute_setup_ha.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/msazure_vm/execute_setup_ha.yml
@@ -272,11 +272,18 @@
 #     - groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
 
 
+- name: MS Azure IAM Role - Prepare IAM Role name
+  ansible.builtin.set_fact:
+    __sap_vm_provision_msazure_ha_iam_role:
+      "{{ sap_vm_provision_msazure_ha_iam_role
+       if sap_vm_provision_msazure_ha_iam_role is defined and sap_vm_provision_msazure_ha_iam_role | length > 0
+       else 'Linux Fence Agent Role' }}"
+
 - name: MS Azure IAM Role - Definition
   no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_msazure_iam_role_fencing
   azure.azcollection.azure_rm_roledefinition:
-    name: "Linux Fence Agent Role"
+    name: "{{ __sap_vm_provision_msazure_ha_iam_role }}"
     description: "Allows to power-off and start virtual machines"
     #scope: /subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/myresourceGroup
     assignable_scopes:
@@ -308,7 +315,7 @@
   no_log: "{{ __sap_vm_provision_no_log }}"
   register: __sap_vm_provision_task_msazure_iam_role_fencing_sub
   azure.azcollection.azure_rm_roledefinition:
-    name: "Linux Fence Agent Role {{ sap_vm_provision_msazure_subscription_id.split('-')[-1] }}"
+    name: "{{ __sap_vm_provision_msazure_ha_iam_role }} {{ sap_vm_provision_msazure_subscription_id.split('-')[-1] }}"
     description: "Allows to power-off and start virtual machines {{ sap_vm_provision_msazure_subscription_id.split('-')[-1] }}"
     assignable_scopes:
       - "/subscriptions/{{ sap_vm_provision_msazure_subscription_id }}"


### PR DESCRIPTION
Description:

1. Introduce new variables for IAM roles to allow parallel clusters in AWS. Same applied for AZ where role was also hardcoded. Solves https://github.com/sap-linuxlab/community.sap_infrastructure/issues/53
```yaml
# Specify role/profile names to allow multiple clusters
# Example for HANA HA: "HA-Role-Pacemaker-{{ sap_system_hana_db_sid }}"
sap_vm_provision_aws_ha_iam_role: "HA-Role-Pacemaker"
sap_vm_provision_aws_ha_iam_instance_profile: "HA-Instance-Profile-Pacemaker-Cluster"

# Specify role name for fence agent
sap_vm_provision_msazure_ha_iam_role: "Linux Fence Agent Role"
```
2. Update missing IAM permission for fence reboot

3. Update incorrect resource limits on AWS IAM policies from IP to Instance ID. Solves https://github.com/sap-linuxlab/community.sap_infrastructure/issues/53


4. Fix hardcoded hostnames search to regex
  - Removed hardcoded reject for all hostnames containing '0'
  - Replaced with regex search checking for "ending with 0" instead.

```yaml
# Before
reject('search', '0')

# After
reject('regex', '0$')
```

NOTE: Same change has to be done for scaleout AP4S scenarios as they suffer from same issue:
https://github.com/sap-linuxlab/ansible.playbooks_for_sap/blob/2410843ebd34c9efbb6e9d69dded9c7574c83b22/deploy_scenarios/sap_bw4hana_standard_scaleout/ansible_playbook.yml#L434

https://github.com/sap-linuxlab/ansible.playbooks_for_sap/blob/2410843ebd34c9efbb6e9d69dded9c7574c83b22/deploy_scenarios/sap_hana_scaleout/ansible_playbook.yml#L344