### PR TITLE
Remove enabled: true from storagebridge

### DIFF
--- a/playbooks/vars/sample-variables-sap-hypervisor-redhat-ocp-virt-preconfigure.yml
+++ b/playbooks/vars/sample-variables-sap-hypervisor-redhat-ocp-virt-preconfigure.yml
@@ -148,7 +148,6 @@ sap_hypervisor_node_preconfigure_cluster_config:
                 prefix-length: 24
             auto-dns: false
             auto-gateway: false
-          enabled: true
           state: up
           type: linux-bridge
 
@@ -202,7 +201,6 @@ sap_hypervisor_node_preconfigure_cluster_config:
                 prefix-length: 24
             auto-dns: false
             auto-gateway: false
-          enabled: true
           state: up
           type: linux-bridge
 


### PR DESCRIPTION
Enabled is not unknown field under interfaces

Currently we get an error :+1: 
$ oc get nncp -A 
NAME                    STATUS      REASON
storagebridge-worker1   Degraded    FailedToConfigure
storagebridge-worker2   Degraded    FailedToConfigure


Events:
  Type     Reason           Age   From                     Message
  ----     ------           ----  ----                     -------
  Warning  ReconcileFailed  123m  worker1.nmstate-handler  error reconciling NodeNetworkConfigurationPolicy on node worker1 at desired state apply: "",
 failed to execute nmstatectl set --no-commit --timeout 480: 'exit status 1' '' '[2024-11-11T10:12:35Z INFO  nmstatectl] Nmstate version: 2.2.33
Using 'set' is deprecated, use 'apply' instead.
Provide file is not valid NetworkState or NetworkPolicy: interfaces: unknown field `enabled` at line 2 column 1
'
