### PR TITLE
sap_vm_provision: Add optional AWS DNS overwrite

### DIFF
--- a/roles/sap_vm_provision/defaults/main.yml
+++ b/roles/sap_vm_provision/defaults/main.yml
@@ -145,6 +145,9 @@ sap_vm_provision_aws_placement_strategy_spread: false
 # Example for HANA HA: "HA-Role-Pacemaker-{{ sap_system_hana_db_sid }}"
 sap_vm_provision_aws_ha_iam_role: "HA-Role-Pacemaker"
 sap_vm_provision_aws_ha_iam_instance_profile: "HA-Instance-Profile-Pacemaker-Cluster"
+# Enable to overwrite existing DNS record.
+# AWS Route53 module fails when DNS record already exists.
+sap_vm_provision_aws_dns_overwrite: false
 
 # Google Cloud
 sap_vm_provision_gcp_credentials_json: ""

--- a/roles/sap_vm_provision/tasks/platform_ansible/aws_ec2_vs/execute_main.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/aws_ec2_vs/execute_main.yml
@@ -103,6 +103,7 @@
         wait: true
         access_key: "{{ sap_vm_provision_aws_access_key }}"
         secret_key: "{{ sap_vm_provision_aws_secret_access_key }}"
+        overwrite: "{{ sap_vm_provision_aws_dns_overwrite if sap_vm_provision_aws_dns_overwrite | bool else false }}"
 
   rescue:
     # This requires no_log set on each Ansible Task, and not set on the Ansible Task Block

--- a/roles/sap_vm_provision/tasks/platform_ansible/aws_ec2_vs/execute_setup_ha.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/aws_ec2_vs/execute_setup_ha.yml
@@ -51,6 +51,7 @@
     wait: true
     access_key: "{{ sap_vm_provision_aws_access_key }}"
     secret_key: "{{ sap_vm_provision_aws_secret_access_key }}"
+    overwrite: "{{ sap_vm_provision_aws_dns_overwrite if sap_vm_provision_aws_dns_overwrite | bool else false }}"
   loop: "{{ (groups['hana_primary'] | default([])) }}"
   loop_control:
     loop_var: host_node
@@ -92,6 +93,7 @@
     wait: true
     access_key: "{{ sap_vm_provision_aws_access_key }}"
     secret_key: "{{ sap_vm_provision_aws_secret_access_key }}"
+    overwrite: "{{ sap_vm_provision_aws_dns_overwrite if sap_vm_provision_aws_dns_overwrite | bool else false }}"
   loop: "{{ (groups['anydb_primary'] | default([])) }}"
   loop_control:
     loop_var: host_node
@@ -133,6 +135,7 @@
     wait: true
     access_key: "{{ sap_vm_provision_aws_access_key }}"
     secret_key: "{{ sap_vm_provision_aws_secret_access_key }}"
+    overwrite: "{{ sap_vm_provision_aws_dns_overwrite if sap_vm_provision_aws_dns_overwrite | bool else false }}"
   loop: "{{ (groups['nwas_ascs'] | default([])) }}"
   loop_control:
     loop_var: host_node
@@ -174,6 +177,7 @@
     wait: true
     access_key: "{{ sap_vm_provision_aws_access_key }}"
     secret_key: "{{ sap_vm_provision_aws_secret_access_key }}"
+    overwrite: "{{ sap_vm_provision_aws_dns_overwrite if sap_vm_provision_aws_dns_overwrite | bool else false }}"
   loop: "{{ (groups['nwas_ers'] | default([])) }}"
   loop_control:
     loop_var: host_node


### PR DESCRIPTION
Description:
- Add optional variable `sap_vm_provision_aws_dns_overwrite` that can be used to overwrite existing DNS records.
- Default: `false`
- Defaults to `false`, if `sap_vm_provision_aws_dns_overwrite` is not boolean

NOTE: This is required to be set `true` for idempotency, but default handling retains parity between cloud implementations. 

https://docs.ansible.com/ansible/latest/collections/amazon/aws/route53_module.html#parameter-overwrite