### PR TITLE
Minor indentation fix for hpp workload field

### DIFF
--- a/roles/sap_hypervisor_node_preconfigure/tasks/platform/redhat_ocp_virt/install-hpp.yml
+++ b/roles/sap_hypervisor_node_preconfigure/tasks/platform/redhat_ocp_virt/install-hpp.yml
@@ -67,10 +67,10 @@
         storagePools:
           - name: localstorage
             path: /var/localstorage
-      workload:
-        nodeSelector:
-          kubernetes.io/os: linux
-          machineconfiguration.openshift.io/role: worker
+        workload:
+          nodeSelector:
+            kubernetes.io/os: linux
+            machineconfiguration.openshift.io/role: worker
 
 - name: Create storage class for HPP
   kubernetes.core.k8s:


### PR DESCRIPTION
Minor indentation fix for hpp:

$ oc explain HostPathProvisioner.spec
GROUP:      hostpathprovisioner.kubevirt.io
KIND:       HostPathProvisioner
VERSION:    v1beta1
FIELD: spec <Object>
DESCRIPTION:
    HostPathProvisionerSpec defines the desired state of HostPathProvisioner
    FIELDS:
  featureGates	<[]string>
    FeatureGates are a list of specific enabled feature gates

  imagePullPolicy	<string>
    ImagePullPolicy is the container pull policy for the host path provisioner
    containers

  pathConfig	<Object>
    PathConfig describes the location and layout of PV storage on nodes.
    Deprecated

  storagePools	<[]Object>
    StoragePools are a list of storage pools

  workload	<Object>
    Restrict on which nodes HPP workload pods will be scheduled
