### PR TITLE
sap_vm_provision: fix var reference to var lookup

### DIFF
--- a/roles/sap_vm_provision/tasks/common/set_ansible_vars.yml
+++ b/roles/sap_vm_provision/tasks/common/set_ansible_vars.yml
@@ -4,7 +4,7 @@
 - name: Set facts for all hosts - use facts from localhost - SAP Variables from host_specifications_dictionary
   ansible.builtin.set_fact:
     "{{ host_spec_sap_item }}": "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][scaleout_origin_host_spec | default(inventory_hostname)][host_spec_sap_item] }}"
-  loop: "{{ vars['sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary'][sap_vm_provision_host_specification_plan][scaleout_origin_host_spec | default(inventory_hostname)].keys() | map('regex_findall', '^sap_.*') | flatten | select() | list }}"
+  loop: "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][scaleout_origin_host_spec | default(inventory_hostname)].keys() | map('regex_findall', '^sap_.*') | flatten | select() | list }}"
   loop_control:
     loop_var: host_spec_sap_item
 


### PR DESCRIPTION
`vars[]` lookup is preventing nested variables from being evaluated.
The loop breaks when a custom `sap_vm_provision_..._host_specifications_dictionary` is used that includes nested variables for flexibility.

All other vars lookups in the role had already been changed to use the lookup plugin some time ago.

Input var:
```
sap_vm_provision_aws_ec2_vs_host_specifications_dictionary:

  # HANA scale-up minimal
  su_min:

    su1hana01: "{{ aws_host_profile.hana_96m_100s.profile_primary }}"
    su1hana02: "{{ aws_host_profile.hana_96m_100s.profile_secondary }}"
```

Original syntax and result:
```
- debug:
    var: vars['sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary'][sap_vm_provision_host_specification_plan][scaleout_origin_host_spec | default('su1hana01')].keys() | map('regex_findall', '^sap_.*') | flatten | select() | list
--------------------------------------------------------------------------------------------

ok: [localhost] => 
  ? vars['sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary'][sap_vm_provision_host_specification_plan][scaleout_origin_host_spec | default('su1hana01')].keys() | map('regex_findall', '^sap_.*') | flatten | select() | list
  : 'VARIABLE IS NOT DEFINED!: ''ansible.parsing.yaml.objects.AnsibleUnicode object'' has no attribute ''keys''. ''ansible.parsing.yaml.objects.AnsibleUnicode object'' has no attribute ''keys'''
```

With the fix:
```
- debug:
    var: lookup('vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][scaleout_origin_host_spec | default('su1hana01')].keys() | map('regex_findall', '^sap_.*') | flatten | select() | list 
--------------------------------------------------------------------------------------------

ok: [localhost] => 
  ? lookup('vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][scaleout_origin_host_spec | default('su1hana01')].keys() | map('regex_findall', '^sap_.*') | flatten | select() | list
  : - sap_host_type
    - sap_storage_setup_sid
    - sap_storage_setup_host_type
```