### PR TITLE
sap_vm_provision/sap_vm_temp_vip: GCP HA improvements and VIP broadcast fix for GCP

### DIFF
--- a/roles/sap_vm_provision/tasks/platform_ansible/gcp_ce_vm/execute_main.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/gcp_ce_vm/execute_main.yml
@@ -325,6 +325,37 @@
         state: stopped
         enabled: false
 
+    # Ensure that backend load balancer configuration is allowed before Load balancers are created
+    # SUSE: https://cloud.google.com/solutions/sap/docs/netweaver-ha-config-sles#enable-back-end-comms
+    # RHEL: https://cloud.google.com/solutions/sap/docs/netweaver-ha-config-rhel#enable-back-end-comms
+    - name: Stop google-guest-agent service
+      ansible.builtin.service:
+        name: google-guest-agent
+        state: stopped
+
+    - name: Update /etc/default/instance_configs.cfg file
+      register: __sap_vm_provision_task_gcp_instance_config
+      ansible.builtin.blockinfile:
+        path: /etc/default/instance_configs.cfg
+        create: true
+        mode: '0644'
+        block: |
+          [IpForwarding]
+          ethernet_proto_id = 66
+          ip_aliases = true
+          target_instance_ips = false
+
+          [NetworkInterfaces]
+          dhclient_script = /sbin/google-dhclient-script
+          dhcp_command =
+          ip_forwarding = false
+          setup = true
+
+    - name: Start google-guest-agent service
+      ansible.builtin.service:
+        name: google-guest-agent
+        state: started
+
 
 - name: Ansible Task block for looped provisioning of High Availability resources for Google Cloud CE VMs
   delegate_to: localhost

--- a/roles/sap_vm_temp_vip/tasks/set_temp_vip.yml
+++ b/roles/sap_vm_temp_vip/tasks/set_temp_vip.yml
@@ -71,7 +71,10 @@
 - name: Append temporary Virtual IP (VIP) to network interface for SAP HANA, will be replaced by Linux Pacemaker IPaddr2 Resource Agent
   ansible.builtin.shell: |
     platform_cidr_32_static="{{ 'true' if (('amazon' in (ansible_system_vendor | lower) or 'amazon' in (ansible_product_name | lower)) or (ansible_product_name == 'Google Compute Engine')) }}"
-    if [ "$platform_cidr_32_static" = "true" ]
+    if [ "$platform_cidr_32_static" = "true" ] && [ "{{ primary_ip_broadcast_address }}" = "" ]
+    then
+      ip address add {{ sap_vm_temp_vip_hana_primary | regex_replace('/.*', '') }}/32 dev eth0 noprefixroute
+    elif [ "$platform_cidr_32_static" = "true" ] && [ "{{ primary_ip_broadcast_address }}" != "" ]
     then
       ip address add {{ sap_vm_temp_vip_hana_primary | regex_replace('/.*', '') }}/32 brd {{ primary_ip_broadcast_address }} dev eth0 noprefixroute
     elif [ "{{ primary_ip_broadcast_address }}" = "" ] && [ "{{ primary_ip_address_netmask_cidr_prefix }}" = "" ]
@@ -108,7 +111,10 @@
 - name: Append temporary Virtual IP (VIP) to network interface for SAP AnyDB, will be replaced by Linux Pacemaker IPaddr2 Resource Agent
   ansible.builtin.shell: |
     platform_cidr_32_static="{{ 'true' if (('amazon' in (ansible_system_vendor | lower) or 'amazon' in (ansible_product_name | lower)) or (ansible_product_name == 'Google Compute Engine')) }}"
-    if [ "$platform_cidr_32_static" = "true" ]
+    if [ "$platform_cidr_32_static" = "true" ] && [ "{{ primary_ip_broadcast_address }}" = "" ]
+    then
+      ip address add {{ sap_vm_temp_vip_anydb_primary | regex_replace('/.*', '') }}/32 dev eth0 noprefixroute
+    elif [ "$platform_cidr_32_static" = "true" ] && [ "{{ primary_ip_broadcast_address }}" != "" ]
     then
       ip address add {{ sap_vm_temp_vip_anydb_primary | regex_replace('/.*', '') }}/32 brd {{ primary_ip_broadcast_address }} dev eth0 noprefixroute
     elif [ "{{ primary_ip_broadcast_address }}" = "" ] && [ "{{ primary_ip_address_netmask_cidr_prefix }}" = "" ]
@@ -150,7 +156,10 @@
 - name: Append temporary Virtual IP (VIP) to network interface for SAP NetWeaver ASCS, will be replaced by Linux Pacemaker IPaddr2 Resource Agent
   ansible.builtin.shell: |
     platform_cidr_32_static="{{ 'true' if (('amazon' in (ansible_system_vendor | lower) or 'amazon' in (ansible_product_name | lower)) or (ansible_product_name == 'Google Compute Engine')) }}"
-    if [ "$platform_cidr_32_static" = "true" ]
+    if [ "$platform_cidr_32_static" = "true" ] && [ "{{ primary_ip_broadcast_address }}" = "" ]
+    then
+      ip address add {{ sap_vm_temp_vip_nwas_abap_ascs | regex_replace('/.*', '') }}/32 dev eth0 noprefixroute
+    elif [ "$platform_cidr_32_static" = "true" ] && [ "{{ primary_ip_broadcast_address }}" != "" ]
     then
       ip address add {{ sap_vm_temp_vip_nwas_abap_ascs | regex_replace('/.*', '') }}/32 brd {{ primary_ip_broadcast_address }} dev eth0 noprefixroute
     elif [ "{{ primary_ip_broadcast_address }}" = "" ] && [ "{{ primary_ip_address_netmask_cidr_prefix }}" = "" ]
@@ -189,7 +198,10 @@
 - name: Append temporary Virtual IP (VIP) to network interface for SAP NetWeaver ERS, will be replaced by Linux Pacemaker IPaddr2 Resource Agent
   ansible.builtin.shell: |
     platform_cidr_32_static="{{ 'true' if (('amazon' in (ansible_system_vendor | lower) or 'amazon' in (ansible_product_name | lower)) or (ansible_product_name == 'Google Compute Engine')) }}"
-    if [ "$platform_cidr_32_static" = "true" ]
+    if [ "$platform_cidr_32_static" = "true" ] && [ "{{ primary_ip_broadcast_address }}" = "" ]
+    then
+      ip address add {{ sap_vm_temp_vip_nwas_abap_ers | regex_replace('/.*', '') }}/32 dev eth0 noprefixroute
+    elif [ "$platform_cidr_32_static" = "true" ] && [ "{{ primary_ip_broadcast_address }}" != "" ]
     then
       ip address add {{ sap_vm_temp_vip_nwas_abap_ers | regex_replace('/.*', '') }}/32 brd {{ primary_ip_broadcast_address }} dev eth0 noprefixroute
     elif [ "{{ primary_ip_broadcast_address }}" = "" ] && [ "{{ primary_ip_address_netmask_cidr_prefix }}" = "" ]


### PR DESCRIPTION
### sap_vm_provision
Added missing enablement of google cloud agent, that allows backend communication between servers using NLB.
Not having this file results in connection blocked.
    # SUSE: https://cloud.google.com/solutions/sap/docs/netweaver-ha-config-sles#enable-back-end-comms
    # RHEL: https://cloud.google.com/solutions/sap/docs/netweaver-ha-config-rhel#enable-back-end-comms

**NOTE**: This is executed on delegated hosts and it has to be done before NLB creation.

### sap_vm_temp_vip
Google servers do not have broadcast IP by default, which is combination missing in VIP role.

Fixes error: `Error: inet address is expected rather than "dev"` caused by empty `primary_ip_broadcast_address`