### PR TITLE
sap_vm_provision: GCP improvements

### DIFF
--- a/roles/sap_vm_provision/PLATFORM_GUIDANCE.md
+++ b/roles/sap_vm_provision/PLATFORM_GUIDANCE.md
@@ -34,11 +34,10 @@ See below for the drop-down list of required environment resources on an Infrast
     - VPC Subnetwork
 - Compute Firewall
 - Compute Router
-    - SNAT
+    - Cloud NAT (SNAT)
 - DNS Managed Zone (Private DNS)
 - Filestore (NFS) or NFS server
 - Bastion host (GCP CE VM)
-- Cloud NAT
 
 </details>
 
@@ -242,6 +241,7 @@ compute.instances.get
 compute.instances.list
 compute.instances.setMetadata
 compute.instances.setServiceAccount
+compute.instances.update
 compute.instances.use
 compute.networks.list
 compute.regionBackendServices.create

--- a/roles/sap_vm_provision/PLATFORM_GUIDANCE.md
+++ b/roles/sap_vm_provision/PLATFORM_GUIDANCE.md
@@ -36,8 +36,9 @@ See below for the drop-down list of required environment resources on an Infrast
 - Compute Router
     - SNAT
 - DNS Managed Zone (Private DNS)
-- Filestore (NFS)
+- Filestore (NFS) or NFS server
 - Bastion host (GCP CE VM)
+- Cloud NAT
 
 </details>
 
@@ -212,6 +213,57 @@ The Google Cloud User credentials (Client ID and Client Secret) JSON file with a
 - Enable the Cloud Filestore API, using https://console.cloud.google.com/apis/library/file.googleapis.com
 - Enable the Service Networking API (Private Services Connection to Filestore), using https://console.cloud.google.com/apis/library/servicenetworking.googleapis.com
 
+It is recommended to create new custom IAM role with detailed actions to improve security.
+- Following permissions are minimum requirement to provision SAP HA system.
+```shell
+compute.addresses.createInternal
+compute.addresses.deleteInternal
+compute.addresses.get
+compute.addresses.useInternal
+compute.disks.create
+compute.disks.get
+compute.disks.use
+compute.forwardingRules.create
+compute.forwardingRules.get
+compute.forwardingRules.update
+compute.healthChecks.create
+compute.healthChecks.get
+compute.healthChecks.update
+compute.healthChecks.useReadOnly
+compute.images.get
+compute.images.list
+compute.instanceGroups.create
+compute.instanceGroups.get
+compute.instanceGroups.update
+compute.instanceGroups.use
+compute.instances.attachDisk
+compute.instances.create
+compute.instances.get
+compute.instances.list
+compute.instances.setMetadata
+compute.instances.setServiceAccount
+compute.instances.use
+compute.networks.list
+compute.regionBackendServices.create
+compute.regionBackendServices.get
+compute.regionBackendServices.list
+compute.regionBackendServices.use
+compute.subnetworks.list
+compute.subnetworks.use
+compute.zoneOperations.get
+dns.changes.create
+dns.changes.get
+dns.changes.list
+dns.managedZones.create
+dns.managedZones.get
+dns.managedZones.list
+dns.managedZones.update
+dns.resourceRecordSets.create
+dns.resourceRecordSets.get
+dns.resourceRecordSets.list
+dns.resourceRecordSets.update
+```
+
 </details>
 
 <details>
@@ -338,6 +390,21 @@ The recommended [IBM PowerVC Security Role](https://www.ibm.com/docs/en/powervc/
 ## Recommended Infrastructure Platform configuration
 
 See below for the drop-down list of recommended configurations for each Infrastructure Platform.
+
+<details>
+<summary><b>Google Cloud (GCP):</b></summary>
+
+Using Cloud NAT to allow outbound communication can result in registration issues on SLES images.
+Please follow troubleshooting guide at [Troubleshooting SLES pay-as-you-go registration](https://cloud.google.com/compute/docs/troubleshooting/troubleshooting-suse-registration)
+
+These issues were detected when using SLES PAYG (Pay As You Go) images
+Issues were resolved by following [Troubleshooting SLES pay-as-you-go registration - Registration failed](https://cloud.google.com/compute/docs/troubleshooting/troubleshooting-suse-registration#registration_failed)
+```
+Cloud NAT parameter "minimum ports per VM instance" has to be increased to higher than 160 (Recommended higher).
+```
+
+
+</details>
 
 <details>
 <summary><b>VMware vCenter:</b></summary>

--- a/roles/sap_vm_provision/tasks/platform_ansible/gcp_ce_vm/execute_main.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/gcp_ce_vm/execute_main.yml
@@ -44,6 +44,33 @@
         auth_kind: "serviceaccount"
         service_account_file: "{{ sap_vm_provision_gcp_credentials_json }}"
 
+    - name: Gather GCP Private DNS information
+      no_log: "{{ __sap_vm_provision_no_log }}"
+      register: __sap_vm_provision_task_gcp_pdns_info
+      google.cloud.gcp_dns_managed_zone_info:
+        project: "{{ sap_vm_provision_gcp_project }}"
+        dns_name: "{{ sap_vm_provision_dns_root_domain }}."
+        auth_kind: "serviceaccount"
+        service_account_file: "{{ sap_vm_provision_gcp_credentials_json }}"
+
+    # There is no reason to proceed if resources were not found.
+    - name: "Check if resources were found (OS Image, VPC, VPC Subnet, DNS)"
+      # Ensure that fail message is shown in rescue block
+      register: __sap_vm_provision_task_gcp_resources_found
+      ansible.builtin.fail:
+        msg: |
+          Variable {{ item[0] }} has no resources.
+          Ensure that provided {{ item[1] }} exists.
+      loop_control:
+        label: "{{ item[1] }}"
+      loop:
+        - ["{{ __sap_vm_provision_task_gcp_os_image_info }}", "OS Image"]
+        - ["{{ __sap_vm_provision_task_gcp_vpc_info }}", "VPC"]
+        - ["{{ __sap_vm_provision_task_gcp_vpc_subnet_info }}", "VPC Subnet"]
+        - ["{{ __sap_vm_provision_task_gcp_pdns_info }}", "DNS"]
+      when: item[0].resources is not defined or item[0].resources | length == 0
+
+
     # - name: Create Placement Policies when High Availability
     #   no_log: "{{ __sap_vm_provision_no_log }}"
     #   register: __sap_vm_provision_task_gcp_availability_policy
@@ -112,25 +139,6 @@
         auth_kind: "serviceaccount"
         service_account_file: "{{ sap_vm_provision_gcp_credentials_json }}"
 
-    - name: Gather GCP VPC Subnet information
-      no_log: "{{ __sap_vm_provision_no_log }}"
-      register: __sap_vm_provision_task_gcp_vpc_subnet_info
-      google.cloud.gcp_compute_subnetwork_info:
-        project: "{{ sap_vm_provision_gcp_project }}"
-        region: "{{ sap_vm_provision_gcp_region }}"
-        filters:
-          - name = {{ sap_vm_provision_gcp_vpc_subnet_name }}
-        auth_kind: "serviceaccount"
-        service_account_file: "{{ sap_vm_provision_gcp_credentials_json }}"
-
-    - name: Gather GCP Private DNS information
-      no_log: "{{ __sap_vm_provision_no_log }}"
-      register: __sap_vm_provision_task_gcp_pdns_info
-      google.cloud.gcp_dns_managed_zone_info:
-        project: "{{ sap_vm_provision_gcp_project }}"
-        dns_name: "{{ sap_vm_provision_dns_root_domain }}."
-        auth_kind: "serviceaccount"
-        service_account_file: "{{ sap_vm_provision_gcp_credentials_json }}"
 
     # - name: Gather information about GCP Router and table for the VPC Subnet
     #   no_log: "{{ __sap_vm_provision_no_log }}"
@@ -188,10 +196,10 @@
         - __sap_vm_provision_task_provision_host_single
         - __sap_vm_provision_task_provision_host_single_info
         - __sap_vm_provision_task_provision_host_all_add
-        - __sap_vm_provision_task_gcp_vpc_subnet_info
         - __sap_vm_provision_task_gcp_pdns_info
         - __sap_vm_provision_task_gcp_router_info
         - __sap_vm_provision_task_gcp_pdns_records
+        - __sap_vm_provision_task_gcp_resources_found
       loop_control:
         loop_var: loop_item
         index_var: loop_item_index

--- a/roles/sap_vm_provision/tasks/platform_ansible/gcp_ce_vm/execute_provision.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/gcp_ce_vm/execute_provision.yml
@@ -172,6 +172,8 @@
     ansible_ssh_common_args: -o ConnectTimeout=180 -o ControlMaster=auto -o ControlPersist=3600s -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ForwardX11=no -o ProxyCommand='ssh -W %h:%p {{ delegate_sap_vm_provision_bastion_user }}@{{ delegate_sap_vm_provision_bastion_public_ip }} -p {{ delegate_sap_vm_provision_bastion_ssh_port }} -i {{ delegate_sap_vm_provision_ssh_bastion_private_key_file_path }} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
   block:
 
+    # Required as state: present on Ansible Module gcp_compute_instance does not allow for waiting until VM has booted
+    # wait_for_connection is used instead to ensure connection is available before proceeding.
     - name: Wait until SSH connection is available
       ansible.builtin.wait_for_connection:
         timeout: 300

--- a/roles/sap_vm_provision/tasks/platform_ansible/gcp_ce_vm/execute_provision.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/gcp_ce_vm/execute_provision.yml
@@ -128,12 +128,6 @@
     auth_kind: "serviceaccount"
     service_account_file: "{{ sap_vm_provision_gcp_credentials_json }}"
 
-# Required as state: present on Ansible Module gcp_compute_instance does not allow for waiting until VM has booted
-- name: Wait 90 seconds for Google Cloud VM to boot
-  ansible.builtin.pause:
-    seconds: 90
-    prompt: ""
-  when: __sap_vm_provision_task_provision_host_single.changed
 
 - name: Read Google Cloud VM information
   no_log: "{{ __sap_vm_provision_no_log }}"
@@ -176,6 +170,10 @@
     ansible_ssh_private_key_file: "{{ delegate_sap_vm_provision_ssh_host_private_key_file_path }}"
     ansible_ssh_common_args: -o ConnectTimeout=180 -o ControlMaster=auto -o ControlPersist=3600s -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ForwardX11=no -o ProxyCommand='ssh -W %h:%p {{ delegate_sap_vm_provision_bastion_user }}@{{ delegate_sap_vm_provision_bastion_public_ip }} -p {{ delegate_sap_vm_provision_bastion_ssh_port }} -i {{ delegate_sap_vm_provision_ssh_bastion_private_key_file_path }} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
   block:
+
+    - name: Wait until SSH connection is available
+      ansible.builtin.wait_for_connection:
+        timeout: 300
 
     - name: Create .ssh directory for root user
       ansible.builtin.file:

--- a/roles/sap_vm_provision/tasks/platform_ansible/gcp_ce_vm/execute_provision.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/gcp_ce_vm/execute_provision.yml
@@ -56,6 +56,7 @@
     zone: "{{ sap_vm_provision_gcp_region_zone }}"
     name: "{{ inventory_hostname + '-vol-' + vol_item.name | replace('_', '-')}}"
     size_gb: "{{ vol_item.size }}"
+    type: "{{ vol_item.type }}"
     provisioned_iops: "{{ vol_item.iops | default(omit) }}"
     auth_kind: "serviceaccount"
     service_account_file: "{{ sap_vm_provision_gcp_credentials_json }}"

--- a/roles/sap_vm_provision/tasks/platform_ansible/gcp_ce_vm/execute_setup_ha.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/gcp_ce_vm/execute_setup_ha.yml
@@ -630,7 +630,7 @@
     project: "{{ sap_vm_provision_gcp_project }}"
     region: "{{ sap_vm_provision_gcp_region }}"
     subnetwork: { "selfLink": "{{ __sap_vm_provision_task_gcp_vpc_subnet_info.resources[0].selfLink }}" }
-    name: "{{ sap_vm_provision_ha_load_balancer_name_nwas + '-ascs-reserved-static-ip-vip' + (vip_item_nr | string) }}"
+    name: "{{ sap_vm_provision_ha_load_balancer_name_nwas + '-ascs-reserved-static-ip-vip' }}"
     address_type: internal
     address: "{{ sap_vm_provision_ha_vip_nwas_abap_ascs | regex_replace('/.*', '') }}"
     #network_tier: PREMIUM # An address with type INTERNAL cannot have a network tier
@@ -648,7 +648,7 @@
     project: "{{ sap_vm_provision_gcp_project }}"
     region: "{{ sap_vm_provision_gcp_region }}"
     subnetwork: { "selfLink": "{{ __sap_vm_provision_task_gcp_vpc_subnet_info.resources[0].selfLink }}" }
-    name: "{{ sap_vm_provision_ha_load_balancer_name_nwas + '-ers-reserved-static-ip-vip' + (vip_item_nr | string) }}"
+    name: "{{ sap_vm_provision_ha_load_balancer_name_nwas + '-ers-reserved-static-ip-vip' }}"
     address_type: internal
     address: "{{ sap_vm_provision_ha_vip_nwas_abap_ers | regex_replace('/.*', '') }}"
     #network_tier: PREMIUM # An address with type INTERNAL cannot have a network tier

--- a/roles/sap_vm_provision/tasks/platform_ansible/gcp_ce_vm/post_deployment_execute.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/gcp_ce_vm/post_deployment_execute.yml
@@ -10,7 +10,6 @@
   #   GCP_AUTH_KIND: "serviceaccount"
   #   GCP_SERVICE_ACCOUNT_FILE: "{{ sap_vm_provision_gcp_credentials_json }}"
   when:
-    - sap_ha_pacemaker_cluster_msazure_resource_group is defined
     - (groups["hana_secondary"] is defined and (groups["hana_secondary"] | length>0)) or (groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0)) or (groups["anydb_secondary"] is defined and (groups["anydb_secondary"] | length>0))
   block:
 


### PR DESCRIPTION
Description:
- Replaced 90 second pause with wait for ssh connection
- Added fail if resources were not found (OS Image, VPC, VPC Subnet, DNS) and catch it with rescue block
- Enable post provisioning steps which were blocked by incorrect variable name
- Documentation improvements to include detailed breakdown of required permissions and guide for Cloud NAT port blocking issue.

**NOTE**
_Further improvements to HA provisioning might be needed after `sap_ha_pacemaker_cluster` role is reworked due to haproxy._