### PR TITLE
sap_vm_provision/sap_vm_temp_vip: Feat: Add dynamic group handling for provisioning

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -9,7 +9,7 @@ collections:
     version: 9.0.0
   - name: azure.azcollection
     type: galaxy
-    version: 3.0.1
+    version: 3.0.0
   - name: google.cloud
     type: galaxy
     version: 1.1.3

--- a/roles/sap_vm_provision/README.md
+++ b/roles/sap_vm_provision/README.md
@@ -112,7 +112,8 @@ Prior to execution of this Ansible Role, there are no Ansible Roles suggested to
     - Variables specific to each Infrastructure Platform (e.g. `sap_vm_provision_aws_access_key`)
     - Include files from subdirectory based upon chosen method and target (e.g. `/tasks/platform_ansible_to_terraform/aws_ec2_vs/`)
 - Provision host/s
-- Add hosts to Ansible Inventory Groups defined by the Host Specification Dictionary _(e.g. hana_primary, hana_secondary, nwas_ascs, nwas_ers, nwas_pas, nwas_aas, anydb_primary, anydb_secondary)_
+- Add hosts to Ansible Inventory Groups defined by the Host Specification Dictionary `sap_host_type` variable _(e.g. hana_primary, hana_secondary, nwas_ascs, nwas_ers, nwas_pas, nwas_aas, anydb_primary, anydb_secondary)_</br>
+  **NOTE:** Group names can be customized using `sap_vm_provision_group_*` variables in `vars/default.yml` (e.g. `sap_vm_provision_group_hana_primary`, `sap_vm_provision_group_nwas_ascs`, etc.).
 - Perform additional tasks for host/s (e.g. DNS Records, /etc/hosts, register OS for Packages, register Web Forward Proxy)
 - Set variables if other Ansible Roles are to be executed (e.g. variables for Ansible Roles in the `sap_install` Ansible Collection)
 - Perform any tasks for High Availability (execution dependent on hosts in Ansible Inventory Groups)

--- a/roles/sap_vm_provision/defaults/main.yml
+++ b/roles/sap_vm_provision/defaults/main.yml
@@ -13,6 +13,18 @@ sap_vm_provision_iac_platform: ""
 # execution_host where ansible playbook will delegate_to
 sap_vm_provision_execution_host: "localhost"
 
+# Customized group names are used by sap_host_type in host_specifications_dictionary plan during provisioning.
+# Variables are also used in sap_vm_temp_vip role
+sap_vm_provision_group_hana_primary: hana_primary
+sap_vm_provision_group_hana_secondary: hana_secondary
+sap_vm_provision_group_nwas_ascs: nwas_ascs
+sap_vm_provision_group_nwas_scs: nwas_scs
+sap_vm_provision_group_nwas_ers: nwas_ers
+sap_vm_provision_group_nwas_pas: nwas_pas
+sap_vm_provision_group_nwas_aas: nwas_aas
+sap_vm_provision_group_anydb_primary: anydb_primary
+sap_vm_provision_group_anydb_secondary: anydb_secondary
+
 ####
 # VM Provision Infrastructure-as-Code (IaC) Configuration - Ansible provisioning - Cloud Hyperscaler
 # Only for use when 'ansible' is value provided for variable sap_vm_provision_iac_type
@@ -666,7 +678,7 @@ sap_vm_provision_aws_ec2_vs_host_specifications_dictionary:
       virtual_machine_profile: r5.8xlarge
       disable_ip_anti_spoofing: false
       #sap_system_type: project_dev # project_dev, project_tst, project_prd
-      sap_host_type: "" # hana_primary, hana_secondary, anydb_primary, anydb_secondary, nwas_ascs, nwas_ers, nwas_pas, nwas_aas
+      sap_host_type: hana_primary # hana_primary, hana_secondary, anydb_primary, anydb_secondary, nwas_ascs, nwas_ers, nwas_pas, nwas_aas
       storage_definition:
         - name: data_0
           mountpoint: /data0

--- a/roles/sap_vm_provision/tasks/common/set_etc_hosts.yml
+++ b/roles/sap_vm_provision/tasks/common/set_etc_hosts.yml
@@ -37,7 +37,7 @@
         line: "{{ sap_vm_provision_dynamic_inventory_hana_primary_ip }}\t{{ sap_vm_provision_dynamic_inventory_hana_primary_hostname }}.{{ sap_vm_provision_dns_root_domain }}\t{{ sap_vm_provision_dynamic_inventory_hana_primary_hostname }}"
         state: present
       when:
-        - groups["hana_primary"] is defined and inventory_hostname_short in groups['hana_primary']
+        - groups[sap_vm_provision_group_hana_primary] is defined and inventory_hostname_short in groups[sap_vm_provision_group_hana_primary]
         - not (ansible_play_hosts_all | length) > 1
 
     - name: Update /etc/hosts file when single sandbox host (nwas_pas)
@@ -45,7 +45,7 @@
         dest: /etc/hosts
         line: "{{ sap_vm_provision_dynamic_inventory_nw_pas_ip }}\t{{ sap_vm_provision_dynamic_inventory_nw_pas_hostname }}.{{ sap_vm_provision_dns_root_domain }}\t{{ sap_vm_provision_dynamic_inventory_nw_pas_hostname }}"
       when:
-        - groups["nwas_pas"] is defined and inventory_hostname_short in groups['nwas_pas']
+        - groups[sap_vm_provision_group_nwas_pas] is defined and inventory_hostname_short in groups[sap_vm_provision_group_nwas_pas]
         - not (ansible_play_hosts_all | length) > 1
 
 
@@ -55,7 +55,7 @@
         line: "{{ sap_vm_provision_dynamic_inventory_hana_primary_ip }}\t{{ sap_vm_provision_dynamic_inventory_hana_primary_hostname }}.{{ sap_vm_provision_dns_root_domain }}\t{{ sap_vm_provision_dynamic_inventory_hana_primary_hostname }}"
         state: present
       when:
-        - (groups["hana_primary"] is defined and (groups["hana_primary"] | length>0))
+        - (groups[sap_vm_provision_group_hana_primary] is defined and (groups[sap_vm_provision_group_hana_primary] | length>0))
         - (ansible_play_hosts_all | length) > 1
 
 
@@ -65,7 +65,7 @@
         line: "{{ sap_vm_provision_dynamic_inventory_anydb_primary_ip }}\t{{ sap_vm_provision_dynamic_inventory_anydb_primary_hostname }}.{{ sap_vm_provision_dns_root_domain }}\t{{ sap_vm_provision_dynamic_inventory_anydb_primary_hostname }}"
         state: present
       when:
-        - (groups["anydb_primary"] is defined and (groups["anydb_primary"] | length>0))
+        - (groups[sap_vm_provision_group_anydb_primary] is defined and (groups[sap_vm_provision_group_anydb_primary] | length>0))
         - (ansible_play_hosts_all | length) > 1
 
 
@@ -75,7 +75,7 @@
         line: "{{ sap_vm_provision_dynamic_inventory_nw_ascs_ip }}\t{{ sap_vm_provision_dynamic_inventory_nw_ascs_hostname }}.{{ sap_vm_provision_dns_root_domain }}\t{{ sap_vm_provision_dynamic_inventory_nw_ascs_hostname }}"
         state: present
       when:
-        - (groups["nwas_ascs"] is defined and (groups["nwas_ascs"] | length>0))
+        - (groups[sap_vm_provision_group_nwas_ascs] is defined and (groups[sap_vm_provision_group_nwas_ascs] | length>0))
         - (ansible_play_hosts_all | length) > 1
 
     - name: Update /etc/hosts file for SAP NetWeaver PAS
@@ -84,7 +84,7 @@
         line: "{{ sap_vm_provision_dynamic_inventory_nw_pas_ip }}\t{{ sap_vm_provision_dynamic_inventory_nw_pas_hostname }}.{{ sap_vm_provision_dns_root_domain }}\t{{ sap_vm_provision_dynamic_inventory_nw_pas_hostname }}"
         state: present
       when:
-        - (groups["nwas_pas"] is defined and (groups["nwas_pas"] | length>0))
+        - (groups[sap_vm_provision_group_nwas_pas] is defined and (groups[sap_vm_provision_group_nwas_pas] | length>0))
         - (ansible_play_hosts_all | length) > 1
 
     - name: Update /etc/hosts file for SAP NetWeaver AAS
@@ -93,5 +93,5 @@
         line: "{{ sap_vm_provision_dynamic_inventory_nw_aas_ip }}\t{{ sap_vm_provision_dynamic_inventory_nw_aas_hostname }}.{{ sap_vm_provision_dns_root_domain }}\t{{ sap_vm_provision_dynamic_inventory_nw_aas_hostname }}"
         state: present
       when:
-        - (groups["nwas_aas"] is defined and (groups["nwas_aas"] | length>0))
+        - (groups[sap_vm_provision_group_nwas_aas] is defined and (groups[sap_vm_provision_group_nwas_aas] | length>0))
         - (ansible_play_hosts_all | length) > 1

--- a/roles/sap_vm_provision/tasks/common/set_etc_hosts_ha.yml
+++ b/roles/sap_vm_provision/tasks/common/set_etc_hosts_ha.yml
@@ -4,7 +4,7 @@
 
 - name: Ansible Play for controlling execution to an Infrastructure Platform when High Availability is used
   when:
-    - (groups["hana_secondary"] is defined and (groups["hana_secondary"] | length>0)) or (groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0)) or (groups["anydb_secondary"] is defined and (groups["anydb_secondary"] | length>0))
+    - (groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary] | length>0)) or (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0)) or (groups[sap_vm_provision_group_anydb_secondary] is defined and (groups[sap_vm_provision_group_anydb_secondary] | length>0))
   block:
 
     # Required to collect the remote host's facts for further processing
@@ -20,7 +20,7 @@
         line: "{{ sap_vm_provision_dynamic_inventory_hana_secondary_ip }}\t{{ sap_vm_provision_dynamic_inventory_hana_secondary_hostname }}.{{ ansible_domain }}\t{{ sap_vm_provision_dynamic_inventory_hana_secondary_hostname }}"
         state: present
       when:
-        - (groups["hana_secondary"] is defined and (groups["hana_secondary"] | length>0))
+        - (groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary] | length>0))
 
     - name: Update /etc/hosts file for SAP NetWeaver ERS
       ansible.builtin.lineinfile:
@@ -28,7 +28,7 @@
         line: "{{ sap_vm_provision_dynamic_inventory_nw_ers_ip }}\t{{ sap_vm_provision_dynamic_inventory_nw_ers_hostname }}.{{ ansible_domain }}\t{{ sap_vm_provision_dynamic_inventory_nw_ers_hostname }}"
         state: present
       when:
-        - (groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0))
+        - (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0))
 
 
     - name: Update /etc/hosts file for SAP HANA HA
@@ -40,7 +40,7 @@
         - "{{ sap_vm_provision_dynamic_inventory_hana_primary_ip }}\t{{ sap_vm_provision_dynamic_inventory_hana_primary_hostname }}.{{ ansible_domain }}\t{{ sap_vm_provision_dynamic_inventory_hana_primary_hostname }}"
         - "{{ sap_vm_provision_dynamic_inventory_hana_secondary_ip }}\t{{ sap_vm_provision_dynamic_inventory_hana_secondary_hostname }}.{{ ansible_domain }}\t{{ sap_vm_provision_dynamic_inventory_hana_secondary_hostname }}"
       when:
-        - (groups["hana_secondary"] is defined and (groups["hana_secondary"] | length>0))
+        - (groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary] | length>0))
 
     - name: Update /etc/hosts file with Virtual IPs for SAP HANA HA
       ansible.builtin.lineinfile:
@@ -50,8 +50,8 @@
       loop:
         - "{{ sap_vm_provision_ha_vip_hana_primary | regex_replace('/.*', '') }}\t{{ sap_swpm_db_host }}.{{ ansible_domain }}\t{{ sap_swpm_db_host }}"
       when:
-        - (groups["hana_secondary"] is defined and (groups["hana_secondary"] | length>0))
-        - (not ansible_product_name == "Google Compute Engine" and not ansible_chassis_vendor == "Microsoft Corporation" and not ansible_chassis_asset_tag == 'ibmcloud') or ( (ansible_product_name == "Google Compute Engine" or ansible_chassis_vendor == "Microsoft Corporation" or ansible_chassis_asset_tag == 'ibmcloud') and (not inventory_hostname in groups["hana_primary"] or not inventory_hostname in groups["hana_secondary"]) )
+        - (groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary] | length>0))
+        - (not ansible_product_name == "Google Compute Engine" and not ansible_chassis_vendor == "Microsoft Corporation" and not ansible_chassis_asset_tag == 'ibmcloud') or ( (ansible_product_name == "Google Compute Engine" or ansible_chassis_vendor == "Microsoft Corporation" or ansible_chassis_asset_tag == 'ibmcloud') and (not inventory_hostname in groups[sap_vm_provision_group_hana_primary] or not inventory_hostname in groups[sap_vm_provision_group_hana_secondary]) )
         - (sap_vm_provision_ha_vip_hana_primary | length) > 0
 
 
@@ -64,7 +64,7 @@
         - "{{ sap_vm_provision_dynamic_inventory_anydb_primary_ip }}\t{{ sap_vm_provision_dynamic_inventory_anydb_primary_hostname }}.{{ ansible_domain }}\t{{ sap_vm_provision_dynamic_inventory_anydb_primary_hostname }}"
         - "{{ sap_vm_provision_dynamic_inventory_anydb_secondary_ip }}\t{{ sap_vm_provision_dynamic_inventory_anydb_secondary_hostname }}.{{ ansible_domain }}\t{{ sap_vm_provision_dynamic_inventory_anydb_secondary_hostname }}"
       when:
-        - (groups["anydb_secondary"] is defined and (groups["anydb_secondary"] | length>0))
+        - (groups[sap_vm_provision_group_anydb_secondary] is defined and (groups[sap_vm_provision_group_anydb_secondary] | length>0))
 
     - name: Update /etc/hosts file with Virtual IPs for SAP AnyDB HA
       ansible.builtin.lineinfile:
@@ -74,7 +74,7 @@
       loop:
         - "{{ sap_vm_provision_ha_vip_anydb_primary | regex_replace('/.*', '') }}\t{{ sap_swpm_db_host }}.{{ ansible_domain }}\t{{ sap_swpm_db_host }}"
       when:
-        - (groups["anydb_secondary"] is defined and (groups["anydb_secondary"] | length>0))
+        - (groups[sap_vm_provision_group_anydb_secondary] is defined and (groups[sap_vm_provision_group_anydb_secondary] | length>0))
         - (sap_vm_provision_ha_vip_anydb_primary | length) > 0
 
 
@@ -92,7 +92,7 @@
             if (sap_vm_provision_dynamic_inventory_nw_pas_hostname is defined and sap_vm_provision_dynamic_inventory_nw_pas_hostname | length > 0 )
             and (sap_vm_provision_dynamic_inventory_nw_pas_ip is defined and sap_vm_provision_dynamic_inventory_nw_pas_ip | length > 0) else ''}}"
       when:
-        - (groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0))
+        - (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0))
         - item != ''
 
     - name: Update /etc/hosts file with Virtual IPs for SAP NetWeaver HA - ASCS / ERS
@@ -104,8 +104,8 @@
         - "{{ sap_vm_provision_ha_vip_nwas_abap_ascs | regex_replace('/.*', '') }}\t{{ sap_swpm_ascs_instance_hostname }}.{{ ansible_domain }}\t{{ sap_swpm_ascs_instance_hostname }}"
         - "{{ sap_vm_provision_ha_vip_nwas_abap_ers | regex_replace('/.*', '') }}\t{{ sap_swpm_ers_instance_hostname }}.{{ ansible_domain }}\t{{ sap_swpm_ers_instance_hostname }}"
       when:
-        - (groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0))
-        - not ansible_chassis_asset_tag == 'ibmcloud' or ((not inventory_hostname_short in groups['nwas_ascs'] and not inventory_hostname_short in groups['nwas_ers']) and ansible_chassis_asset_tag == 'ibmcloud')
+        - (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0))
+        - not ansible_chassis_asset_tag == 'ibmcloud' or ((not inventory_hostname_short in groups[sap_vm_provision_group_nwas_ascs] and not inventory_hostname_short in groups[sap_vm_provision_group_nwas_ers]) and ansible_chassis_asset_tag == 'ibmcloud')
         - (sap_vm_provision_ha_vip_nwas_abap_ascs | length) > 0
         - (sap_vm_provision_ha_vip_nwas_abap_ers | length) > 0
 
@@ -118,8 +118,8 @@
     #     - "{{ sap_vm_provision_ha_vip_nwas_abap_pas | regex_replace('/.*', '') }}\t{{ sap_swpm_pas_instance_hostname }}.{{ ansible_domain }}\t{{ sap_swpm_pas_instance_hostname }}"
     #     - "{{ sap_vm_provision_ha_vip_nwas_abap_aas | regex_replace('/.*', '') }}\t{{ .sap_swpm_aas_instance_hostname }}.{{ ansible_domain }}\t{{ sap_swpm_aas_instance_hostname }}"
     #   when:
-    #     - (groups["nwas_aas"] is defined and (groups["nwas_aas"] | length>0))
-    #     - not ansible_chassis_asset_tag == 'ibmcloud' or ((not inventory_hostname_short in groups['nwas_pas'] and not inventory_hostname_short in groups['nwas_pas']) and ansible_chassis_asset_tag == 'ibmcloud')
+    #     - (groups[sap_vm_provision_group_nwas_aas] is defined and (groups[sap_vm_provision_group_nwas_aas] | length>0))
+    #     - not ansible_chassis_asset_tag == 'ibmcloud' or ((not inventory_hostname_short in groups[sap_vm_provision_group_nwas_pas] and not inventory_hostname_short in groups[sap_vm_provision_group_nwas_pas]) and ansible_chassis_asset_tag == 'ibmcloud')
     #     - (sap_vm_provision_ha_vip_nwas_abap_pas | length) > 0
     #     - (sap_vm_provision_ha_vip_nwas_abap_aas | length) > 0
 
@@ -131,7 +131,7 @@
       loop:
         - "{{ sap_vm_provision_dynamic_inventory_nw_aas_ip }}\t{{ sap_vm_provision_dynamic_inventory_nw_aas_hostname }}.{{ ansible_domain }}\t{{ sap_vm_provision_dynamic_inventory_nw_aas_hostname }}"
       when:
-        - (groups["nwas_aas"] is defined and (groups["nwas_aas"] | length>0))
+        - (groups[sap_vm_provision_group_nwas_aas] is defined and (groups[sap_vm_provision_group_nwas_aas] | length>0))
 
 
 # Ensure SAP AnyDB, SAP HANA or SAP NetWeaver hostname is not localhost in /etc/hosts. See SAP Note 1054467 - Local host name refers to loopback address.
@@ -142,7 +142,7 @@
 # by appending an alias of the Virtual Hostname to the existing /etc/hosts entry for the host IP Address.
 - name: Ansible Play for controlling execution to an Infrastructure Platform when High Availability is used - IBM Cloud
   when:
-    - (groups["hana_secondary"] is defined and (groups["hana_secondary"] | length>0)) or (groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0)) or (groups["anydb_secondary"] is defined and (groups["anydb_secondary"] | length>0))
+    - (groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary] | length>0)) or (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0)) or (groups[sap_vm_provision_group_anydb_secondary] is defined and (groups[sap_vm_provision_group_anydb_secondary] | length>0))
     - ansible_chassis_asset_tag == 'ibmcloud'
   block:
 
@@ -156,9 +156,9 @@
         - "{{ sap_vm_provision_dynamic_inventory_nw_ers_ip }}\t{{ sap_vm_provision_dynamic_inventory_nw_ers_hostname }}.{{ ansible_domain }}\t{{ sap_vm_provision_dynamic_inventory_nw_ers_hostname }}"
         - "{{ sap_vm_provision_ha_vip_nwas_abap_ers | regex_replace('/.*', '') }}\t{{ sap_swpm_ers_instance_hostname }}.{{ ansible_domain }}\t{{ sap_swpm_ers_instance_hostname }}"
       when:
-        - (groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0))
+        - (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0))
         - ansible_chassis_asset_tag == 'ibmcloud'
-        - inventory_hostname_short in groups['nwas_ascs']
+        - inventory_hostname_short in groups[sap_vm_provision_group_nwas_ascs]
         - (sap_vm_provision_ha_vip_nwas_abap_ascs | length) > 0
 
     - name: Update /etc/hosts file with Virtual Hostname for SAP NetWeaver HA ERS on IBM Cloud
@@ -171,9 +171,9 @@
         - "{{ sap_vm_provision_dynamic_inventory_nw_ers_ip }}\t{{ sap_vm_provision_dynamic_inventory_nw_ers_hostname }}.{{ ansible_domain }}\t{{ sap_vm_provision_dynamic_inventory_nw_ers_hostname }}\t{{ sap_swpm_ers_instance_hostname }}.{{ ansible_domain }}\t{{ sap_swpm_ers_instance_hostname }}"
         - "{{ sap_vm_provision_ha_vip_nwas_abap_ascs | regex_replace('/.*', '') }}\t{{ sap_swpm_ascs_instance_hostname }}.{{ ansible_domain }}\t{{ sap_swpm_ascs_instance_hostname }}"
       when:
-        - (groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0))
+        - (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0))
         - ansible_chassis_asset_tag == 'ibmcloud'
-        - inventory_hostname_short in groups['nwas_ers']
+        - inventory_hostname_short in groups[sap_vm_provision_group_nwas_ers]
         - (sap_vm_provision_ha_vip_nwas_abap_ers | length) > 0
 
     # Remove /etc/hosts entries and then consolidate into one entry with aliases
@@ -186,9 +186,9 @@
         - "{{ sap_vm_provision_dynamic_inventory_nw_ascs_ip }}\t{{ sap_vm_provision_dynamic_inventory_nw_ascs_hostname }}.{{ ansible_domain }}\t{{ sap_vm_provision_dynamic_inventory_nw_ascs_hostname }}"
         - "{{ sap_vm_provision_ha_vip_nwas_abap_ascs | regex_replace('/.*', '') }}\t{{ sap_swpm_ascs_instance_hostname }}.{{ ansible_domain }}\t{{ sap_swpm_ascs_instance_hostname }}"
       when:
-        - (groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0))
+        - (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0))
         - ansible_chassis_asset_tag == 'ibmcloud'
-        - inventory_hostname_short in groups['nwas_ascs']
+        - inventory_hostname_short in groups[sap_vm_provision_group_nwas_ascs]
         - (sap_vm_provision_ha_vip_nwas_abap_ascs | length) > 0
 
     # Remove /etc/hosts entries and then consolidate into one entry with aliases
@@ -201,7 +201,7 @@
         - "{{ sap_vm_provision_dynamic_inventory_nw_ers_ip }}\t{{ sap_vm_provision_dynamic_inventory_nw_ers_hostname }}.{{ ansible_domain }}\t{{ sap_vm_provision_dynamic_inventory_nw_ers_hostname }}"
         - "{{ sap_vm_provision_ha_vip_nwas_abap_ers | regex_replace('/.*', '') }}\t{{ sap_swpm_ers_instance_hostname }}.{{ ansible_domain }}\t{{ sap_swpm_ers_instance_hostname }}"
       when:
-        - (groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0))
+        - (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0))
         - ansible_chassis_asset_tag == 'ibmcloud'
-        - inventory_hostname_short in groups['nwas_ers']
+        - inventory_hostname_short in groups[sap_vm_provision_group_nwas_ers]
         - (sap_vm_provision_ha_vip_nwas_abap_ers | length) > 0

--- a/roles/sap_vm_provision/tasks/common/set_etc_hosts_scaleout.yml
+++ b/roles/sap_vm_provision/tasks/common/set_etc_hosts_scaleout.yml
@@ -4,7 +4,7 @@
 
 - name: Ansible Play for controlling execution to an Infrastructure Platform when SAP HANA Scale-Out is used
   when:
-    - (groups["hana_primary"] is defined and (groups["hana_primary"] | length>0)) and (sap_vm_provision_calculate_sap_hana_scaleout_active_coordinator is defined or sap_vm_provision_calculate_sap_hana_scaleout_active_worker is defined or sap_vm_provision_calculate_sap_hana_scaleout_standby is defined)
+    - (groups[sap_vm_provision_group_hana_primary] is defined and (groups[sap_vm_provision_group_hana_primary] | length>0)) and (sap_vm_provision_calculate_sap_hana_scaleout_active_coordinator is defined or sap_vm_provision_calculate_sap_hana_scaleout_active_worker is defined or sap_vm_provision_calculate_sap_hana_scaleout_standby is defined)
   block:
 
     # Required to collect the remote host's facts for further processing
@@ -20,10 +20,10 @@
         line: "{{ item }}"
         state: present
       loop:
-        - "# SAP HANA scale-out parent\n{{ hostvars[(groups['hana_primary'] | first)]['ansible_host'] }}\t{{ hostvars[(groups['hana_primary'] | first)]['ansible_fqdn'] }}\t{{ hostvars[(groups['hana_primary'] | first)]['inventory_hostname_short'] }}"
+        - "# SAP HANA scale-out parent\n{{ hostvars[(groups[sap_vm_provision_group_hana_primary] | first)]['ansible_host'] }}\t{{ hostvars[(groups[sap_vm_provision_group_hana_primary] | first)]['ansible_fqdn'] }}\t{{ hostvars[(groups[sap_vm_provision_group_hana_primary] | first)]['inventory_hostname_short'] }}"
       loop_control:
         label: "{{ inventory_hostname_short }}"
-      when: not inventory_hostname_short == hostvars[(groups['hana_primary'] | first)]['inventory_hostname_short']
+      when: not inventory_hostname_short == hostvars[(groups[sap_vm_provision_group_hana_primary] | first)]['inventory_hostname_short']
 
     - name: Update /etc/hosts file for SAP HANA Scale-Out Active Workers (no Standby)
       ansible.builtin.lineinfile:
@@ -31,7 +31,7 @@
         line: "{{ item }}"
         state: present
       loop:
-        - "# SAP HANA scale-out workers\n{% for host in (groups['hana_primary'] | reject('regex', '0$') | list) %}{% if (host != inventory_hostname_short) %}{{ hostvars[host]['ansible_host'] }}\t{{ hostvars[host]['ansible_fqdn'] }}\t{{ hostvars[host]['inventory_hostname_short'] }}\n{% endif %}{% endfor %}"
+        - "# SAP HANA scale-out workers\n{% for host in (groups[sap_vm_provision_group_hana_primary] | reject('regex', '0$') | list) %}{% if (host != inventory_hostname_short) %}{{ hostvars[host]['ansible_host'] }}\t{{ hostvars[host]['ansible_fqdn'] }}\t{{ hostvars[host]['inventory_hostname_short'] }}\n{% endif %}{% endfor %}"
       loop_control:
         label: "{{ inventory_hostname_short }}"
       when:
@@ -43,7 +43,7 @@
         line: "{{ item }}"
         state: present
       loop:
-        - "# SAP HANA scale-out workers\n{% for host in (groups['hana_primary'] | reject('regex', '0$') | list)[:-1] %}{% if (host != inventory_hostname_short) %}{{ hostvars[host]['ansible_host'] }}\t{{ hostvars[host]['ansible_fqdn'] }}\t{{ hostvars[host]['inventory_hostname_short'] }}\n{% endif %}{% endfor %}"
+        - "# SAP HANA scale-out workers\n{% for host in (groups[sap_vm_provision_group_hana_primary] | reject('regex', '0$') | list)[:-1] %}{% if (host != inventory_hostname_short) %}{{ hostvars[host]['ansible_host'] }}\t{{ hostvars[host]['ansible_fqdn'] }}\t{{ hostvars[host]['inventory_hostname_short'] }}\n{% endif %}{% endfor %}"
       loop_control:
         label: "{{ inventory_hostname_short }}"
       when: sap_vm_provision_calculate_sap_hana_scaleout_standby > 0
@@ -54,9 +54,9 @@
         line: "{{ item }}"
         state: present
       loop:
-        - "# SAP HANA scale-out standby\n{{ hostvars[(groups['hana_primary'][-1])]['ansible_host'] }}\t{{ hostvars[(groups['hana_primary'][-1])]['ansible_fqdn'] }}\t{{ hostvars[(groups['hana_primary'][-1])]['inventory_hostname_short'] }}"
+        - "# SAP HANA scale-out standby\n{{ hostvars[(groups[sap_vm_provision_group_hana_primary][-1])]['ansible_host'] }}\t{{ hostvars[(groups[sap_vm_provision_group_hana_primary][-1])]['ansible_fqdn'] }}\t{{ hostvars[(groups[sap_vm_provision_group_hana_primary][-1])]['inventory_hostname_short'] }}"
       loop_control:
         label: "{{ inventory_hostname_short }}"
       when:
         - sap_vm_provision_calculate_sap_hana_scaleout_standby > 0
-        - not inventory_hostname_short == hostvars[(groups['hana_primary'] | last)]['inventory_hostname_short']
+        - not inventory_hostname_short == hostvars[(groups[sap_vm_provision_group_hana_primary] | last)]['inventory_hostname_short']

--- a/roles/sap_vm_provision/tasks/platform_ansible/aws_ec2_vs/execute_main.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/aws_ec2_vs/execute_main.yml
@@ -31,9 +31,9 @@
         access_key: "{{ sap_vm_provision_aws_access_key }}"
         secret_key: "{{ sap_vm_provision_aws_secret_access_key }}"
       loop:
-        - "{{ 'hana'  if 'hana_secondary' in lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan] | json_query('*') | map(attribute='sap_host_type') else '' }}"
-        - "{{ 'anydb' if 'anydb_secondary' in lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan] | json_query('*') | map(attribute='sap_host_type') else '' }}"
-        - "{{ 'nwas'  if 'nwas_ers' in lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan] | json_query('*') | map(attribute='sap_host_type') else '' }}"
+        - "{{ 'hana'  if sap_vm_provision_group_hana_secondary in lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan] | json_query('*') | map(attribute='sap_host_type') else '' }}"
+        - "{{ 'anydb' if sap_vm_provision_group_anydb_secondary in lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan] | json_query('*') | map(attribute='sap_host_type') else '' }}"
+        - "{{ 'nwas'  if sap_vm_provision_group_nwas_ers in lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan] | json_query('*') | map(attribute='sap_host_type') else '' }}"
       when:
         - sap_vm_provision_aws_placement_resource_name is defined
         - sap_vm_provision_aws_placement_strategy_spread
@@ -82,7 +82,7 @@
 
     - name: Set fact to hold all inventory hosts in all groups
       ansible.builtin.set_fact:
-        groups_merged_list: "{{ [ [ groups['hana_primary'] | default([]) ] , [ groups['hana_secondary'] | default([]) ] , [ groups['anydb_primary'] | default([]) ] , [ groups['anydb_secondary'] | default([]) ] , [ groups['nwas_ascs'] | default([]) ] , [ groups['nwas_ers'] | default([]) ] , [ groups['nwas_pas'] | default([]) ] , [ groups['nwas_aas'] | default([]) ] ] | flatten | select() }}"
+        groups_merged_list: "{{ [ [ groups[sap_vm_provision_group_hana_primary] | default([]) ] , [ groups[sap_vm_provision_group_hana_secondary] | default([]) ] , [ groups[sap_vm_provision_group_anydb_primary] | default([]) ] , [ groups[sap_vm_provision_group_anydb_secondary] | default([]) ] , [ groups[sap_vm_provision_group_nwas_ascs] | default([]) ] , [ groups[sap_vm_provision_group_nwas_ers] | default([]) ] , [ groups[sap_vm_provision_group_nwas_pas] | default([]) ] , [ groups[sap_vm_provision_group_nwas_aas] | default([]) ] ] | flatten | select() }}"
 
     - name: Set Ansible Vars
       register: __sap_vm_provision_task_ansible_vars_set
@@ -157,14 +157,14 @@
       ansible.builtin.include_tasks:
         file: common/set_etc_hosts_ha.yml
       when:
-        - (groups["hana_secondary"] is defined and (groups["hana_secondary"] | length>0)) or (groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0)) or (groups["anydb_secondary"] is defined and (groups["anydb_secondary"] | length>0))
+        - (groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary] | length>0)) or (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0)) or (groups[sap_vm_provision_group_anydb_secondary] is defined and (groups[sap_vm_provision_group_anydb_secondary] | length>0))
 
     - name: Set /etc/hosts for Scale-Out
       register: __sap_vm_provision_task_os_etc_hosts_scaleout
       ansible.builtin.include_tasks:
         file: common/set_etc_hosts_scaleout.yml
       when:
-        - (groups["hana_primary"] is defined and (groups["hana_primary"] | length>0)) and (sap_vm_provision_calculate_sap_hana_scaleout_active_coordinator is defined or sap_vm_provision_calculate_sap_hana_scaleout_active_worker is defined or sap_vm_provision_calculate_sap_hana_scaleout_standby is defined)
+        - (groups[sap_vm_provision_group_hana_primary] is defined and (groups[sap_vm_provision_group_hana_primary] | length>0)) and (sap_vm_provision_calculate_sap_hana_scaleout_active_coordinator is defined or sap_vm_provision_calculate_sap_hana_scaleout_active_worker is defined or sap_vm_provision_calculate_sap_hana_scaleout_standby is defined)
 
     - name: Set vars for sap_storage_setup Ansible Role
       register: __sap_vm_provision_task_ansible_vars_storage
@@ -188,7 +188,7 @@
     AWS_REGION: "{{ sap_vm_provision_aws_region }}"
   when:
     - sap_ha_pacemaker_cluster_aws_region is defined
-    - (groups["hana_secondary"] is defined and (groups["hana_secondary"] | length>0)) or (groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0)) or (groups["anydb_secondary"] is defined and (groups["anydb_secondary"] | length>0))
+    - (groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary] | length>0)) or (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0)) or (groups[sap_vm_provision_group_anydb_secondary] is defined and (groups[sap_vm_provision_group_anydb_secondary] | length>0))
   block:
 
     - name: Provision High Availability resources for AWS EC2 hosts

--- a/roles/sap_vm_provision/tasks/platform_ansible/aws_ec2_vs/execute_provision.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/aws_ec2_vs/execute_provision.yml
@@ -46,13 +46,13 @@
       availability_zone: "{{ sap_vm_provision_aws_vpc_availability_zone }}"
       group_name: "{{ (
         (__sap_vm_provision_task_aws_placement_group.results | selectattr('item','==','hana'))[0].name
-        if ('hana_primary' in target_provision_host_spec.sap_host_type or 'hana_secondary' in target_provision_host_spec.sap_host_type)
+        if (sap_vm_provision_group_hana_primary in target_provision_host_spec.sap_host_type or sap_vm_provision_group_hana_secondary in target_provision_host_spec.sap_host_type)
         else
         (__sap_vm_provision_task_aws_placement_group.results | selectattr('item','==','anydb'))[0].name
-        if ('anydb_primary' in target_provision_host_spec.sap_host_type or 'anydb_secondary' in target_provision_host_spec.sap_host_type)
+        if (sap_vm_provision_group_anydb_primary in target_provision_host_spec.sap_host_type or sap_vm_provision_group_anydb_secondary in target_provision_host_spec.sap_host_type)
         else
         (__sap_vm_provision_task_aws_placement_group.results | selectattr('item','==','nwas'))[0].name
-        if ('nwas_ascs' in target_provision_host_spec.sap_host_type or 'nwas_ers' in target_provision_host_spec.sap_host_type)
+        if (sap_vm_provision_group_nwas_ascs in target_provision_host_spec.sap_host_type or sap_vm_provision_group_nwas_ers in target_provision_host_spec.sap_host_type)
         ) | default(omit) }}"
       tenancy: default # default is shared tenancy
 

--- a/roles/sap_vm_provision/tasks/platform_ansible/aws_ec2_vs/execute_setup_ha.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/aws_ec2_vs/execute_setup_ha.yml
@@ -31,11 +31,11 @@
         instance_id: "{{ hostvars[host_node].ansible_board_asset_tag }}"
     access_key: "{{ sap_vm_provision_aws_access_key }}"
     secret_key: "{{ sap_vm_provision_aws_secret_access_key }}"
-  loop: "{{ (groups['hana_primary'] | default([])) }}"
+  loop: "{{ (groups[sap_vm_provision_group_hana_primary] | default([])) }}"
   loop_control:
     loop_var: host_node
   when:
-    - groups["hana_secondary"] is defined and (groups["hana_secondary"] | length>0)
+    - groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary] | length>0)
 
 - name: Ansible AWS Route53 DNS Records for SAP HANA HA Virtual Hostname
   register: __sap_vm_provision_task_aws_route53_sap_hana
@@ -52,11 +52,11 @@
     access_key: "{{ sap_vm_provision_aws_access_key }}"
     secret_key: "{{ sap_vm_provision_aws_secret_access_key }}"
     overwrite: "{{ sap_vm_provision_aws_dns_overwrite if sap_vm_provision_aws_dns_overwrite | bool else false }}"
-  loop: "{{ (groups['hana_primary'] | default([])) }}"
+  loop: "{{ (groups[sap_vm_provision_group_hana_primary] | default([])) }}"
   loop_control:
     loop_var: host_node
   when:
-    - groups["hana_secondary"] is defined and (groups["hana_secondary"]|length>0)
+    - groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary]|length>0)
 
 - name: Ansible AWS VPC Route Table append route for SAP AnyDB HA
   register: __sap_vm_provision_task_aws_vpc_subnet_rt_route_sap_anydb
@@ -73,11 +73,11 @@
         instance_id: "{{ hostvars[host_node].ansible_board_asset_tag }}"
     access_key: "{{ sap_vm_provision_aws_access_key }}"
     secret_key: "{{ sap_vm_provision_aws_secret_access_key }}"
-  loop: "{{ (groups['anydb_primary'] | default([])) }}"
+  loop: "{{ (groups[sap_vm_provision_group_anydb_primary] | default([])) }}"
   loop_control:
     loop_var: host_node
   when:
-    - groups["anydb_secondary"] is defined and (groups["anydb_secondary"] | length>0)
+    - groups[sap_vm_provision_group_anydb_secondary] is defined and (groups[sap_vm_provision_group_anydb_secondary] | length>0)
 
 - name: Ansible AWS Route53 DNS Records for SAP AnyDB HA Virtual Hostname
   register: __sap_vm_provision_task_aws_route53_sap_anydb
@@ -94,11 +94,11 @@
     access_key: "{{ sap_vm_provision_aws_access_key }}"
     secret_key: "{{ sap_vm_provision_aws_secret_access_key }}"
     overwrite: "{{ sap_vm_provision_aws_dns_overwrite if sap_vm_provision_aws_dns_overwrite | bool else false }}"
-  loop: "{{ (groups['anydb_primary'] | default([])) }}"
+  loop: "{{ (groups[sap_vm_provision_group_anydb_primary] | default([])) }}"
   loop_control:
     loop_var: host_node
   when:
-    - groups["anydb_secondary"] is defined and (groups["anydb_secondary"]|length>0)
+    - groups[sap_vm_provision_group_anydb_secondary] is defined and (groups[sap_vm_provision_group_anydb_secondary]|length>0)
 
 - name: Ansible AWS VPC Route Table append route for SAP NetWeaver ASCS HA
   register: __sap_vm_provision_task_aws_vpc_subnet_rt_route_sap_netweaver_ascs
@@ -115,11 +115,11 @@
         instance_id: "{{ hostvars[host_node].ansible_board_asset_tag }}"
     access_key: "{{ sap_vm_provision_aws_access_key }}"
     secret_key: "{{ sap_vm_provision_aws_secret_access_key }}"
-  loop: "{{ (groups['nwas_ascs'] | default([])) }}"
+  loop: "{{ (groups[sap_vm_provision_group_nwas_ascs] | default([])) }}"
   loop_control:
     loop_var: host_node
   when:
-    - groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0)
+    - groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0)
 
 - name: Ansible AWS Route53 DNS Records for SAP NetWeaver ASCS HA Virtual Hostname
   register: __sap_vm_provision_task_aws_route53_sap_netweaver_ascs
@@ -136,11 +136,11 @@
     access_key: "{{ sap_vm_provision_aws_access_key }}"
     secret_key: "{{ sap_vm_provision_aws_secret_access_key }}"
     overwrite: "{{ sap_vm_provision_aws_dns_overwrite if sap_vm_provision_aws_dns_overwrite | bool else false }}"
-  loop: "{{ (groups['nwas_ascs'] | default([])) }}"
+  loop: "{{ (groups[sap_vm_provision_group_nwas_ascs] | default([])) }}"
   loop_control:
     loop_var: host_node
   when:
-    - groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
+    - groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers]|length>0)
 
 - name: Ansible AWS VPC Route Table append route for SAP NetWeaver ERS HA
   register: __sap_vm_provision_task_aws_vpc_subnet_rt_route_sap_netweaver_ers
@@ -157,11 +157,11 @@
         instance_id: "{{ hostvars[host_node].ansible_board_asset_tag }}"
     access_key: "{{ sap_vm_provision_aws_access_key }}"
     secret_key: "{{ sap_vm_provision_aws_secret_access_key }}"
-  loop: "{{ (groups['nwas_ers'] | default([])) }}"
+  loop: "{{ (groups[sap_vm_provision_group_nwas_ers] | default([])) }}"
   loop_control:
     loop_var: host_node
   when:
-    - groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0)
+    - groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0)
 
 - name: Ansible AWS Route53 DNS Records for SAP NetWeaver ERS HA Virtual Hostname
   register: __sap_vm_provision_task_aws_route53_sap_netweaver_ers
@@ -178,11 +178,11 @@
     access_key: "{{ sap_vm_provision_aws_access_key }}"
     secret_key: "{{ sap_vm_provision_aws_secret_access_key }}"
     overwrite: "{{ sap_vm_provision_aws_dns_overwrite if sap_vm_provision_aws_dns_overwrite | bool else false }}"
-  loop: "{{ (groups['nwas_ers'] | default([])) }}"
+  loop: "{{ (groups[sap_vm_provision_group_nwas_ers] | default([])) }}"
   loop_control:
     loop_var: host_node
   when:
-    - groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
+    - groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers]|length>0)
 
 ## For HA of PAS and AAS, if required
 
@@ -199,11 +199,11 @@
 #     routes:
 #       - dest: "{{ sap_vm_provision_ha_vip_nwas_abap_pas }}"
 #         instance_id: "{{ hostvars[host_node].ansible_board_asset_tag }}"
-#   loop: "{{ (groups['nwas_pas'] | default([])) }}"
+#   loop: "{{ (groups[sap_vm_provision_group_nwas_pas] | default([])) }}"
 #   loop_control:
 #     loop_var: host_node
 #   when:
-#     - groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0)
+#     - groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0)
 
 # - name: Ansible AWS Route53 DNS Records for SAP NetWeaver PAS HA Virtual Hostname
 #   amazon.aws.route53:
@@ -215,11 +215,11 @@
 #     ttl: 7200
 #     value: "{{ sap_vm_provision_ha_vip_nwas_abap_pas | regex_replace('/.*', '') }}"
 #     wait: true
-#   loop: "{{ (groups['nwas_pas'] | default([])) }}"
+#   loop: "{{ (groups[sap_vm_provision_group_nwas_pas] | default([])) }}"
 #   loop_control:
 #     loop_var: host_node
 #   when:
-#     - groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
+#     - groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers]|length>0)
 
 
 # - name: Ansible AWS VPC Route Table append route for SAP NetWeaver AAS HA
@@ -235,11 +235,11 @@
 #     routes:
 #       - dest: "{{ sap_vm_provision_ha_vip_nwas_abap_aas }}"
 #         instance_id: "{{ hostvars[host_node].ansible_board_asset_tag }}"
-#   loop: "{{ (groups['nwas_aas'] | default([])) }}"
+#   loop: "{{ (groups[sap_vm_provision_group_nwas_aas] | default([])) }}"
 #   loop_control:
 #     loop_var: host_node
 #   when:
-#     - groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0)
+#     - groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0)
 
 # - name: Ansible AWS Route53 DNS Records for SAP NetWeaver AAS HA Virtual Hostname
 #   amazon.aws.route53:
@@ -251,11 +251,11 @@
 #     ttl: 7200
 #     value: "{{ sap_vm_provision_ha_vip_nwas_abap_aas | regex_replace('/.*', '') }}"
 #     wait: true
-#   loop: "{{ (groups['nwas_aas'] | default([])) }}"
+#   loop: "{{ (groups[sap_vm_provision_group_nwas_aas] | default([])) }}"
 #   loop_control:
 #     loop_var: host_node
 #   when:
-#     - groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
+#     - groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers]|length>0)
 
 
 # Setup custom IAM Role name using sap_vm_provision_aws_ha_iam_role
@@ -398,16 +398,16 @@
                   ],
                   "Resource": [
                       "arn:aws:ec2:{{ sap_vm_provision_aws_region }}:{{ __sap_vm_provision_task_aws_account_info.account }}:instance/{{
-                       hostvars[groups['hana_primary'][0]].__sap_vm_provision_task_provision_host_single_info.instances[0].instance_id }}",
+                       hostvars[groups[sap_vm_provision_group_hana_primary][0]].__sap_vm_provision_task_provision_host_single_info.instances[0].instance_id }}",
                       "arn:aws:ec2:{{ sap_vm_provision_aws_region }}:{{ __sap_vm_provision_task_aws_account_info.account }}:instance/{{
-                       hostvars[groups['hana_secondary'][0]].__sap_vm_provision_task_provision_host_single_info.instances[0].instance_id }}"
+                       hostvars[groups[sap_vm_provision_group_hana_secondary][0]].__sap_vm_provision_task_provision_host_single_info.instances[0].instance_id }}"
                   ]
               }
           ]
       }
     access_key: "{{ sap_vm_provision_aws_access_key }}"
     secret_key: "{{ sap_vm_provision_aws_secret_access_key }}"
-  when: groups["hana_secondary"] is defined and (groups["hana_secondary"]|length>0)
+  when: groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary]|length>0)
 
 # AWS HA for SAP - STONITH of SAP ANYDB
 - name: AWS IAM Policy - HA-Policy-STONITH-SAPANYDB
@@ -443,16 +443,16 @@
                   ],
                   "Resource": [
                       "arn:aws:ec2:{{ sap_vm_provision_aws_region }}:{{ __sap_vm_provision_task_aws_account_info.account }}:instance/{{
-                       hostvars[groups['anydb_primary'][0]].__sap_vm_provision_task_provision_host_single_info.instances[0].instance_id }}",
+                       hostvars[groups[sap_vm_provision_group_anydb_primary][0]].__sap_vm_provision_task_provision_host_single_info.instances[0].instance_id }}",
                       "arn:aws:ec2:{{ sap_vm_provision_aws_region }}:{{ __sap_vm_provision_task_aws_account_info.account }}:instance/{{
-                       hostvars[groups['anydb_secondary'][0]].__sap_vm_provision_task_provision_host_single_info.instances[0].instance_id }}"
+                       hostvars[groups[sap_vm_provision_group_anydb_secondary][0]].__sap_vm_provision_task_provision_host_single_info.instances[0].instance_id }}"
                   ]
               }
           ]
       }
     access_key: "{{ sap_vm_provision_aws_access_key }}"
     secret_key: "{{ sap_vm_provision_aws_secret_access_key }}"
-  when: groups["anydb_secondary"] is defined and (groups["anydb_secondary"]|length>0)
+  when: groups[sap_vm_provision_group_anydb_secondary] is defined and (groups[sap_vm_provision_group_anydb_secondary]|length>0)
 
 # AWS HA for SAP - STONITH of SAP NWAS
 - name: AWS IAM Policy - HA-Policy-STONITH-SAPNWAS
@@ -487,16 +487,16 @@
                   ],
                   "Resource": [
                       "arn:aws:ec2:{{ sap_vm_provision_aws_region }}:{{ __sap_vm_provision_task_aws_account_info.account }}:instance/{{
-                       hostvars[groups['nwas_ascs'][0]].__sap_vm_provision_task_provision_host_single_info.instances[0].instance_id }}",
+                       hostvars[groups[sap_vm_provision_group_nwas_ascs][0]].__sap_vm_provision_task_provision_host_single_info.instances[0].instance_id }}",
                       "arn:aws:ec2:{{ sap_vm_provision_aws_region }}:{{ __sap_vm_provision_task_aws_account_info.account }}:instance/{{
-                       hostvars[groups['nwas_ers'][0]].__sap_vm_provision_task_provision_host_single_info.instances[0].instance_id }}"
+                       hostvars[groups[sap_vm_provision_group_nwas_ers][0]].__sap_vm_provision_task_provision_host_single_info.instances[0].instance_id }}"
                   ]
               }
           ]
       }
     access_key: "{{ sap_vm_provision_aws_access_key }}"
     secret_key: "{{ sap_vm_provision_aws_secret_access_key }}"
-  when: groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
+  when: groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers]|length>0)
 
 
 - name: AWS IAM Role - Prepare IAM Instance Profile name
@@ -529,10 +529,10 @@
     iam_instance_profile: "{{ __sap_vm_provision_aws_ha_iam_instance_profile }}"
     access_key: "{{ sap_vm_provision_aws_access_key }}"
     secret_key: "{{ sap_vm_provision_aws_secret_access_key }}"
-  loop: "{{ [ [ groups['hana_primary'] | default([]) ] , [ groups['hana_secondary'] | default([]) ] ] | flatten | select() }}"
+  loop: "{{ [ [ groups[sap_vm_provision_group_hana_primary] | default([]) ] , [ groups[sap_vm_provision_group_hana_secondary] | default([]) ] ] | flatten | select() }}"
   loop_control:
     loop_var: host_node
-  when: groups["hana_secondary"] is defined and (groups["hana_secondary"]|length>0)
+  when: groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary]|length>0)
   ignore_errors: true
 
 # Equivalent to aws ec2 associate-iam-instance-profile --iam-instance-profile "Name=HA-Instance-Profile-Pacemaker-Cluster" --instance-id {{ hostvars[host_node].ansible_board_asset_tag }}
@@ -544,10 +544,10 @@
     iam_instance_profile: "{{ __sap_vm_provision_aws_ha_iam_instance_profile }}"
     access_key: "{{ sap_vm_provision_aws_access_key }}"
     secret_key: "{{ sap_vm_provision_aws_secret_access_key }}"
-  loop: "{{ [ [ groups['anydb_primary'] | default([]) ] , [ groups['anydb_secondary'] | default([]) ] ] | flatten | select() }}"
+  loop: "{{ [ [ groups[sap_vm_provision_group_anydb_primary] | default([]) ] , [ groups[sap_vm_provision_group_anydb_secondary] | default([]) ] ] | flatten | select() }}"
   loop_control:
     loop_var: host_node
-  when: groups["anydb_secondary"] is defined and (groups["anydb_secondary"]|length>0)
+  when: groups[sap_vm_provision_group_anydb_secondary] is defined and (groups[sap_vm_provision_group_anydb_secondary]|length>0)
   ignore_errors: true
 
 # Equivalent to aws ec2 associate-iam-instance-profile --iam-instance-profile "Name=HA-Instance-Profile-Pacemaker-Cluster" --instance-id {{ hostvars[host_node].ansible_board_asset_tag }}
@@ -559,8 +559,8 @@
     iam_instance_profile: "{{ __sap_vm_provision_aws_ha_iam_instance_profile }}"
     access_key: "{{ sap_vm_provision_aws_access_key }}"
     secret_key: "{{ sap_vm_provision_aws_secret_access_key }}"
-  loop: "{{ [ [ groups['nwas_ascs'] | default([]) ] , [ groups['nwas_ers'] | default([]) ] , [ groups['nwas_pas'] | default([]) ] , [ groups['nwas_aas'] | default([]) ] ] | flatten | select() }}"
+  loop: "{{ [ [ groups[sap_vm_provision_group_nwas_ascs] | default([]) ] , [ groups[sap_vm_provision_group_nwas_ers] | default([]) ] , [ groups[sap_vm_provision_group_nwas_pas] | default([]) ] , [ groups[sap_vm_provision_group_nwas_aas] | default([]) ] ] | flatten | select() }}"
   loop_control:
     loop_var: host_node
-  when: groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
+  when: groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers]|length>0)
   ignore_errors: true

--- a/roles/sap_vm_provision/tasks/platform_ansible/gcp_ce_vm/execute_main.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/gcp_ce_vm/execute_main.yml
@@ -121,7 +121,7 @@
 
     - name: Set fact to hold all inventory hosts in all groups
       ansible.builtin.set_fact:
-        groups_merged_list: "{{ [ [ groups['hana_primary'] | default([]) ] , [ groups['hana_secondary'] | default([]) ] , [ groups['anydb_primary'] | default([]) ] , [ groups['anydb_secondary'] | default([]) ] , [ groups['nwas_ascs'] | default([]) ] , [ groups['nwas_ers'] | default([]) ] , [ groups['nwas_pas'] | default([]) ] , [ groups['nwas_aas'] | default([]) ] ] | flatten | select() }}"
+        groups_merged_list: "{{ [ [ groups[sap_vm_provision_group_hana_primary] | default([]) ] , [ groups[sap_vm_provision_group_hana_secondary] | default([]) ] , [ groups[sap_vm_provision_group_anydb_primary] | default([]) ] , [ groups[sap_vm_provision_group_anydb_secondary] | default([]) ] , [ groups[sap_vm_provision_group_nwas_ascs] | default([]) ] , [ groups[sap_vm_provision_group_nwas_ers] | default([]) ] , [ groups[sap_vm_provision_group_nwas_pas] | default([]) ] , [ groups[sap_vm_provision_group_nwas_aas] | default([]) ] ] | flatten | select() }}"
 
     - name: Set Ansible Vars
       register: __sap_vm_provision_task_ansible_vars_set
@@ -293,14 +293,14 @@
       ansible.builtin.include_tasks:
         file: common/set_etc_hosts_ha.yml
       when:
-        - (groups["hana_secondary"] is defined and (groups["hana_secondary"] | length>0)) or (groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0)) or (groups["anydb_secondary"] is defined and (groups["anydb_secondary"] | length>0))
+        - (groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary] | length>0)) or (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0)) or (groups[sap_vm_provision_group_anydb_secondary] is defined and (groups[sap_vm_provision_group_anydb_secondary] | length>0))
 
     - name: Set /etc/hosts for Scale-Out
       register: __sap_vm_provision_task_os_etc_hosts_scaleout
       ansible.builtin.include_tasks:
         file: common/set_etc_hosts_scaleout.yml
       when:
-        - (groups["hana_primary"] is defined and (groups["hana_primary"] | length>0)) and (sap_vm_provision_calculate_sap_hana_scaleout_active_coordinator is defined or sap_vm_provision_calculate_sap_hana_scaleout_active_worker is defined or sap_vm_provision_calculate_sap_hana_scaleout_standby is defined)
+        - (groups[sap_vm_provision_group_hana_primary] is defined and (groups[sap_vm_provision_group_hana_primary] | length>0)) and (sap_vm_provision_calculate_sap_hana_scaleout_active_coordinator is defined or sap_vm_provision_calculate_sap_hana_scaleout_active_worker is defined or sap_vm_provision_calculate_sap_hana_scaleout_standby is defined)
 
     - name: Set vars for sap_storage_setup Ansible Role
       register: __sap_vm_provision_task_ansible_vars_storage
@@ -316,7 +316,7 @@
   delegate_to: "{{ inventory_hostname }}"
   when:
     - sap_ha_pacemaker_cluster_gcp_region_zone is defined
-    - (groups["hana_secondary"] is defined and (groups["hana_secondary"] | length>0)) or (groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0)) or (groups["anydb_secondary"] is defined and (groups["anydb_secondary"] | length>0))
+    - (groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary] | length>0)) or (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0)) or (groups[sap_vm_provision_group_anydb_secondary] is defined and (groups[sap_vm_provision_group_anydb_secondary] | length>0))
   block:
 
     - name: Stop firewalld on all hosts before setup of Google Cloud Load Balancer
@@ -368,7 +368,7 @@
   #   GCP_SERVICE_ACCOUNT_FILE: "{{ sap_vm_provision_gcp_credentials_json }}"
   when:
     - sap_ha_pacemaker_cluster_gcp_region_zone is defined
-    - (groups["hana_secondary"] is defined and (groups["hana_secondary"] | length>0)) or (groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0)) or (groups["anydb_secondary"] is defined and (groups["anydb_secondary"] | length>0))
+    - (groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary] | length>0)) or (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0)) or (groups[sap_vm_provision_group_anydb_secondary] is defined and (groups[sap_vm_provision_group_anydb_secondary] | length>0))
   block:
 
     - name: Provision High Availability resources for GCP CE hosts

--- a/roles/sap_vm_provision/tasks/platform_ansible/gcp_ce_vm/execute_setup_ha.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/gcp_ce_vm/execute_setup_ha.yml
@@ -17,11 +17,11 @@
 #       selfLink: "{{ __sap_vm_provision_task_gcp_vpc_info.resources[0].selfLink }}"
 #     auth_kind: "serviceaccount"
 #     service_account_file: "{{ sap_vm_provision_gcp_credentials_json }}"
-#   loop: "{{ (groups['hana_primary'] | default([])) }}"
+#   loop: "{{ (groups[sap_vm_provision_group_hana_primary] | default([])) }}"
 #   loop_control:
 #     loop_var: host_node
 #   when:
-#     - groups["hana_secondary"] is defined and (groups["hana_secondary"] | length>0)
+#     - groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary] | length>0)
 
 - name: GCP Private DNS Record for SAP HANA HA Virtual Hostname
   no_log: "{{ __sap_vm_provision_no_log }}"
@@ -38,11 +38,11 @@
     ttl: 7200
     auth_kind: "serviceaccount"
     service_account_file: "{{ sap_vm_provision_gcp_credentials_json }}"
-  loop: "{{ (groups['hana_primary'] | default([])) }}"
+  loop: "{{ (groups[sap_vm_provision_group_hana_primary] | default([])) }}"
   loop_control:
     loop_var: host_node
   when:
-    - groups["hana_secondary"] is defined and (groups["hana_secondary"]|length>0)
+    - groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary]|length>0)
 
 
 # - name: GCP append route for SAP AnyDB HA (route must be outside of existing VPC Subnet Range/s)
@@ -59,11 +59,11 @@
 #       selfLink: "{{ __sap_vm_provision_task_gcp_vpc_info.resources[0].selfLink }}"
 #     auth_kind: "serviceaccount"
 #     service_account_file: "{{ sap_vm_provision_gcp_credentials_json }}"
-#   loop: "{{ (groups['anydb_primary'] | default([])) }}"
+#   loop: "{{ (groups[sap_vm_provision_group_anydb_primary] | default([])) }}"
 #   loop_control:
 #     loop_var: host_node
 #   when:
-#     - groups["hana_secondary"] is defined and (groups["hana_secondary"] | length>0)
+#     - groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary] | length>0)
 
 - name: GCP Private DNS Record for SAP AnyDB HA Virtual Hostname
   no_log: "{{ __sap_vm_provision_no_log }}"
@@ -80,11 +80,11 @@
     ttl: 7200
     auth_kind: "serviceaccount"
     service_account_file: "{{ sap_vm_provision_gcp_credentials_json }}"
-  loop: "{{ (groups['anydb_primary'] | default([])) }}"
+  loop: "{{ (groups[sap_vm_provision_group_anydb_primary] | default([])) }}"
   loop_control:
     loop_var: host_node
   when:
-    - groups["hana_secondary"] is defined and (groups["hana_secondary"]|length>0)
+    - groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary]|length>0)
 
 
 # - name: GCP append route for SAP NetWeaver ASCS HA (route must be outside of existing VPC Subnet Range/s)
@@ -101,11 +101,11 @@
 #       selfLink: "{{ __sap_vm_provision_task_gcp_vpc_info.resources[0].selfLink }}"
 #     auth_kind: "serviceaccount"
 #     service_account_file: "{{ sap_vm_provision_gcp_credentials_json }}"
-#   loop: "{{ (groups['nwas_ascs'] | default([])) }}"
+#   loop: "{{ (groups[sap_vm_provision_group_nwas_ascs] | default([])) }}"
 #   loop_control:
 #     loop_var: host_node
 #   when:
-#     - groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0)
+#     - groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0)
 
 - name: GCP Private DNS Record for SAP NetWeaver ASCS HA Virtual Hostname
   no_log: "{{ __sap_vm_provision_no_log }}"
@@ -122,11 +122,11 @@
     ttl: 7200
     auth_kind: "serviceaccount"
     service_account_file: "{{ sap_vm_provision_gcp_credentials_json }}"
-  loop: "{{ (groups['nwas_ascs'] | default([])) }}"
+  loop: "{{ (groups[sap_vm_provision_group_nwas_ascs] | default([])) }}"
   loop_control:
     loop_var: host_node
   when:
-    - groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
+    - groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers]|length>0)
 
 
 # - name: GCP append route for SAP NetWeaver ERS HA
@@ -143,11 +143,11 @@
 #       selfLink: "{{ __sap_vm_provision_task_gcp_vpc_info.resources[0].selfLink }}"
 #     auth_kind: "serviceaccount"
 #     service_account_file: "{{ sap_vm_provision_gcp_credentials_json }}"
-#   loop: "{{ (groups['nwas_ers'] | default([])) }}"
+#   loop: "{{ (groups[sap_vm_provision_group_nwas_ers] | default([])) }}"
 #   loop_control:
 #     loop_var: host_node
 #   when:
-#     - groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0)
+#     - groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0)
 
 - name: GCP Private DNS Record for SAP NetWeaver ERS HA Virtual Hostname
   no_log: "{{ __sap_vm_provision_no_log }}"
@@ -164,11 +164,11 @@
     ttl: 7200
     auth_kind: "serviceaccount"
     service_account_file: "{{ sap_vm_provision_gcp_credentials_json }}"
-  loop: "{{ (groups['nwas_ers'] | default([])) }}"
+  loop: "{{ (groups[sap_vm_provision_group_nwas_ers] | default([])) }}"
   loop_control:
     loop_var: host_node
   when:
-    - groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
+    - groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers]|length>0)
 
 
 ## For HA of PAS and AAS, if required
@@ -187,11 +187,11 @@
 #       selfLink: "{{ __sap_vm_provision_task_gcp_vpc_info.resources[0].selfLink }}"
 #     auth_kind: "serviceaccount"
 #     service_account_file: "{{ sap_vm_provision_gcp_credentials_json }}"
-#   loop: "{{ (groups['nwas_pas'] | default([])) }}"
+#   loop: "{{ (groups[sap_vm_provision_group_nwas_pas] | default([])) }}"
 #   loop_control:
 #     loop_var: host_node
 #   when:
-#     - groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0)
+#     - groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0)
 
 # - name: GCP Private DNS Record for SAP NetWeaver PAS HA Virtual Hostname
 #   no_log: "{{ __sap_vm_provision_no_log }}"
@@ -208,11 +208,11 @@
 #     ttl: 7200
 #     auth_kind: "serviceaccount"
 #     service_account_file: "{{ sap_vm_provision_gcp_credentials_json }}"
-#   loop: "{{ (groups['nwas_pas'] | default([])) }}"
+#   loop: "{{ (groups[sap_vm_provision_group_nwas_pas] | default([])) }}"
 #   loop_control:
 #     loop_var: host_node
 #   when:
-#     - groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
+#     - groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers]|length>0)
 
 
 # - name: GCP append route for SAP NetWeaver AAS HA
@@ -229,11 +229,11 @@
 #       selfLink: "{{ __sap_vm_provision_task_gcp_vpc_info.resources[0].selfLink }}"
 #     auth_kind: "serviceaccount"
 #     service_account_file: "{{ sap_vm_provision_gcp_credentials_json }}"
-#   loop: "{{ (groups['nwas_aas'] | default([])) }}"
+#   loop: "{{ (groups[sap_vm_provision_group_nwas_aas] | default([])) }}"
 #   loop_control:
 #     loop_var: host_node
 #   when:
-#     - groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0)
+#     - groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0)
 
 # - name: GCP Private DNS Record for SAP NetWeaver AAS HA Virtual Hostname
 #   no_log: "{{ __sap_vm_provision_no_log }}"
@@ -250,11 +250,11 @@
 #     ttl: 7200
 #     auth_kind: "serviceaccount"
 #     service_account_file: "{{ sap_vm_provision_gcp_credentials_json }}"
-#   loop: "{{ (groups['nwas_aas'] | default([])) }}"
+#   loop: "{{ (groups[sap_vm_provision_group_nwas_aas] | default([])) }}"
 #   loop_control:
 #     loop_var: host_node
 #   when:
-#     - groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
+#     - groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers]|length>0)
 
 
 # Google Cloud Load Balancing - Internal passthrough Network Load Balancer (NLB for TCP/UDP) and Reserved Static Internal IP Address
@@ -289,7 +289,7 @@
     service_account_file: "{{ sap_vm_provision_gcp_credentials_json }}"
   when:
     - vip_item | length > 0
-    - groups["hana_secondary"] is defined and (groups["hana_secondary"]|length>0)
+    - groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary]|length>0)
   loop:
     - "{{ sap_vm_provision_ha_vip_hana_primary }}"
   loop_control:
@@ -314,7 +314,7 @@
     auth_kind: "serviceaccount"
     service_account_file: "{{ sap_vm_provision_gcp_credentials_json }}"
   when:
-    - groups["hana_secondary"] is defined and (groups["hana_secondary"]|length>0)
+    - groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary]|length>0)
 
 - name: Gather GCP VM information
   no_log: "{{ __sap_vm_provision_no_log }}"
@@ -330,7 +330,7 @@
   loop_control:
     loop_var: host_node
   when:
-    - groups["hana_secondary"] is defined and (groups["hana_secondary"]|length>0)
+    - groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary]|length>0)
 
 - name: Create Google Cloud Compute Engine Instance Group (Self-Managed/Unmanaged) Primary - for SAP HANA
   no_log: "{{ __sap_vm_provision_no_log }}"
@@ -347,11 +347,11 @@
     #    port: 80 # default
     auth_kind: "serviceaccount"
     service_account_file: "{{ sap_vm_provision_gcp_credentials_json }}"
-  loop: "{{ (groups['hana_primary'] | default([])) }}"
+  loop: "{{ (groups[sap_vm_provision_group_hana_primary] | default([])) }}"
   loop_control:
     loop_var: host_node
   when:
-    - groups["hana_secondary"] is defined and (groups["hana_secondary"]|length>0)
+    - groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary]|length>0)
 
 - name: Create Google Cloud Compute Engine Instance Group (Self-Managed/Unmanaged) Secondary (Failover) - for SAP HANA
   no_log: "{{ __sap_vm_provision_no_log }}"
@@ -368,11 +368,11 @@
     #    port: 80 # default
     auth_kind: "serviceaccount"
     service_account_file: "{{ sap_vm_provision_gcp_credentials_json }}"
-  loop: "{{ (groups['hana_secondary'] | default([])) }}"
+  loop: "{{ (groups[sap_vm_provision_group_hana_secondary] | default([])) }}"
   loop_control:
     loop_var: host_node
   when:
-    - groups["hana_secondary"] is defined and (groups["hana_secondary"]|length>0)
+    - groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary]|length>0)
 
 # Note: Failover Ratio must be 1.0, which enforces failover to Secondary/Failover Instance Group if any VM the Backend Service's Primary Instance Group
 # No option for --global-health-checks ?
@@ -403,7 +403,7 @@
     auth_kind: "serviceaccount"
     service_account_file: "{{ sap_vm_provision_gcp_credentials_json }}"
   when:
-    - groups["hana_secondary"] is defined and (groups["hana_secondary"]|length>0)
+    - groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary]|length>0)
 
 - name: Create Google Cloud Compute Engine Forwarding Rule (aka. Frontend IP and Port) for SAP HANA
   no_log: "{{ __sap_vm_provision_no_log }}"
@@ -426,7 +426,7 @@
     service_account_file: "{{ sap_vm_provision_gcp_credentials_json }}"
   when:
     - vip_item | length > 0
-    - groups["hana_secondary"] is defined and (groups["hana_secondary"]|length>0)
+    - groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary]|length>0)
   loop:
     - "{{ sap_vm_provision_ha_vip_hana_primary }}"
   loop_control:
@@ -444,7 +444,7 @@
     auth_kind: "serviceaccount"
     service_account_file: "{{ sap_vm_provision_gcp_credentials_json }}"
   when:
-    - groups["hana_secondary"] is defined and (groups["hana_secondary"]|length>0)
+    - groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary]|length>0)
 
 
 - name: Create Google Cloud Compute Engine Reserved Static Internal IP Address for the Virtual IP (VIP) of SAP AnyDB
@@ -464,7 +464,7 @@
     service_account_file: "{{ sap_vm_provision_gcp_credentials_json }}"
   when:
     - vip_item | length > 0
-    - groups["anydb_secondary"] is defined and (groups["anydb_secondary"]|length>0)
+    - groups[sap_vm_provision_group_anydb_secondary] is defined and (groups[sap_vm_provision_group_anydb_secondary]|length>0)
   loop:
     - "{{ sap_vm_provision_ha_vip_anydb_primary }}"
   loop_control:
@@ -489,7 +489,7 @@
     auth_kind: "serviceaccount"
     service_account_file: "{{ sap_vm_provision_gcp_credentials_json }}"
   when:
-    - groups["anydb_secondary"] is defined and (groups["anydb_secondary"]|length>0)
+    - groups[sap_vm_provision_group_anydb_secondary] is defined and (groups[sap_vm_provision_group_anydb_secondary]|length>0)
 
 - name: Gather GCP VM information
   no_log: "{{ __sap_vm_provision_no_log }}"
@@ -505,7 +505,7 @@
   loop_control:
     loop_var: host_node
   when:
-    - groups["anydb_secondary"] is defined and (groups["anydb_secondary"]|length>0)
+    - groups[sap_vm_provision_group_anydb_secondary] is defined and (groups[sap_vm_provision_group_anydb_secondary]|length>0)
 
 - name: Create Google Cloud Compute Engine Instance Group (Self-Managed/Unmanaged) Primary - for SAP AnyDB
   no_log: "{{ __sap_vm_provision_no_log }}"
@@ -522,11 +522,11 @@
     #    port: 80 # default
     auth_kind: "serviceaccount"
     service_account_file: "{{ sap_vm_provision_gcp_credentials_json }}"
-  loop: "{{ (groups['anydb_primary'] | default([])) }}"
+  loop: "{{ (groups[sap_vm_provision_group_anydb_primary] | default([])) }}"
   loop_control:
     loop_var: host_node
   when:
-    - groups["anydb_secondary"] is defined and (groups["anydb_secondary"]|length>0)
+    - groups[sap_vm_provision_group_anydb_secondary] is defined and (groups[sap_vm_provision_group_anydb_secondary]|length>0)
 
 - name: Create Google Cloud Compute Engine Instance Group (Self-Managed/Unmanaged) Secondary (Failover) - for SAP AnyDB
   no_log: "{{ __sap_vm_provision_no_log }}"
@@ -543,11 +543,11 @@
     #    port: 80 # default
     auth_kind: "serviceaccount"
     service_account_file: "{{ sap_vm_provision_gcp_credentials_json }}"
-  loop: "{{ (groups['anydb_secondary'] | default([])) }}"
+  loop: "{{ (groups[sap_vm_provision_group_anydb_secondary] | default([])) }}"
   loop_control:
     loop_var: host_node
   when:
-    - groups["anydb_secondary"] is defined and (groups["anydb_secondary"]|length>0)
+    - groups[sap_vm_provision_group_anydb_secondary] is defined and (groups[sap_vm_provision_group_anydb_secondary]|length>0)
 
 # Note: Failover Ratio must be 1.0, which enforces failover to Secondary/Failover Instance Group if any VM the Backend Service's Primary Instance Group
 # No option for --global-health-checks ?
@@ -578,7 +578,7 @@
     auth_kind: "serviceaccount"
     service_account_file: "{{ sap_vm_provision_gcp_credentials_json }}"
   when:
-    - groups["anydb_secondary"] is defined and (groups["anydb_secondary"]|length>0)
+    - groups[sap_vm_provision_group_anydb_secondary] is defined and (groups[sap_vm_provision_group_anydb_secondary]|length>0)
 
 - name: Create Google Cloud Compute Engine Forwarding Rule (aka. Frontend IP and Port) for SAP AnyDB
   no_log: "{{ __sap_vm_provision_no_log }}"
@@ -601,7 +601,7 @@
     service_account_file: "{{ sap_vm_provision_gcp_credentials_json }}"
   when:
     - vip_item | length > 0
-    - groups["anydb_secondary"] is defined and (groups["anydb_secondary"]|length>0)
+    - groups[sap_vm_provision_group_anydb_secondary] is defined and (groups[sap_vm_provision_group_anydb_secondary]|length>0)
   loop:
     - "{{ sap_vm_provision_ha_vip_anydb_primary }}"
   loop_control:
@@ -619,7 +619,7 @@
     auth_kind: "serviceaccount"
     service_account_file: "{{ sap_vm_provision_gcp_credentials_json }}"
   when:
-    - groups["anydb_secondary"] is defined and (groups["anydb_secondary"]|length>0)
+    - groups[sap_vm_provision_group_anydb_secondary] is defined and (groups[sap_vm_provision_group_anydb_secondary]|length>0)
 
 
 - name: Create Google Cloud Compute Engine Reserved Static Internal IP Address for the Virtual IP (VIP) of SAP NetWeaver ASCS
@@ -638,7 +638,7 @@
     auth_kind: "serviceaccount"
     service_account_file: "{{ sap_vm_provision_gcp_credentials_json }}"
   when:
-    - groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
+    - groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers]|length>0)
 
 - name: Create Google Cloud Compute Engine Reserved Static Internal IP Address for the Virtual IP (VIP) of SAP NetWeaver ERS
   no_log: "{{ __sap_vm_provision_no_log }}"
@@ -656,7 +656,7 @@
     auth_kind: "serviceaccount"
     service_account_file: "{{ sap_vm_provision_gcp_credentials_json }}"
   when:
-    - groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
+    - groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers]|length>0)
 
 - name: Create Google Cloud Compute Engine Health Check (Global) service instance for SAP NetWeaver ASCS
   no_log: "{{ __sap_vm_provision_no_log }}"
@@ -676,7 +676,7 @@
     auth_kind: "serviceaccount"
     service_account_file: "{{ sap_vm_provision_gcp_credentials_json }}"
   when:
-    - groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
+    - groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers]|length>0)
 
 - name: Create Google Cloud Compute Engine Health Check (Global) service instance for SAP NetWeaver ERS
   no_log: "{{ __sap_vm_provision_no_log }}"
@@ -696,7 +696,7 @@
     auth_kind: "serviceaccount"
     service_account_file: "{{ sap_vm_provision_gcp_credentials_json }}"
   when:
-    - groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
+    - groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers]|length>0)
 
 - name: Gather GCP VM information
   no_log: "{{ __sap_vm_provision_no_log }}"
@@ -712,7 +712,7 @@
   loop_control:
     loop_var: host_node
   when:
-    - groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
+    - groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers]|length>0)
 
 - name: Create Google Cloud Compute Engine Instance Group (Self-Managed/Unmanaged) Primary - for SAP NetWeaver ASCS
   no_log: "{{ __sap_vm_provision_no_log }}"
@@ -729,11 +729,11 @@
     #    port: 80 # default
     auth_kind: "serviceaccount"
     service_account_file: "{{ sap_vm_provision_gcp_credentials_json }}"
-  loop: "{{ (groups['nwas_ascs'] | default([])) }}"
+  loop: "{{ (groups[sap_vm_provision_group_nwas_ascs] | default([])) }}"
   loop_control:
     loop_var: host_node
   when:
-    - groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
+    - groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers]|length>0)
 
 - name: Create Google Cloud Compute Engine Instance Group (Self-Managed/Unmanaged) Secondary (Failover) - for SAP NetWeaver ERS
   no_log: "{{ __sap_vm_provision_no_log }}"
@@ -750,11 +750,11 @@
     #    port: 80 # default
     auth_kind: "serviceaccount"
     service_account_file: "{{ sap_vm_provision_gcp_credentials_json }}"
-  loop: "{{ (groups['nwas_ers'] | default([])) }}"
+  loop: "{{ (groups[sap_vm_provision_group_nwas_ers] | default([])) }}"
   loop_control:
     loop_var: host_node
   when:
-    - groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
+    - groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers]|length>0)
 
 # Note: Failover Ratio must be 1.0, which enforces failover to Secondary/Failover Instance Group if any VM the Backend Service's Primary Instance Group
 # No option for --global-health-checks ?
@@ -785,7 +785,7 @@
     auth_kind: "serviceaccount"
     service_account_file: "{{ sap_vm_provision_gcp_credentials_json }}"
   when:
-    - groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
+    - groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers]|length>0)
 
 # Note: Failover Ratio must be 1.0, which enforces failover to Secondary/Failover Instance Group if any VM the Backend Service's Primary Instance Group
 # No option for --global-health-checks ?
@@ -816,7 +816,7 @@
     auth_kind: "serviceaccount"
     service_account_file: "{{ sap_vm_provision_gcp_credentials_json }}"
   when:
-    - groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
+    - groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers]|length>0)
 
 - name: Create Google Cloud Compute Engine Forwarding Rule (aka. Frontend IP and Port) for SAP NetWeaver ASCS
   no_log: "{{ __sap_vm_provision_no_log }}"
@@ -838,7 +838,7 @@
     auth_kind: "serviceaccount"
     service_account_file: "{{ sap_vm_provision_gcp_credentials_json }}"
   when:
-    - groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
+    - groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers]|length>0)
 
 - name: Create Google Cloud Compute Engine Forwarding Rule (aka. Frontend IP and Port) for SAP NetWeaver ERS
   no_log: "{{ __sap_vm_provision_no_log }}"
@@ -860,7 +860,7 @@
     auth_kind: "serviceaccount"
     service_account_file: "{{ sap_vm_provision_gcp_credentials_json }}"
   when:
-    - groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
+    - groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers]|length>0)
 
 
 - name: Get information on Google Cloud Compute Engine (Regional) Backend Service for SAP NetWeaver ASCS
@@ -874,7 +874,7 @@
     auth_kind: "serviceaccount"
     service_account_file: "{{ sap_vm_provision_gcp_credentials_json }}"
   when:
-    - groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
+    - groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers]|length>0)
 
 - name: Get information on Google Cloud Compute Engine (Regional) Backend Service for SAP NetWeaver ERS
   no_log: "{{ __sap_vm_provision_no_log }}"
@@ -887,4 +887,4 @@
     auth_kind: "serviceaccount"
     service_account_file: "{{ sap_vm_provision_gcp_credentials_json }}"
   when:
-    - groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
+    - groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers]|length>0)

--- a/roles/sap_vm_provision/tasks/platform_ansible/gcp_ce_vm/post_deployment_execute.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/gcp_ce_vm/post_deployment_execute.yml
@@ -10,7 +10,7 @@
   #   GCP_AUTH_KIND: "serviceaccount"
   #   GCP_SERVICE_ACCOUNT_FILE: "{{ sap_vm_provision_gcp_credentials_json }}"
   when:
-    - (groups["hana_secondary"] is defined and (groups["hana_secondary"] | length>0)) or (groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0)) or (groups["anydb_secondary"] is defined and (groups["anydb_secondary"] | length>0))
+    - (groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary] | length>0)) or (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0)) or (groups[sap_vm_provision_group_anydb_secondary] is defined and (groups[sap_vm_provision_group_anydb_secondary] | length>0))
   block:
 
     - name: Inherit variable - set fact for Google Cloud Compute Engine Health Check (Global) - SAP HANA
@@ -61,7 +61,7 @@
         auth_kind: "serviceaccount"
         service_account_file: "{{ sap_vm_provision_gcp_credentials_json }}"
       when:
-        - groups["hana_secondary"] is defined and (groups["hana_secondary"]|length>0)
+        - groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary]|length>0)
 
     - name: Create Google Cloud Compute Engine Health Check (Global) service instance for SAP AnyDB
       no_log: "{{ __sap_vm_provision_no_log }}"
@@ -81,7 +81,7 @@
         auth_kind: "serviceaccount"
         service_account_file: "{{ sap_vm_provision_gcp_credentials_json }}"
       when:
-        - groups["anydb_secondary"] is defined and (groups["anydb_secondary"]|length>0)
+        - groups[sap_vm_provision_group_anydb_secondary] is defined and (groups[sap_vm_provision_group_anydb_secondary]|length>0)
 
     - name: Create Google Cloud Compute Engine Health Check (Global) service instance for SAP NetWeaver ASCS
       no_log: "{{ __sap_vm_provision_no_log }}"
@@ -101,7 +101,7 @@
         auth_kind: "serviceaccount"
         service_account_file: "{{ sap_vm_provision_gcp_credentials_json }}"
       when:
-        - groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
+        - groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers]|length>0)
 
     - name: Create Google Cloud Compute Engine Health Check (Global) service instance for SAP NetWeaver ERS
       no_log: "{{ __sap_vm_provision_no_log }}"
@@ -121,4 +121,4 @@
         auth_kind: "serviceaccount"
         service_account_file: "{{ sap_vm_provision_gcp_credentials_json }}"
       when:
-        - groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
+        - groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers]|length>0)

--- a/roles/sap_vm_provision/tasks/platform_ansible/ibmcloud_powervs/execute_main.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/ibmcloud_powervs/execute_main.yml
@@ -235,9 +235,9 @@
         pi_placement_group_policy: "anti-affinity"
         ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
       loop:
-        - "{{ 'hana'  if 'hana_secondary' in lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan] | json_query('*') | map(attribute='sap_host_type') else '' }}"
-        - "{{ 'anydb' if 'anydb_secondary' in lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan] | json_query('*') | map(attribute='sap_host_type') else '' }}"
-        - "{{ 'nwas'  if 'nwas_ers' in lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan] | json_query('*') | map(attribute='sap_host_type') else '' }}"
+        - "{{ 'hana'  if sap_vm_provision_group_hana_secondary in lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan] | json_query('*') | map(attribute='sap_host_type') else '' }}"
+        - "{{ 'anydb' if sap_vm_provision_group_anydb_secondary in lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan] | json_query('*') | map(attribute='sap_host_type') else '' }}"
+        - "{{ 'nwas'  if sap_vm_provision_group_nwas_ers in lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan] | json_query('*') | map(attribute='sap_host_type') else '' }}"
       when:
         - sap_vm_provision_ibmcloud_placement_resource_name is defined
         - sap_vm_provision_ibmcloud_placement_strategy_spread
@@ -289,7 +289,7 @@
 
     - name: Set fact to hold all inventory hosts in all groups
       ansible.builtin.set_fact:
-        groups_merged_list: "{{ [ [ groups['hana_primary'] | default([]) ] , [ groups['hana_secondary'] | default([]) ] , [ groups['anydb_primary'] | default([]) ] , [ groups['anydb_secondary'] | default([]) ] , [ groups['nwas_ascs'] | default([]) ] , [ groups['nwas_ers'] | default([]) ] , [ groups['nwas_pas'] | default([]) ] , [ groups['nwas_aas'] | default([]) ] ] | flatten | select() }}"
+        groups_merged_list: "{{ [ [ groups[sap_vm_provision_group_hana_primary] | default([]) ] , [ groups[sap_vm_provision_group_hana_secondary] | default([]) ] , [ groups[sap_vm_provision_group_anydb_primary] | default([]) ] , [ groups[sap_vm_provision_group_anydb_secondary] | default([]) ] , [ groups[sap_vm_provision_group_nwas_ascs] | default([]) ] , [ groups[sap_vm_provision_group_nwas_ers] | default([]) ] , [ groups[sap_vm_provision_group_nwas_pas] | default([]) ] , [ groups[sap_vm_provision_group_nwas_aas] | default([]) ] ] | flatten | select() }}"
 
     - name: Set Ansible Vars
       register: __sap_vm_provision_task_ansible_vars_set
@@ -374,14 +374,14 @@
       ansible.builtin.include_tasks:
         file: common/set_etc_hosts_ha.yml
       when:
-        - (groups["hana_secondary"] is defined and (groups["hana_secondary"] | length>0)) or (groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0)) or (groups["anydb_secondary"] is defined and (groups["anydb_secondary"] | length>0))
+        - (groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary] | length>0)) or (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0)) or (groups[sap_vm_provision_group_anydb_secondary] is defined and (groups[sap_vm_provision_group_anydb_secondary] | length>0))
 
     - name: Set /etc/hosts for Scale-Out
       register: __sap_vm_provision_task_os_etc_hosts_scaleout
       ansible.builtin.include_tasks:
         file: common/set_etc_hosts_scaleout.yml
       when:
-        - (groups["hana_primary"] is defined and (groups["hana_primary"] | length>0)) and (sap_vm_provision_calculate_sap_hana_scaleout_active_coordinator is defined or sap_vm_provision_calculate_sap_hana_scaleout_active_worker is defined or sap_vm_provision_calculate_sap_hana_scaleout_standby is defined)
+        - (groups[sap_vm_provision_group_hana_primary] is defined and (groups[sap_vm_provision_group_hana_primary] | length>0)) and (sap_vm_provision_calculate_sap_hana_scaleout_active_coordinator is defined or sap_vm_provision_calculate_sap_hana_scaleout_active_worker is defined or sap_vm_provision_calculate_sap_hana_scaleout_standby is defined)
 
     - name: Set vars for sap_storage_setup Ansible Role
       register: __sap_vm_provision_task_ansible_vars_storage

--- a/roles/sap_vm_provision/tasks/platform_ansible/ibmcloud_powervs/execute_provision.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/ibmcloud_powervs/execute_provision.yml
@@ -84,13 +84,13 @@
 
     pi_placement_group_id: "{{ (
       (__sap_vm_provision_task_ibmcloud_placement_groups_list.resource.placement_groups | selectattr('name','search','hana'))[0].id
-      if ('hana_primary' in target_provision_host_spec.sap_host_type or 'hana_secondary' in target_provision_host_spec.sap_host_type) and not __sap_vm_provision_task_ibmcloud_placement_groups_list is skipped
+      if (sap_vm_provision_group_hana_primary in target_provision_host_spec.sap_host_type or sap_vm_provision_group_hana_secondary in target_provision_host_spec.sap_host_type) and not __sap_vm_provision_task_ibmcloud_placement_groups_list is skipped
       else
       (__sap_vm_provision_task_ibmcloud_placement_groups_list.resource.placement_groups | selectattr('name','search','anydb'))[0].id
-      if ('anydb_primary' in target_provision_host_spec.sap_host_type or 'anydb_secondary' in target_provision_host_spec.sap_host_type) and not __sap_vm_provision_task_ibmcloud_placement_groups_list is skipped
+      if (sap_vm_provision_group_anydb_primary in target_provision_host_spec.sap_host_type or sap_vm_provision_group_anydb_secondary in target_provision_host_spec.sap_host_type) and not __sap_vm_provision_task_ibmcloud_placement_groups_list is skipped
       else
       (__sap_vm_provision_task_ibmcloud_placement_groups_list.resource.placement_groups | selectattr('name','search','nwas'))[0].id
-      if ('nwas_ascs' in target_provision_host_spec.sap_host_type or 'nwas_ers' in target_provision_host_spec.sap_host_type) and not __sap_vm_provision_task_ibmcloud_placement_groups_list is skipped
+      if (sap_vm_provision_group_nwas_ascs in target_provision_host_spec.sap_host_type or sap_vm_provision_group_nwas_ers in target_provision_host_spec.sap_host_type) and not __sap_vm_provision_task_ibmcloud_placement_groups_list is skipped
       ) | default(omit) }}"
 
     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"

--- a/roles/sap_vm_provision/tasks/platform_ansible/ibmcloud_vs/execute_main.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/ibmcloud_vs/execute_main.yml
@@ -90,9 +90,9 @@
         strategy: power_spread
         ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
       loop:
-        - "{{ 'hana'  if 'hana_secondary' in lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan] | json_query('*') | map(attribute='sap_host_type') else '' }}"
-        - "{{ 'anydb' if 'anydb_secondary' in lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan] | json_query('*') | map(attribute='sap_host_type') else '' }}"
-        - "{{ 'nwas'  if 'nwas_ers' in lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan] | json_query('*') | map(attribute='sap_host_type') else '' }}"
+        - "{{ 'hana'  if sap_vm_provision_group_hana_secondary in lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan] | json_query('*') | map(attribute='sap_host_type') else '' }}"
+        - "{{ 'anydb' if sap_vm_provision_group_anydb_secondary in lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan] | json_query('*') | map(attribute='sap_host_type') else '' }}"
+        - "{{ 'nwas'  if sap_vm_provision_group_nwas_ers in lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan] | json_query('*') | map(attribute='sap_host_type') else '' }}"
       when:
         - sap_vm_provision_ibmcloud_placement_resource_name is defined
         - sap_vm_provision_ibmcloud_placement_strategy_spread
@@ -131,7 +131,7 @@
 
     - name: Set fact to hold all inventory hosts in all groups
       ansible.builtin.set_fact:
-        groups_merged_list: "{{ [ [ groups['hana_primary'] | default([]) ] , [ groups['hana_secondary'] | default([]) ] , [ groups['anydb_primary'] | default([]) ] , [ groups['anydb_secondary'] | default([]) ] , [ groups['nwas_ascs'] | default([]) ] , [ groups['nwas_ers'] | default([]) ] , [ groups['nwas_pas'] | default([]) ] , [ groups['nwas_aas'] | default([]) ] ] | flatten | select() }}"
+        groups_merged_list: "{{ [ [ groups[sap_vm_provision_group_hana_primary] | default([]) ] , [ groups[sap_vm_provision_group_hana_secondary] | default([]) ] , [ groups[sap_vm_provision_group_anydb_primary] | default([]) ] , [ groups[sap_vm_provision_group_anydb_secondary] | default([]) ] , [ groups[sap_vm_provision_group_nwas_ascs] | default([]) ] , [ groups[sap_vm_provision_group_nwas_ers] | default([]) ] , [ groups[sap_vm_provision_group_nwas_pas] | default([]) ] , [ groups[sap_vm_provision_group_nwas_aas] | default([]) ] ] | flatten | select() }}"
 
     - name: Set Ansible Vars
       register: __sap_vm_provision_task_ansible_vars_set
@@ -213,7 +213,7 @@
       ansible.builtin.include_tasks:
         file: common/set_etc_hosts_scaleout.yml
       when:
-        - (groups["hana_primary"] is defined and (groups["hana_primary"] | length>0)) and (sap_vm_provision_calculate_sap_hana_scaleout_active_coordinator is defined or sap_vm_provision_calculate_sap_hana_scaleout_active_worker is defined or sap_vm_provision_calculate_sap_hana_scaleout_standby is defined)
+        - (groups[sap_vm_provision_group_hana_primary] is defined and (groups[sap_vm_provision_group_hana_primary] | length>0)) and (sap_vm_provision_calculate_sap_hana_scaleout_active_coordinator is defined or sap_vm_provision_calculate_sap_hana_scaleout_active_worker is defined or sap_vm_provision_calculate_sap_hana_scaleout_standby is defined)
 
     - name: Set vars for sap_storage_setup Ansible Role
       register: __sap_vm_provision_task_ansible_vars_storage
@@ -229,7 +229,7 @@
 #   delegate_to: "{{ inventory_hostname }}"
 #   when:
 #     - sap_ha_pacemaker_cluster_ibmcloud_region is defined
-#     - (groups["hana_secondary"] is defined and (groups["hana_secondary"] | length>0)) or (groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0)) or (groups["anydb_secondary"] is defined and (groups["anydb_secondary"] | length>0))
+#     - (groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary] | length>0)) or (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0)) or (groups[sap_vm_provision_group_anydb_secondary] is defined and (groups[sap_vm_provision_group_anydb_secondary] | length>0))
 #   block:
 
 
@@ -245,7 +245,7 @@
     IC_REGION: "{{ sap_vm_provision_ibmcloud_region }}"
   when:
     - sap_ha_pacemaker_cluster_ibmcloud_region is defined
-    - (groups["hana_secondary"] is defined and (groups["hana_secondary"] | length>0)) or (groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0)) or (groups["anydb_secondary"] is defined and (groups["anydb_secondary"] | length>0))
+    - (groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary] | length>0)) or (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0)) or (groups[sap_vm_provision_group_anydb_secondary] is defined and (groups[sap_vm_provision_group_anydb_secondary] | length>0))
   block:
 
     - name: Provision High Availability resources for IBM Cloud hosts
@@ -349,7 +349,7 @@
   delegate_to: "{{ inventory_hostname }}"
   when:
     - sap_ha_pacemaker_cluster_ibmcloud_region is defined
-    - (groups["hana_secondary"] is defined and (groups["hana_secondary"] | length>0)) or (groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0)) or (groups["anydb_secondary"] is defined and (groups["anydb_secondary"] | length>0))
+    - (groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary] | length>0)) or (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0)) or (groups[sap_vm_provision_group_anydb_secondary] is defined and (groups[sap_vm_provision_group_anydb_secondary] | length>0))
   block:
 
     - name: Set /etc/hosts for HA

--- a/roles/sap_vm_provision/tasks/platform_ansible/ibmcloud_vs/execute_provision.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/ibmcloud_vs/execute_provision.yml
@@ -68,13 +68,13 @@
 
     placement_group: "{{ (
       (__sap_vm_provision_task_ibmcloud_placement_group.results | selectattr('item','==','hana'))[0].resource.id
-      if ('hana_primary' in target_provision_host_spec.sap_host_type or 'hana_secondary' in target_provision_host_spec.sap_host_type) and not __sap_vm_provision_task_ibmcloud_placement_group is skipped
+      if (sap_vm_provision_group_hana_primary in target_provision_host_spec.sap_host_type or sap_vm_provision_group_hana_secondary in target_provision_host_spec.sap_host_type) and not __sap_vm_provision_task_ibmcloud_placement_group is skipped
       else
       (__sap_vm_provision_task_ibmcloud_placement_group.results | selectattr('item','==','anydb'))[0].resource.id
-      if ('anydb_primary' in target_provision_host_spec.sap_host_type or 'anydb_secondary' in target_provision_host_spec.sap_host_type) and not __sap_vm_provision_task_ibmcloud_placement_group is skipped
+      if (sap_vm_provision_group_anydb_primary in target_provision_host_spec.sap_host_type or sap_vm_provision_group_anydb_secondary in target_provision_host_spec.sap_host_type) and not __sap_vm_provision_task_ibmcloud_placement_group is skipped
       else
       (__sap_vm_provision_task_ibmcloud_placement_group.results | selectattr('item','==','nwas'))[0].resource.id
-      if ('nwas_ascs' in target_provision_host_spec.sap_host_type or 'nwas_ers' in target_provision_host_spec.sap_host_type) and not __sap_vm_provision_task_ibmcloud_placement_group is skipped
+      if (sap_vm_provision_group_nwas_ascs in target_provision_host_spec.sap_host_type or sap_vm_provision_group_nwas_ers in target_provision_host_spec.sap_host_type) and not __sap_vm_provision_task_ibmcloud_placement_group is skipped
       ) | default(omit) }}"
 
     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"

--- a/roles/sap_vm_provision/tasks/platform_ansible/ibmcloud_vs/execute_setup_ha.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/ibmcloud_vs/execute_setup_ha.yml
@@ -44,10 +44,10 @@
         zone_id: "{{ (__sap_vm_provision_task_ibmcloud_pdns.resource.dns_zones | selectattr('name', '==', sap_vm_provision_dns_root_domain) | first).zone_id }}"
     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
   loop:
-    - "{{ sap_vm_provision_ha_load_balancer_name_hana if (groups['hana_secondary'] is defined and (groups['hana_secondary'] | length>0)) else '' }}"
-    - "{{ sap_vm_provision_ha_load_balancer_name_anydb if (groups['anydb_secondary'] is defined and (groups['anydb_secondary'] | length>0)) else '' }}"
-    - "{{ sap_vm_provision_ha_load_balancer_name_nwas + '-ascs' if (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0)) else '' }}"
-    - "{{ sap_vm_provision_ha_load_balancer_name_nwas + '-ers' if (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0)) else '' }}"
+    - "{{ sap_vm_provision_ha_load_balancer_name_hana if (groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary] | length>0)) else '' }}"
+    - "{{ sap_vm_provision_ha_load_balancer_name_anydb if (groups[sap_vm_provision_group_anydb_secondary] is defined and (groups[sap_vm_provision_group_anydb_secondary] | length>0)) else '' }}"
+    - "{{ sap_vm_provision_ha_load_balancer_name_nwas + '-ascs' if (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0)) else '' }}"
+    - "{{ sap_vm_provision_ha_load_balancer_name_nwas + '-ers' if (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0)) else '' }}"
   loop_control:
     label: "Waiting for {{ item }}"
   when: not item == ''
@@ -73,10 +73,10 @@
 #     ibmcloud plugin install infrastructure-service -f --quiet
 #     ibmcloud is load-balancer-update "{{ item }}" --dns-instance-crn "{{ __sap_vm_provision_task_ibmcloud_pdns_service_instance.resource.resource_crn }}" --dns-zone-id "{{ (__sap_vm_provision_task_ibmcloud_pdns.resource.dns_zones | selectattr('name', '==', sap_vm_provision_dns_root_domain) | first).zone_id }}"
 #   loop:
-#     - "{{ sap_vm_provision_ha_load_balancer_name_hana if (groups['hana_secondary'] is defined and (groups['hana_secondary'] | length>0)) else '' }}"
-#     - "{{ sap_vm_provision_ha_load_balancer_name_anydb if (groups['anydb_secondary'] is defined and (groups['anydb_secondary'] | length>0)) else '' }}"
-#     - "{{ sap_vm_provision_ha_load_balancer_name_nwas + '-ascs' if (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0)) else '' }}"
-#     - "{{ sap_vm_provision_ha_load_balancer_name_nwas + '-ers' if (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0)) else '' }}"
+#     - "{{ sap_vm_provision_ha_load_balancer_name_hana if (groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary] | length>0)) else '' }}"
+#     - "{{ sap_vm_provision_ha_load_balancer_name_anydb if (groups[sap_vm_provision_group_anydb_secondary] is defined and (groups[sap_vm_provision_group_anydb_secondary] | length>0)) else '' }}"
+#     - "{{ sap_vm_provision_ha_load_balancer_name_nwas + '-ascs' if (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0)) else '' }}"
+#     - "{{ sap_vm_provision_ha_load_balancer_name_nwas + '-ers' if (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0)) else '' }}"
 #   when: not item == ''
 #   failed_when: not __sap_vm_provision_task_ibmcloud_lb_update_dns.rc == 0 and not 'nothing to update the load balancer with' in __sap_vm_provision_task_ibmcloud_lb_update_dns.stderr
 
@@ -119,7 +119,7 @@
       - "{{ ('3' + sap_system_hana_db_instance_nr + '15') if sap_system_hana_db_instance_nr is defined else 'IGNORE' }} - SAP HANA - MDC Tenant 1 SQL"
       - "{{ ('5' + sap_system_hana_db_instance_nr + '13') if sap_system_hana_db_instance_nr is defined else 'IGNORE' }} - SAP HANA - startsrv HTTP"
       - "{{ ('5' + sap_system_hana_db_instance_nr + '14') if sap_system_hana_db_instance_nr is defined else 'IGNORE' }} - SAP HANA - startsrv HTTPS"
-      - "{{ '5912' if groups['anydb_secondary'] is defined else 'IGNORE' }} - SAP AnyDB - IBM Db2 Communication Port"
+      - "{{ '5912' if groups[sap_vm_provision_group_anydb_secondary] is defined else 'IGNORE' }} - SAP AnyDB - IBM Db2 Communication Port"
       - "{{ ('32' + sap_system_nwas_abap_ascs_instance_nr) if sap_system_nwas_abap_ascs_instance_nr is defined else 'IGNORE' }} - SAP NetWeaver ASCS - Dispatcher sapdp<ASCS_NN> process"
       - "{{ ('36' + sap_system_nwas_abap_ascs_instance_nr) if sap_system_nwas_abap_ascs_instance_nr is defined else 'IGNORE' }} - SAP NetWeaver ASCS - Message Server sapms<SAPSID> process"
       - "{{ ('81' + sap_system_nwas_abap_ascs_instance_nr) if sap_system_nwas_abap_ascs_instance_nr is defined else 'IGNORE' }} - SAP NetWeaver ASCS - Message Server HTTP sapms<SAPSID> process"
@@ -148,7 +148,7 @@
     health_type: tcp
     health_monitor_port: 55550
     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-  when: (groups['hana_secondary'] is defined and (groups['hana_secondary'] | length>0))
+  when: (groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary] | length>0))
 
 - name: Create IBM Cloud Load Balancer Back-end Pool for SAP HANA - MDC Tenant 1 SQL
   no_log: "{{ __sap_vm_provision_no_log }}"
@@ -164,7 +164,7 @@
     health_type: tcp
     health_monitor_port: 55550
     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-  when: (groups['hana_secondary'] is defined and (groups['hana_secondary'] | length>0))
+  when: (groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary] | length>0))
 
 - name: Create IBM Cloud Load Balancer Back-end Pool for SAP HANA - startsrv HTTP
   no_log: "{{ __sap_vm_provision_no_log }}"
@@ -180,7 +180,7 @@
     health_type: tcp
     health_monitor_port: 55550
     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-  when: (groups['hana_secondary'] is defined and (groups['hana_secondary'] | length>0))
+  when: (groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary] | length>0))
 
 - name: Create IBM Cloud Load Balancer Back-end Pool for SAP HANA - startsrv HTTPS
   no_log: "{{ __sap_vm_provision_no_log }}"
@@ -196,7 +196,7 @@
     health_type: tcp
     health_monitor_port: 55550
     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-  when: (groups['hana_secondary'] is defined and (groups['hana_secondary'] | length>0))
+  when: (groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary] | length>0))
 
 - name: Create IBM Cloud Load Balancer Back-end Pool for SAP AnyDB - IBM Db2 Communication Port
   no_log: "{{ __sap_vm_provision_no_log }}"
@@ -211,7 +211,7 @@
     health_type: tcp
     health_monitor_port: 55550
     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-  when: (groups['anydb_secondary'] is defined and (groups['anydb_secondary'] | length>0))
+  when: (groups[sap_vm_provision_group_anydb_secondary] is defined and (groups[sap_vm_provision_group_anydb_secondary] | length>0))
 
 - name: Create IBM Cloud Load Balancer Back-end Pool for SAP NetWeaver ASCS - Dispatcher sapdp<ASCS_NN> process
   no_log: "{{ __sap_vm_provision_no_log }}"
@@ -227,7 +227,7 @@
     health_type: tcp
     health_monitor_port: 55551
     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-  when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
+  when: (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0))
 
 - name: Create IBM Cloud Load Balancer Back-end Pool for SAP NetWeaver ASCS - Message Server sapms<SAPSID> process
   no_log: "{{ __sap_vm_provision_no_log }}"
@@ -243,7 +243,7 @@
     health_type: tcp
     health_monitor_port: 55551
     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-  when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
+  when: (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0))
 
 - name: Create IBM Cloud Load Balancer Back-end Pool for SAP NetWeaver ASCS - Message Server HTTP sapms<SAPSID> process
   no_log: "{{ __sap_vm_provision_no_log }}"
@@ -259,7 +259,7 @@
     health_type: tcp
     health_monitor_port: 55551
     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-  when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
+  when: (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0))
 
 - name: Create IBM Cloud Load Balancer Back-end Pool for SAP NetWeaver ASCS - Enqueue Server sapenq<SAPSID> process
   no_log: "{{ __sap_vm_provision_no_log }}"
@@ -275,7 +275,7 @@
     health_type: tcp
     health_monitor_port: 55551
     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-  when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
+  when: (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0))
 
 - name: Create IBM Cloud Load Balancer Back-end Pool for SAP NetWeaver ASCS - Enqueue Replicator Server sapenqrepl<SAPSID> process
   no_log: "{{ __sap_vm_provision_no_log }}"
@@ -291,7 +291,7 @@
     health_type: tcp
     health_monitor_port: 55551
     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-  when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
+  when: (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0))
 
 - name: Create IBM Cloud Load Balancer Back-end Pool for SAP NetWeaver ASCS - SAP Start Service (SAPControl SOAP) HTTP sapctrl<ASCS_NN> process
   no_log: "{{ __sap_vm_provision_no_log }}"
@@ -307,7 +307,7 @@
     health_type: tcp
     health_monitor_port: 55551
     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-  when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
+  when: (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0))
 
 - name: Create IBM Cloud Load Balancer Back-end Pool for SAP NetWeaver ASCS - SAP Start Service (SAPControl SOAP) HTTPS (Secure) sapctrls<ASCS_NN>
   no_log: "{{ __sap_vm_provision_no_log }}"
@@ -323,7 +323,7 @@
     health_type: tcp
     health_monitor_port: 55551
     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-  when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
+  when: (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0))
 
 # - name: Create IBM Cloud Load Balancer Back-end Pool for SAP NetWeaver ERS - Dispatcher sapdp<ERS_NN> process
 #   no_log: "{{ __sap_vm_provision_no_log }}"
@@ -339,7 +339,7 @@
 #     health_type: tcp
 #     health_monitor_port: 55552
 #     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-#   when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
+#   when: (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0))
 
 # - name: Create IBM Cloud Load Balancer Back-end Pool for SAP NetWeaver ERS - Message Server sapms<SAPSID> process
 #   no_log: "{{ __sap_vm_provision_no_log }}"
@@ -355,7 +355,7 @@
 #     health_type: tcp
 #     health_monitor_port: 55552
 #     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-#   when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
+#   when: (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0))
 
 - name: Create IBM Cloud Load Balancer Back-end Pool for SAP NetWeaver ERS - Enqueue Replication Server sapenqr<SAPSID> process
   no_log: "{{ __sap_vm_provision_no_log }}"
@@ -371,7 +371,7 @@
     health_type: tcp
     health_monitor_port: 55552
     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-  when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
+  when: (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0))
 
 - name: Create IBM Cloud Load Balancer Back-end Pool for SAP NetWeaver ERS - SAP Start Service (SAPControl SOAP) HTTP sapctrl<ERS_NN> process
   no_log: "{{ __sap_vm_provision_no_log }}"
@@ -387,7 +387,7 @@
     health_type: tcp
     health_monitor_port: 55552
     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-  when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
+  when: (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0))
 
 - name: Create IBM Cloud Load Balancer Back-end Pool for SAP NetWeaver ERS - SAP Start Service (SAPControl SOAP) HTTPS (Secure) sapctrls<ERS_NN>
   no_log: "{{ __sap_vm_provision_no_log }}"
@@ -403,7 +403,7 @@
     health_type: tcp
     health_monitor_port: 55552
     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-  when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
+  when: (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0))
 
 
 # Identify the provisioned IBM Cloud Load Balancer Back-end Pools
@@ -437,7 +437,7 @@
     port: "{{ ('3' + sap_system_hana_db_instance_nr + '13') | int }}"
     idle_connection_timeout: 600 # 10 minutes
     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-  when: (groups['hana_secondary'] is defined and (groups['hana_secondary'] | length>0))
+  when: (groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary] | length>0))
   failed_when: not __sap_vm_provision_task_ibmcloud_lb_frontend_listener_hana1.rc == 0 and not 'listener_duplicate_port' in __sap_vm_provision_task_ibmcloud_lb_frontend_listener_hana1.stderr
 
 - name: Create IBM Cloud Load Balancer Front-end Listener for SAP HANA - MDC Tenant 1 SQL
@@ -450,7 +450,7 @@
     port: "{{ ('3' + sap_system_hana_db_instance_nr + '15') | int }}"
     idle_connection_timeout: 600 # 10 minutes
     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-  when: (groups['hana_secondary'] is defined and (groups['hana_secondary'] | length>0))
+  when: (groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary] | length>0))
   failed_when: not __sap_vm_provision_task_ibmcloud_lb_frontend_listener_hana2.rc == 0 and not 'listener_duplicate_port' in __sap_vm_provision_task_ibmcloud_lb_frontend_listener_hana2.stderr
 
 - name: Create IBM Cloud Load Balancer Front-end Listener for SAP HANA - startsrv HTTP
@@ -463,7 +463,7 @@
     port: "{{ ('5' + sap_system_hana_db_instance_nr + '13') | int }}"
     idle_connection_timeout: 600 # 10 minutes
     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-  when: (groups['hana_secondary'] is defined and (groups['hana_secondary'] | length>0))
+  when: (groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary] | length>0))
   failed_when: not __sap_vm_provision_task_ibmcloud_lb_frontend_listener_hana3.rc == 0 and not 'listener_duplicate_port' in __sap_vm_provision_task_ibmcloud_lb_frontend_listener_hana3.stderr
 
 - name: Create IBM Cloud Load Balancer Front-end Listener for SAP HANA - startsrv HTTPS
@@ -476,7 +476,7 @@
     port: "{{ ('5' + sap_system_hana_db_instance_nr + '14') | int }}"
     idle_connection_timeout: 600 # 10 minutes
     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-  when: (groups['hana_secondary'] is defined and (groups['hana_secondary'] | length>0))
+  when: (groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary] | length>0))
   failed_when: not __sap_vm_provision_task_ibmcloud_lb_frontend_listener_hana4.rc == 0 and not 'listener_duplicate_port' in __sap_vm_provision_task_ibmcloud_lb_frontend_listener_hana4.stderr
 
 - name: Create IBM Cloud Load Balancer Front-end Listener for SAP AnyDB - IBM Db2 Communication Port
@@ -489,7 +489,7 @@
     port: 5912
     idle_connection_timeout: 600 # 10 minutes
     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-  when: (groups['anydb_secondary'] is defined and (groups['anydb_secondary'] | length>0))
+  when: (groups[sap_vm_provision_group_anydb_secondary] is defined and (groups[sap_vm_provision_group_anydb_secondary] | length>0))
   failed_when: not __sap_vm_provision_task_ibmcloud_lb_frontend_listener_anydb1.rc == 0 and not 'listener_duplicate_port' in __sap_vm_provision_task_ibmcloud_lb_frontend_listener_anydb1.stderr
 
 - name: Create IBM Cloud Load Balancer Front-end Listener for SAP NetWeaver ASCS - Dispatcher sapdp<ASCS_NN> process
@@ -502,7 +502,7 @@
     port: "{{ ('32' + sap_system_nwas_abap_ascs_instance_nr) | int }}"
     idle_connection_timeout: 600 # 10 minutes
     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-  when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
+  when: (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0))
   failed_when: not __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ascs1.rc == 0 and not 'listener_duplicate_port' in __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ascs1.stderr
 
 - name: Create IBM Cloud Load Balancer Front-end Listener for SAP NetWeaver ASCS - Message Server sapms<SAPSID> process
@@ -515,7 +515,7 @@
     port: "{{ ('36' + sap_system_nwas_abap_ascs_instance_nr) | int }}"
     idle_connection_timeout: 600 # 10 minutes
     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-  when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
+  when: (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0))
   failed_when: not __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ascs2.rc == 0 and not 'listener_duplicate_port' in __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ascs2.stderr
 
 - name: Create IBM Cloud Load Balancer Front-end Listener for SAP NetWeaver ASCS - Message Server HTTP sapms<SAPSID> process
@@ -528,7 +528,7 @@
     port: "{{ ('81' + sap_system_nwas_abap_ascs_instance_nr) | int }}"
     idle_connection_timeout: 600 # 10 minutes
     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-  when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
+  when: (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0))
   failed_when: not __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ascs3.rc == 0 and not 'listener_duplicate_port' in __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ascs3.stderr
 
 - name: Create IBM Cloud Load Balancer Front-end Listener for SAP NetWeaver ASCS - Enqueue Server sapenq<SAPSID> process
@@ -541,7 +541,7 @@
     port: "{{ ('39' + sap_system_nwas_abap_ascs_instance_nr) | int }}"
     idle_connection_timeout: 600 # 10 minutes
     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-  when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
+  when: (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0))
   failed_when: not __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ascs4.rc == 0 and not 'listener_duplicate_port' in __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ascs4.stderr
 
 - name: Create IBM Cloud Load Balancer Front-end Listener for SAP NetWeaver ASCS - Enqueue Replicator Server sapenqrepl<SAPSID> process
@@ -554,7 +554,7 @@
     port: "{{ ('5' + sap_system_nwas_abap_ascs_instance_nr + '16') | int }}"
     idle_connection_timeout: 600 # 10 minutes
     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-  when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
+  when: (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0))
   failed_when: not __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ascs5.rc == 0 and not 'listener_duplicate_port' in __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ascs5.stderr
 
 - name: Create IBM Cloud Load Balancer Front-end Listener for SAP NetWeaver ASCS - SAP Start Service (SAPControl SOAP) HTTP sapctrl<ASCS_NN> process
@@ -567,7 +567,7 @@
     port: "{{ ('5' + sap_system_nwas_abap_ascs_instance_nr + '13') | int }}"
     idle_connection_timeout: 600 # 10 minutes
     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-  when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
+  when: (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0))
   failed_when: not __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ascs6.rc == 0 and not 'listener_duplicate_port' in __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ascs6.stderr
 
 - name: Create IBM Cloud Load Balancer Front-end Listener for SAP NetWeaver ASCS - SAP Start Service (SAPControl SOAP) HTTPS (Secure) sapctrls<ASCS_NN>
@@ -580,7 +580,7 @@
     port: "{{ ('5' + sap_system_nwas_abap_ascs_instance_nr + '14') | int }}"
     idle_connection_timeout: 600 # 10 minutes
     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-  when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
+  when: (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0))
   failed_when: not __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ascs7.rc == 0 and not 'listener_duplicate_port' in __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ascs7.stderr
 
 # - name: Create IBM Cloud Load Balancer Front-end Listener for SAP NetWeaver ERS - Dispatcher sapdp<ERS_NN> process
@@ -593,7 +593,7 @@
 #     port: "{{ ('32' + sap_system_nwas_abap_ers_instance_nr) | int }}"
 #     idle_connection_timeout: 600 # 10 minutes
 #     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-#   when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
+#   when: (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0))
 #   failed_when: not __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ers1.rc == 0 and not 'listener_duplicate_port' in __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ers1.stderr
 
 # - name: Create IBM Cloud Load Balancer Front-end Listener for SAP NetWeaver ERS - Message Server sapms<SAPSID> process
@@ -606,7 +606,7 @@
 #     port: "{{ ('36' + sap_system_nwas_abap_ers_instance_nr) | int }}"
 #     idle_connection_timeout: 600 # 10 minutes
 #     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-#   when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
+#   when: (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0))
 #   failed_when: not __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ers2.rc == 0 and not 'listener_duplicate_port' in __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ers2.stderr
 
 - name: Create IBM Cloud Load Balancer Front-end Listener for SAP NetWeaver ERS - Enqueue Replication Server sapenqr<SAPSID> process
@@ -619,7 +619,7 @@
     port: "{{ ('39' + sap_system_nwas_abap_ers_instance_nr) | int }}"
     idle_connection_timeout: 600 # 10 minutes
     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-  when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
+  when: (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0))
   failed_when: not __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ers3.rc == 0 and not 'listener_duplicate_port' in __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ers3.stderr
 
 - name: Create IBM Cloud Load Balancer Front-end Listener for SAP NetWeaver ERS - SAP Start Service (SAPControl SOAP) HTTP sapctrl<ERS_NN> process
@@ -632,7 +632,7 @@
     port: "{{ ('5' + sap_system_nwas_abap_ers_instance_nr + '13') | int }}"
     idle_connection_timeout: 600 # 10 minutes
     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-  when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
+  when: (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0))
   failed_when: not __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ers4.rc == 0 and not 'listener_duplicate_port' in __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ers4.stderr
 
 - name: Create IBM Cloud Load Balancer Front-end Listener for SAP NetWeaver ERS - SAP Start Service (SAPControl SOAP) HTTPS (Secure) sapctrls<ERS_NN>
@@ -645,7 +645,7 @@
     port: "{{ ('5' + sap_system_nwas_abap_ers_instance_nr + '14') | int }}"
     idle_connection_timeout: 600 # 10 minutes
     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-  when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
+  when: (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0))
   failed_when: not __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ers5.rc == 0 and not 'listener_duplicate_port' in __sap_vm_provision_task_ibmcloud_lb_frontend_listener_ers5.stderr
 
 
@@ -662,10 +662,10 @@
     port: "{{ ('3' + sap_system_hana_db_instance_nr + '13') | int }}"
     weight: 100
     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-  loop: "{{ (groups['hana_primary'] | default([]) ) }}"
+  loop: "{{ (groups[sap_vm_provision_group_hana_primary] | default([]) ) }}"
   loop_control:
     loop_var: host_node
-  when: (groups['hana_secondary'] is defined and (groups['hana_secondary'] | length>0))
+  when: (groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary] | length>0))
   failed_when: not __sap_vm_provision_task_ibmcloud_lb_pool_members_hana1.rc == 0 and not 'already exists in a pool' in __sap_vm_provision_task_ibmcloud_lb_pool_members_hana1.stderr
 
 # Secondary
@@ -679,10 +679,10 @@
     port: "{{ ('3' + sap_system_hana_db_instance_nr + '13') | int }}"
     weight: 1
     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-  loop: "{{ (groups['hana_secondary'] | default([]) ) }}"
+  loop: "{{ (groups[sap_vm_provision_group_hana_secondary] | default([]) ) }}"
   loop_control:
     loop_var: host_node
-  when: (groups['hana_secondary'] is defined and (groups['hana_secondary'] | length>0))
+  when: (groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary] | length>0))
   failed_when: not __sap_vm_provision_task_ibmcloud_lb_pool_members_hana2.rc == 0 and not 'already exists in a pool' in __sap_vm_provision_task_ibmcloud_lb_pool_members_hana2.stderr
 
 
@@ -697,10 +697,10 @@
     port: "{{ ('3' + sap_system_hana_db_instance_nr + '15') | int }}"
     weight: 100
     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-  loop: "{{ (groups['hana_primary'] | default([]) ) }}"
+  loop: "{{ (groups[sap_vm_provision_group_hana_primary] | default([]) ) }}"
   loop_control:
     loop_var: host_node
-  when: (groups['hana_secondary'] is defined and (groups['hana_secondary'] | length>0))
+  when: (groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary] | length>0))
   failed_when: not __sap_vm_provision_task_ibmcloud_lb_pool_members_hana3.rc == 0 and not 'already exists in a pool' in __sap_vm_provision_task_ibmcloud_lb_pool_members_hana3.stderr
 
 # Secondary
@@ -714,10 +714,10 @@
     port: "{{ ('3' + sap_system_hana_db_instance_nr + '15') | int }}"
     weight: 1
     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-  loop: "{{ (groups['hana_secondary'] | default([]) ) }}"
+  loop: "{{ (groups[sap_vm_provision_group_hana_secondary] | default([]) ) }}"
   loop_control:
     loop_var: host_node
-  when: (groups['hana_secondary'] is defined and (groups['hana_secondary'] | length>0))
+  when: (groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary] | length>0))
   failed_when: not __sap_vm_provision_task_ibmcloud_lb_pool_members_hana4.rc == 0 and not 'already exists in a pool' in __sap_vm_provision_task_ibmcloud_lb_pool_members_hana4.stderr
 
 
@@ -732,10 +732,10 @@
     port: "{{ ('5' + sap_system_hana_db_instance_nr + '13') | int }}"
     weight: 100
     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-  loop: "{{ (groups['hana_primary'] | default([]) ) }}"
+  loop: "{{ (groups[sap_vm_provision_group_hana_primary] | default([]) ) }}"
   loop_control:
     loop_var: host_node
-  when: (groups['hana_secondary'] is defined and (groups['hana_secondary'] | length>0))
+  when: (groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary] | length>0))
   failed_when: not __sap_vm_provision_task_ibmcloud_lb_pool_members_hana5.rc == 0 and not 'already exists in a pool' in __sap_vm_provision_task_ibmcloud_lb_pool_members_hana5.stderr
 
 # Secondary
@@ -749,10 +749,10 @@
     port: "{{ ('5' + sap_system_hana_db_instance_nr + '13') | int }}"
     weight: 1
     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-  loop: "{{ (groups['hana_secondary'] | default([]) ) }}"
+  loop: "{{ (groups[sap_vm_provision_group_hana_secondary] | default([]) ) }}"
   loop_control:
     loop_var: host_node
-  when: (groups['hana_secondary'] is defined and (groups['hana_secondary'] | length>0))
+  when: (groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary] | length>0))
   failed_when: not __sap_vm_provision_task_ibmcloud_lb_pool_members_hana6.rc == 0 and not 'already exists in a pool' in __sap_vm_provision_task_ibmcloud_lb_pool_members_hana6.stderr
 
 
@@ -767,10 +767,10 @@
     port: "{{ ('5' + sap_system_hana_db_instance_nr + '14') | int }}"
     weight: 100
     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-  loop: "{{ (groups['hana_primary'] | default([]) ) }}"
+  loop: "{{ (groups[sap_vm_provision_group_hana_primary] | default([]) ) }}"
   loop_control:
     loop_var: host_node
-  when: (groups['hana_secondary'] is defined and (groups['hana_secondary'] | length>0))
+  when: (groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary] | length>0))
   failed_when: not __sap_vm_provision_task_ibmcloud_lb_pool_members_hana7.rc == 0 and not 'already exists in a pool' in __sap_vm_provision_task_ibmcloud_lb_pool_members_hana7.stderr
 
 # Secondary
@@ -784,10 +784,10 @@
     port: "{{ ('5' + sap_system_hana_db_instance_nr + '14') | int }}"
     weight: 1
     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-  loop: "{{ (groups['hana_secondary'] | default([]) ) }}"
+  loop: "{{ (groups[sap_vm_provision_group_hana_secondary] | default([]) ) }}"
   loop_control:
     loop_var: host_node
-  when: (groups['hana_secondary'] is defined and (groups['hana_secondary'] | length>0))
+  when: (groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary] | length>0))
   failed_when: not __sap_vm_provision_task_ibmcloud_lb_pool_members_hana8.rc == 0 and not 'already exists in a pool' in __sap_vm_provision_task_ibmcloud_lb_pool_members_hana8.stderr
 
 
@@ -802,10 +802,10 @@
     port: 5912
     weight: 100
     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-  loop: "{{ (groups['anydb_primary'] | default([]) ) }}"
+  loop: "{{ (groups[sap_vm_provision_group_anydb_primary] | default([]) ) }}"
   loop_control:
     loop_var: host_node
-  when: (groups['anydb_secondary'] is defined and (groups['anydb_secondary'] | length>0))
+  when: (groups[sap_vm_provision_group_anydb_secondary] is defined and (groups[sap_vm_provision_group_anydb_secondary] | length>0))
   failed_when: not __sap_vm_provision_task_ibmcloud_lb_pool_members_anydb1.rc == 0 and not 'already exists in a pool' in __sap_vm_provision_task_ibmcloud_lb_pool_members_anydb1.stderr
 
 # Secondary
@@ -819,10 +819,10 @@
     port: 5912
     weight: 1
     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-  loop: "{{ (groups['anydb_secondary'] | default([]) ) }}"
+  loop: "{{ (groups[sap_vm_provision_group_anydb_secondary] | default([]) ) }}"
   loop_control:
     loop_var: host_node
-  when: (groups['anydb_secondary'] is defined and (groups['anydb_secondary'] | length>0))
+  when: (groups[sap_vm_provision_group_anydb_secondary] is defined and (groups[sap_vm_provision_group_anydb_secondary] | length>0))
   failed_when: not __sap_vm_provision_task_ibmcloud_lb_pool_members_anydb2.rc == 0 and not 'already exists in a pool' in __sap_vm_provision_task_ibmcloud_lb_pool_members_anydb2.stderr
 
 
@@ -837,10 +837,10 @@
     port: "{{ ('32' + sap_system_nwas_abap_ascs_instance_nr) | int }}"
     weight: 100
     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-  loop: "{{ (groups['nwas_ascs'] | default([]) ) }}"
+  loop: "{{ (groups[sap_vm_provision_group_nwas_ascs] | default([]) ) }}"
   loop_control:
     loop_var: host_node
-  when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
+  when: (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0))
   failed_when: not __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ascs1.rc == 0 and not 'already exists in a pool' in __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ascs1.stderr
 
 # Secondary
@@ -854,10 +854,10 @@
     port: "{{ ('32' + sap_system_nwas_abap_ascs_instance_nr) | int }}"
     weight: 1
     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-  loop: "{{ (groups['nwas_ers'] | default([]) ) }}"
+  loop: "{{ (groups[sap_vm_provision_group_nwas_ers] | default([]) ) }}"
   loop_control:
     loop_var: host_node
-  when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
+  when: (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0))
   failed_when: not __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ascs2.rc == 0 and not 'already exists in a pool' in __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ascs2.stderr
 
 
@@ -872,10 +872,10 @@
     port: "{{ ('36' + sap_system_nwas_abap_ascs_instance_nr) | int }}"
     weight: 100
     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-  loop: "{{ (groups['nwas_ascs'] | default([]) ) }}"
+  loop: "{{ (groups[sap_vm_provision_group_nwas_ascs] | default([]) ) }}"
   loop_control:
     loop_var: host_node
-  when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
+  when: (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0))
   failed_when: not __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ascs3.rc == 0 and not 'already exists in a pool' in __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ascs3.stderr
 
 # Secondary
@@ -889,10 +889,10 @@
     port: "{{ ('36' + sap_system_nwas_abap_ascs_instance_nr) | int }}"
     weight: 1
     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-  loop: "{{ (groups['nwas_ers'] | default([]) ) }}"
+  loop: "{{ (groups[sap_vm_provision_group_nwas_ers] | default([]) ) }}"
   loop_control:
     loop_var: host_node
-  when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
+  when: (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0))
   failed_when: not __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ascs4.rc == 0 and not 'already exists in a pool' in __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ascs4.stderr
 
 
@@ -907,10 +907,10 @@
     port: "{{ ('81' + sap_system_nwas_abap_ascs_instance_nr) | int }}"
     weight: 100
     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-  loop: "{{ (groups['nwas_ascs'] | default([]) ) }}"
+  loop: "{{ (groups[sap_vm_provision_group_nwas_ascs] | default([]) ) }}"
   loop_control:
     loop_var: host_node
-  when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
+  when: (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0))
   failed_when: not __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ascs5.rc == 0 and not 'already exists in a pool' in __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ascs5.stderr
 
 # Secondary
@@ -924,10 +924,10 @@
     port: "{{ ('81' + sap_system_nwas_abap_ascs_instance_nr) | int }}"
     weight: 1
     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-  loop: "{{ (groups['nwas_ers'] | default([]) ) }}"
+  loop: "{{ (groups[sap_vm_provision_group_nwas_ers] | default([]) ) }}"
   loop_control:
     loop_var: host_node
-  when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
+  when: (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0))
   failed_when: not __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ascs6.rc == 0 and not 'already exists in a pool' in __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ascs6.stderr
 
 
@@ -942,10 +942,10 @@
     port: "{{ ('39' + sap_system_nwas_abap_ascs_instance_nr) | int }}"
     weight: 100
     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-  loop: "{{ (groups['nwas_ascs'] | default([]) ) }}"
+  loop: "{{ (groups[sap_vm_provision_group_nwas_ascs] | default([]) ) }}"
   loop_control:
     loop_var: host_node
-  when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
+  when: (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0))
   failed_when: not __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ascs7.rc == 0 and not 'already exists in a pool' in __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ascs7.stderr
 
 # Secondary
@@ -959,10 +959,10 @@
     port: "{{ ('39' + sap_system_nwas_abap_ascs_instance_nr) | int }}"
     weight: 1
     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-  loop: "{{ (groups['nwas_ers'] | default([]) ) }}"
+  loop: "{{ (groups[sap_vm_provision_group_nwas_ers] | default([]) ) }}"
   loop_control:
     loop_var: host_node
-  when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
+  when: (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0))
   failed_when: not __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ascs8.rc == 0 and not 'already exists in a pool' in __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ascs8.stderr
 
 
@@ -977,10 +977,10 @@
     port: "{{ ('5' + sap_system_nwas_abap_ascs_instance_nr + '16') | int }}"
     weight: 100
     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-  loop: "{{ (groups['nwas_ascs'] | default([]) ) }}"
+  loop: "{{ (groups[sap_vm_provision_group_nwas_ascs] | default([]) ) }}"
   loop_control:
     loop_var: host_node
-  when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
+  when: (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0))
   failed_when: not __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ascs9.rc == 0 and not 'already exists in a pool' in __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ascs9.stderr
 
 # Secondary
@@ -994,10 +994,10 @@
     port: "{{ ('5' + sap_system_nwas_abap_ascs_instance_nr + '16') | int }}"
     weight: 1
     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-  loop: "{{ (groups['nwas_ers'] | default([]) ) }}"
+  loop: "{{ (groups[sap_vm_provision_group_nwas_ers] | default([]) ) }}"
   loop_control:
     loop_var: host_node
-  when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
+  when: (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0))
   failed_when: not __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ascs10.rc == 0 and not 'already exists in a pool' in __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ascs10.stderr
 
 
@@ -1012,10 +1012,10 @@
     port: "{{ ('5' + sap_system_nwas_abap_ascs_instance_nr + '13') | int }}"
     weight: 100
     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-  loop: "{{ (groups['nwas_ascs'] | default([]) ) }}"
+  loop: "{{ (groups[sap_vm_provision_group_nwas_ascs] | default([]) ) }}"
   loop_control:
     loop_var: host_node
-  when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
+  when: (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0))
   failed_when: not __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ascs11.rc == 0 and not 'already exists in a pool' in __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ascs11.stderr
 
 # Secondary
@@ -1029,10 +1029,10 @@
     port: "{{ ('5' + sap_system_nwas_abap_ascs_instance_nr + '13') | int }}"
     weight: 1
     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-  loop: "{{ (groups['nwas_ers'] | default([]) ) }}"
+  loop: "{{ (groups[sap_vm_provision_group_nwas_ers] | default([]) ) }}"
   loop_control:
     loop_var: host_node
-  when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
+  when: (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0))
   failed_when: not __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ascs12.rc == 0 and not 'already exists in a pool' in __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ascs12.stderr
 
 
@@ -1047,10 +1047,10 @@
     port: "{{ ('5' + sap_system_nwas_abap_ascs_instance_nr + '14') | int }}"
     weight: 100
     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-  loop: "{{ (groups['nwas_ascs'] | default([]) ) }}"
+  loop: "{{ (groups[sap_vm_provision_group_nwas_ascs] | default([]) ) }}"
   loop_control:
     loop_var: host_node
-  when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
+  when: (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0))
   failed_when: not __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ascs13.rc == 0 and not 'already exists in a pool' in __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ascs13.stderr
 
 # Secondary
@@ -1064,10 +1064,10 @@
     port: "{{ ('5' + sap_system_nwas_abap_ascs_instance_nr + '14') | int }}"
     weight: 1
     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-  loop: "{{ (groups['nwas_ers'] | default([]) ) }}"
+  loop: "{{ (groups[sap_vm_provision_group_nwas_ers] | default([]) ) }}"
   loop_control:
     loop_var: host_node
-  when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
+  when: (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0))
   failed_when: not __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ascs14.rc == 0 and not 'already exists in a pool' in __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ascs14.stderr
 
 
@@ -1082,10 +1082,10 @@
 #     port: "{{ ('32' + sap_system_nwas_abap_ers_instance_nr) | int }}"
 #     weight: 100
 #     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-#   loop: "{{ (groups['nwas_ers'] | default([]) ) }}"
+#   loop: "{{ (groups[sap_vm_provision_group_nwas_ers] | default([]) ) }}"
 #   loop_control:
 #     loop_var: host_node
-#   when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
+#   when: (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0))
 #   failed_when: not __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ers1.rc == 0 and not 'already exists in a pool' in __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ers1.stderr
 
 # Secondary
@@ -1099,10 +1099,10 @@
 #     port: "{{ ('32' + sap_system_nwas_abap_ers_instance_nr) | int }}"
 #     weight: 1
 #     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-#   loop: "{{ (groups['nwas_ascs'] | default([]) ) }}"
+#   loop: "{{ (groups[sap_vm_provision_group_nwas_ascs] | default([]) ) }}"
 #   loop_control:
 #     loop_var: host_node
-#   when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
+#   when: (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0))
 #   failed_when: not __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ers2.rc == 0 and not 'already exists in a pool' in __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ers2.stderr
 
 
@@ -1117,10 +1117,10 @@
 #     port: "{{ ('36' + sap_system_nwas_abap_ers_instance_nr) | int }}"
 #     weight: 100
 #     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-#   loop: "{{ (groups['nwas_ers'] | default([]) ) }}"
+#   loop: "{{ (groups[sap_vm_provision_group_nwas_ers] | default([]) ) }}"
 #   loop_control:
 #     loop_var: host_node
-#   when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
+#   when: (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0))
 #   failed_when: not __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ers3.rc == 0 and not 'already exists in a pool' in __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ers3.stderr
 
 # Secondary
@@ -1134,10 +1134,10 @@
 #     port: "{{ ('36' + sap_system_nwas_abap_ers_instance_nr) | int }}"
 #     weight: 1
 #     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-#   loop: "{{ (groups['nwas_ascs'] | default([]) ) }}"
+#   loop: "{{ (groups[sap_vm_provision_group_nwas_ascs] | default([]) ) }}"
 #   loop_control:
 #     loop_var: host_node
-#   when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
+#   when: (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0))
 #   failed_when: not __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ers4.rc == 0 and not 'already exists in a pool' in __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ers4.stderr
 
 
@@ -1152,10 +1152,10 @@
     port: "{{ ('39' + sap_system_nwas_abap_ers_instance_nr) | int }}"
     weight: 100
     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-  loop: "{{ (groups['nwas_ers'] | default([]) ) }}"
+  loop: "{{ (groups[sap_vm_provision_group_nwas_ers] | default([]) ) }}"
   loop_control:
     loop_var: host_node
-  when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
+  when: (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0))
   failed_when: not __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ers5.rc == 0 and not 'already exists in a pool' in __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ers5.stderr
 
 # Secondary
@@ -1169,10 +1169,10 @@
     port: "{{ ('39' + sap_system_nwas_abap_ers_instance_nr) | int }}"
     weight: 1
     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-  loop: "{{ (groups['nwas_ascs'] | default([]) ) }}"
+  loop: "{{ (groups[sap_vm_provision_group_nwas_ascs] | default([]) ) }}"
   loop_control:
     loop_var: host_node
-  when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
+  when: (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0))
   failed_when: not __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ers6.rc == 0 and not 'already exists in a pool' in __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ers6.stderr
 
 
@@ -1187,10 +1187,10 @@
     port: "{{ ('5' + sap_system_nwas_abap_ers_instance_nr + '13') | int }}"
     weight: 100
     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-  loop: "{{ (groups['nwas_ers'] | default([]) ) }}"
+  loop: "{{ (groups[sap_vm_provision_group_nwas_ers] | default([]) ) }}"
   loop_control:
     loop_var: host_node
-  when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
+  when: (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0))
   failed_when: not __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ers7.rc == 0 and not 'already exists in a pool' in __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ers7.stderr
 
 # Secondary
@@ -1204,10 +1204,10 @@
     port: "{{ ('5' + sap_system_nwas_abap_ers_instance_nr + '13') | int }}"
     weight: 1
     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-  loop: "{{ (groups['nwas_ascs'] | default([]) ) }}"
+  loop: "{{ (groups[sap_vm_provision_group_nwas_ascs] | default([]) ) }}"
   loop_control:
     loop_var: host_node
-  when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
+  when: (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0))
   failed_when: not __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ers8.rc == 0 and not 'already exists in a pool' in __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ers8.stderr
 
 
@@ -1222,10 +1222,10 @@
     port: "{{ ('5' + sap_system_nwas_abap_ers_instance_nr + '14') | int }}"
     weight: 100
     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-  loop: "{{ (groups['nwas_ers'] | default([]) ) }}"
+  loop: "{{ (groups[sap_vm_provision_group_nwas_ers] | default([]) ) }}"
   loop_control:
     loop_var: host_node
-  when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
+  when: (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0))
   failed_when: not __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ers9.rc == 0 and not 'already exists in a pool' in __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ers9.stderr
 
 # Secondary
@@ -1239,10 +1239,10 @@
     port: "{{ ('5' + sap_system_nwas_abap_ers_instance_nr + '14') | int }}"
     weight: 1
     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-  loop: "{{ (groups['nwas_ascs'] | default([]) ) }}"
+  loop: "{{ (groups[sap_vm_provision_group_nwas_ascs] | default([]) ) }}"
   loop_control:
     loop_var: host_node
-  when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
+  when: (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0))
   failed_when: not __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ers10.rc == 0 and not 'already exists in a pool' in __sap_vm_provision_task_ibmcloud_lb_pool_members_nwas_ers10.stderr
 
 
@@ -1260,11 +1260,11 @@
     ttl: 7200
     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
   failed_when: not __sap_vm_provision_task_ibmcloud_pdns_record.rc == 0 and not 'The record already exists' in __sap_vm_provision_task_ibmcloud_pdns_record.stderr
-  loop: "{{ (groups['hana_primary'] | default([])) }}"
+  loop: "{{ (groups[sap_vm_provision_group_hana_primary] | default([])) }}"
   loop_control:
     loop_var: host_node
   when:
-    - groups["hana_secondary"] is defined and (groups["hana_secondary"]|length>0)
+    - groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary]|length>0)
 
 - name: IBM Cloud Private DNS Record for SAP AnyDB HA Virtual Hostname
   no_log: "{{ __sap_vm_provision_no_log }}"
@@ -1278,11 +1278,11 @@
     ttl: 7200
     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
   failed_when: not __sap_vm_provision_task_ibmcloud_pdns_record.rc == 0 and not 'The record already exists' in __sap_vm_provision_task_ibmcloud_pdns_record.stderr
-  loop: "{{ (groups['anydb_primary'] | default([])) }}"
+  loop: "{{ (groups[sap_vm_provision_group_anydb_primary] | default([])) }}"
   loop_control:
     loop_var: host_node
   when:
-    - groups["anydb_secondary"] is defined and (groups["anydb_secondary"]|length>0)
+    - groups[sap_vm_provision_group_anydb_secondary] is defined and (groups[sap_vm_provision_group_anydb_secondary]|length>0)
 
 - name: IBM Cloud Private DNS Record for SAP NetWeaver ASCS HA Virtual Hostname
   no_log: "{{ __sap_vm_provision_no_log }}"
@@ -1296,11 +1296,11 @@
     ttl: 7200
     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
   failed_when: not __sap_vm_provision_task_ibmcloud_pdns_record.rc == 0 and not 'The record already exists' in __sap_vm_provision_task_ibmcloud_pdns_record.stderr
-  loop: "{{ (groups['nwas_ascs'] | default([])) }}"
+  loop: "{{ (groups[sap_vm_provision_group_nwas_ascs] | default([])) }}"
   loop_control:
     loop_var: host_node
   when:
-    - groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
+    - groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers]|length>0)
 
 - name: IBM Cloud Private DNS Record for SAP NetWeaver ERS HA Virtual Hostname
   no_log: "{{ __sap_vm_provision_no_log }}"
@@ -1314,11 +1314,11 @@
     ttl: 7200
     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
   failed_when: not __sap_vm_provision_task_ibmcloud_pdns_record.rc == 0 and not 'The record already exists' in __sap_vm_provision_task_ibmcloud_pdns_record.stderr
-  loop: "{{ (groups['nwas_ers'] | default([])) }}"
+  loop: "{{ (groups[sap_vm_provision_group_nwas_ers] | default([])) }}"
   loop_control:
     loop_var: host_node
   when:
-    - groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
+    - groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers]|length>0)
 
 
 - name: Set facts for all hosts - use facts from localhost - HA/DR - IBM Cloud Load Balancer - SAP HANA Primary node
@@ -1328,7 +1328,7 @@
     sap_ha_pacemaker_cluster_vip_hana_primary_ip_address: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', sap_vm_provision_ha_load_balancer_name_hana))[0].private_ips[0].address }}"
   when:
     - sap_ha_pacemaker_cluster_ibmcloud_region is defined
-    - groups["hana_secondary"] is defined and (groups["hana_secondary"]|length>0)
+    - groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary]|length>0)
   delegate_to: "{{ item }}"
   delegate_facts: true
   loop: "{{ groups_merged_list }}"
@@ -1340,7 +1340,7 @@
     sap_ha_install_anydb_ibmdb2_vip_primary_ip_address: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', sap_vm_provision_ha_load_balancer_name_anydb))[0].private_ips[0].address }}"
   when:
     - sap_ha_pacemaker_cluster_ibmcloud_region is defined
-    - groups["anydb_secondary"] is defined and (groups["anydb_secondary"]|length>0)
+    - groups[sap_vm_provision_group_anydb_secondary] is defined and (groups[sap_vm_provision_group_anydb_secondary]|length>0)
   delegate_to: "{{ item }}"
   delegate_facts: true
   loop: "{{ groups_merged_list }}"
@@ -1355,7 +1355,7 @@
     sap_ha_pacemaker_cluster_vip_nwas_abap_ers_ip_address: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', sap_vm_provision_ha_load_balancer_name_nwas + '-ers'))[0].private_ips[0].address }}"
   when:
     - sap_ha_pacemaker_cluster_ibmcloud_region is defined
-    - groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
+    - groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers]|length>0)
   delegate_to: "{{ item }}"
   delegate_facts: true
   loop: "{{ groups_merged_list }}"
@@ -1368,7 +1368,7 @@
 #     sap_ha_pacemaker_cluster_vip_nwas_abap_aas_ip_address: "{{ (ibmcloud_lbs_all_info | selectattr('name', '==', sap_vm_provision_ha_load_balancer_name_nwas + '-aas'))[0].private_ips[0].address }}"
 #   when:
 #     - sap_ha_pacemaker_cluster_ibmcloud_region is defined
-#     - groups["nwas_aas"] is defined and (groups["nwas_aas"]|length>0)
+#     - groups[sap_vm_provision_group_nwas_aas] is defined and (groups[sap_vm_provision_group_nwas_aas]|length>0)
 #   delegate_to: "{{ item }}"
 #   delegate_facts: true
 #   loop: "{{ groups_merged_list }}"

--- a/roles/sap_vm_provision/tasks/platform_ansible/ibmcloud_vs/post_deployment_execute.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/ibmcloud_vs/post_deployment_execute.yml
@@ -18,7 +18,7 @@
     IC_REGION: "{{ sap_vm_provision_ibmcloud_region }}"
   when:
     - sap_ha_pacemaker_cluster_ibmcloud_region is defined
-    - (groups["hana_secondary"] is defined and (groups["hana_secondary"] | length>0)) or (groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0)) or (groups["anydb_secondary"] is defined and (groups["anydb_secondary"] | length>0))
+    - (groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary] | length>0)) or (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0)) or (groups[sap_vm_provision_group_anydb_secondary] is defined and (groups[sap_vm_provision_group_anydb_secondary] | length>0))
   block:
 
     - name: Inherit variable - set fact for IBM Cloud Load Balancer Pool Health Check - SAP HANA
@@ -104,7 +104,7 @@
         health_type: tcp
         health_monitor_port: "{{ ibmcloud_lb_pool_healthcheck_hana }}"
         ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-      when: (groups['hana_secondary'] is defined and (groups['hana_secondary'] | length>0))
+      when: (groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary] | length>0))
 
     - name: Update IBM Cloud Load Balancer Back-end Pool Health Check Port to Linux Pacemaker controlled listening port for SAP HANA - MDC Tenant 1 SQL
       no_log: "{{ __sap_vm_provision_no_log }}"
@@ -121,7 +121,7 @@
         health_type: tcp
         health_monitor_port: "{{ ibmcloud_lb_pool_healthcheck_hana }}"
         ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-      when: (groups['hana_secondary'] is defined and (groups['hana_secondary'] | length>0))
+      when: (groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary] | length>0))
 
     - name: Update IBM Cloud Load Balancer Back-end Pool Health Check Port to Linux Pacemaker controlled listening port for SAP HANA - startsrv HTTP
       no_log: "{{ __sap_vm_provision_no_log }}"
@@ -138,7 +138,7 @@
         health_type: tcp
         health_monitor_port: "{{ ibmcloud_lb_pool_healthcheck_hana }}"
         ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-      when: (groups['hana_secondary'] is defined and (groups['hana_secondary'] | length>0))
+      when: (groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary] | length>0))
 
     - name: Update IBM Cloud Load Balancer Back-end Pool Health Check Port to Linux Pacemaker controlled listening port for SAP HANA - startsrv HTTPS
       no_log: "{{ __sap_vm_provision_no_log }}"
@@ -155,7 +155,7 @@
         health_type: tcp
         health_monitor_port: "{{ ibmcloud_lb_pool_healthcheck_hana }}"
         ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-      when: (groups['hana_secondary'] is defined and (groups['hana_secondary'] | length>0))
+      when: (groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary] | length>0))
 
     - name: Update IBM Cloud Load Balancer Back-end Pool Health Check Port to Linux Pacemaker controlled listening port for SAP AnyDB - IBM Db2 Communication Port
       no_log: "{{ __sap_vm_provision_no_log }}"
@@ -171,7 +171,7 @@
         health_type: tcp
         health_monitor_port: 62700
         ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-      when: (groups['anydb_secondary'] is defined and (groups['anydb_secondary'] | length>0))
+      when: (groups[sap_vm_provision_group_anydb_secondary] is defined and (groups[sap_vm_provision_group_anydb_secondary] | length>0))
 
     - name: Update IBM Cloud Load Balancer Back-end Pool Health Check Port to Linux Pacemaker controlled listening port for SAP NetWeaver ASCS - Dispatcher sapdp<ASCS_NN> process
       no_log: "{{ __sap_vm_provision_no_log }}"
@@ -188,7 +188,7 @@
         health_type: tcp
         health_monitor_port: "{{ ibmcloud_lb_pool_healthcheck_nwas_ascs }}"
         ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-      when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
+      when: (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0))
 
     - name: Update IBM Cloud Load Balancer Back-end Pool Health Check Port to Linux Pacemaker controlled listening port for SAP NetWeaver ASCS - Message Server sapms<SAPSID> process
       no_log: "{{ __sap_vm_provision_no_log }}"
@@ -205,7 +205,7 @@
         health_type: tcp
         health_monitor_port: "{{ ibmcloud_lb_pool_healthcheck_nwas_ascs }}"
         ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-      when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
+      when: (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0))
 
     - name: Update IBM Cloud Load Balancer Back-end Pool Health Check Port to Linux Pacemaker controlled listening port for SAP NetWeaver ASCS - Message Server HTTP sapms<SAPSID> process
       no_log: "{{ __sap_vm_provision_no_log }}"
@@ -222,7 +222,7 @@
         health_type: tcp
         health_monitor_port: "{{ ibmcloud_lb_pool_healthcheck_nwas_ascs }}"
         ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-      when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
+      when: (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0))
 
     - name: Update IBM Cloud Load Balancer Back-end Pool Health Check Port to Linux Pacemaker controlled listening port for SAP NetWeaver ASCS - Enqueue Server sapenq<SAPSID> process
       no_log: "{{ __sap_vm_provision_no_log }}"
@@ -239,7 +239,7 @@
         health_type: tcp
         health_monitor_port: "{{ ibmcloud_lb_pool_healthcheck_nwas_ascs }}"
         ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-      when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
+      when: (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0))
 
     - name: Update IBM Cloud Load Balancer Back-end Pool Health Check Port to Linux Pacemaker controlled listening port for SAP NetWeaver ASCS - Enqueue Replicator Server sapenqrepl<SAPSID> process
       no_log: "{{ __sap_vm_provision_no_log }}"
@@ -256,7 +256,7 @@
         health_type: tcp
         health_monitor_port: "{{ ibmcloud_lb_pool_healthcheck_nwas_ascs }}"
         ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-      when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
+      when: (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0))
 
     - name: Update IBM Cloud Load Balancer Back-end Pool Health Check Port to Linux Pacemaker controlled listening port for SAP NetWeaver ASCS - SAP Start Service (SAPControl SOAP) HTTP sapctrl<ASCS_NN> process
       no_log: "{{ __sap_vm_provision_no_log }}"
@@ -273,7 +273,7 @@
         health_type: tcp
         health_monitor_port: "{{ ibmcloud_lb_pool_healthcheck_nwas_ascs }}"
         ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-      when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
+      when: (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0))
 
     - name: Update IBM Cloud Load Balancer Back-end Pool Health Check Port to Linux Pacemaker controlled listening port for SAP NetWeaver ASCS - SAP Start Service (SAPControl SOAP) HTTPS (Secure) sapctrls<ASCS_NN>
       no_log: "{{ __sap_vm_provision_no_log }}"
@@ -290,7 +290,7 @@
         health_type: tcp
         health_monitor_port: "{{ ibmcloud_lb_pool_healthcheck_nwas_ascs }}"
         ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-      when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
+      when: (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0))
 
     # - name: Update IBM Cloud Load Balancer Back-end Pool Health Check Port to Linux Pacemaker controlled listening port for SAP NetWeaver ERS - Dispatcher sapdp<ERS_NN> process
     #   no_log: "{{ __sap_vm_provision_no_log }}"
@@ -307,7 +307,7 @@
     #     health_type: tcp
     #     health_monitor_port: "{{ ibmcloud_lb_pool_healthcheck_nwas_ers }}"
     #     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-    #   when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
+    #   when: (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0))
 
     # - name: Update IBM Cloud Load Balancer Back-end Pool Health Check Port to Linux Pacemaker controlled listening port for SAP NetWeaver ERS - Message Server sapms<SAPSID> process
     #   no_log: "{{ __sap_vm_provision_no_log }}"
@@ -324,7 +324,7 @@
     #     health_type: tcp
     #     health_monitor_port: "{{ ibmcloud_lb_pool_healthcheck_nwas_ers }}"
     #     ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-    #   when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
+    #   when: (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0))
 
     - name: Update IBM Cloud Load Balancer Back-end Pool Health Check Port to Linux Pacemaker controlled listening port for SAP NetWeaver ERS - Enqueue Replication Server sapenqr<SAPSID> process
       no_log: "{{ __sap_vm_provision_no_log }}"
@@ -341,7 +341,7 @@
         health_type: tcp
         health_monitor_port: "{{ ibmcloud_lb_pool_healthcheck_nwas_ers }}"
         ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-      when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
+      when: (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0))
 
     - name: Update IBM Cloud Load Balancer Back-end Pool Health Check Port to Linux Pacemaker controlled listening port for SAP NetWeaver ERS - SAP Start Service (SAPControl SOAP) HTTP sapctrl<ERS_NN> process
       no_log: "{{ __sap_vm_provision_no_log }}"
@@ -358,7 +358,7 @@
         health_type: tcp
         health_monitor_port: "{{ ibmcloud_lb_pool_healthcheck_nwas_ers }}"
         ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-      when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
+      when: (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0))
 
     - name: Update IBM Cloud Load Balancer Back-end Pool Health Check Port to Linux Pacemaker controlled listening port for SAP NetWeaver ERS - SAP Start Service (SAPControl SOAP) HTTPS (Secure) sapctrls<ERS_NN>
       no_log: "{{ __sap_vm_provision_no_log }}"
@@ -375,4 +375,4 @@
         health_type: tcp
         health_monitor_port: "{{ ibmcloud_lb_pool_healthcheck_nwas_ers }}"
         ibmcloud_api_key: "{{ sap_vm_provision_ibmcloud_api_key }}"
-      when: (groups['nwas_ers'] is defined and (groups['nwas_ers'] | length>0))
+      when: (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0))

--- a/roles/sap_vm_provision/tasks/platform_ansible/ibmpowervm_vm/execute_main.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/ibmpowervm_vm/execute_main.yml
@@ -63,9 +63,9 @@
         validate_certs: false # Allow Self-Signed Certificate
         auth: "{{ __sap_vm_provision_task_ibmpowervm_openstack_auth }}"
       loop:
-        - "{{ 'hana'  if 'hana_secondary' in lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan] | json_query('*') | map(attribute='sap_host_type') else '' }}"
-        - "{{ 'anydb' if 'anydb_secondary' in lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan] | json_query('*') | map(attribute='sap_host_type') else '' }}"
-        - "{{ 'nwas'  if 'nwas_ers' in lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan] | json_query('*') | map(attribute='sap_host_type') else '' }}"
+        - "{{ 'hana'  if sap_vm_provision_group_hana_secondary in lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan] | json_query('*') | map(attribute='sap_host_type') else '' }}"
+        - "{{ 'anydb' if sap_vm_provision_group_anydb_secondary in lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan] | json_query('*') | map(attribute='sap_host_type') else '' }}"
+        - "{{ 'nwas'  if sap_vm_provision_group_nwas_ers in lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan] | json_query('*') | map(attribute='sap_host_type') else '' }}"
       when:
         - sap_vm_provision_ibmpowervm_placement_resource_name is defined
         - sap_vm_provision_ibmpowervm_placement_strategy_spread
@@ -99,7 +99,7 @@
 
     - name: Set fact to hold all inventory hosts in all groups
       ansible.builtin.set_fact:
-        groups_merged_list: "{{ [ [ groups['hana_primary'] | default([]) ] , [ groups['hana_secondary'] | default([]) ] , [ groups['anydb_primary'] | default([]) ] , [ groups['anydb_secondary'] | default([]) ] , [ groups['nwas_ascs'] | default([]) ] , [ groups['nwas_ers'] | default([]) ] , [ groups['nwas_pas'] | default([]) ] , [ groups['nwas_aas'] | default([]) ] ] | flatten | select() }}"
+        groups_merged_list: "{{ [ [ groups[sap_vm_provision_group_hana_primary] | default([]) ] , [ groups[sap_vm_provision_group_hana_secondary] | default([]) ] , [ groups[sap_vm_provision_group_anydb_primary] | default([]) ] , [ groups[sap_vm_provision_group_anydb_secondary] | default([]) ] , [ groups[sap_vm_provision_group_nwas_ascs] | default([]) ] , [ groups[sap_vm_provision_group_nwas_ers] | default([]) ] , [ groups[sap_vm_provision_group_nwas_pas] | default([]) ] , [ groups[sap_vm_provision_group_nwas_aas] | default([]) ] ] | flatten | select() }}"
 
     - name: Set Ansible Vars
       register: __sap_vm_provision_task_ansible_vars_set
@@ -167,14 +167,14 @@
       ansible.builtin.include_tasks:
         file: common/set_etc_hosts_ha.yml
       when:
-        - (groups["hana_secondary"] is defined and (groups["hana_secondary"] | length>0)) or (groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0)) or (groups["anydb_secondary"] is defined and (groups["anydb_secondary"] | length>0))
+        - (groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary] | length>0)) or (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0)) or (groups[sap_vm_provision_group_anydb_secondary] is defined and (groups[sap_vm_provision_group_anydb_secondary] | length>0))
 
     - name: Set /etc/hosts for Scale-Out
       register: __sap_vm_provision_task_os_etc_hosts_scaleout
       ansible.builtin.include_tasks:
         file: common/set_etc_hosts_scaleout.yml
       when:
-        - (groups["hana_primary"] is defined and (groups["hana_primary"] | length>0)) and (sap_vm_provision_calculate_sap_hana_scaleout_active_coordinator is defined or sap_vm_provision_calculate_sap_hana_scaleout_active_worker is defined or sap_vm_provision_calculate_sap_hana_scaleout_standby is defined)
+        - (groups[sap_vm_provision_group_hana_primary] is defined and (groups[sap_vm_provision_group_hana_primary] | length>0)) and (sap_vm_provision_calculate_sap_hana_scaleout_active_coordinator is defined or sap_vm_provision_calculate_sap_hana_scaleout_active_worker is defined or sap_vm_provision_calculate_sap_hana_scaleout_standby is defined)
 
     - name: Set vars for sap_storage_setup Ansible Role
       register: __sap_vm_provision_task_ansible_vars_storage

--- a/roles/sap_vm_provision/tasks/platform_ansible/ibmpowervm_vm/execute_provision.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/ibmpowervm_vm/execute_provision.yml
@@ -178,13 +178,13 @@
           #   "drivers:multipath": "0"
           group: "{{ (
             (__sap_vm_provision_task_ibmpowervm_collocation_rule.results | selectattr('item','==','hana'))[0].name
-            if ('hana_primary' in target_provision_host_spec.sap_host_type or 'hana_secondary' in target_provision_host_spec.sap_host_type)
+            if (sap_vm_provision_group_hana_primary in target_provision_host_spec.sap_host_type or sap_vm_provision_group_hana_secondary in target_provision_host_spec.sap_host_type)
             else
             (__sap_vm_provision_task_ibmpowervm_collocation_rule.results | selectattr('item','==','anydb'))[0].name
-            if ('anydb_primary' in target_provision_host_spec.sap_host_type or 'anydb_secondary' in target_provision_host_spec.sap_host_type)
+            if (sap_vm_provision_group_anydb_primary in target_provision_host_spec.sap_host_type or sap_vm_provision_group_anydb_secondary in target_provision_host_spec.sap_host_type)
             else
             (__sap_vm_provision_task_ibmpowervm_collocation_rule.results | selectattr('item','==','nwas'))[0].name
-            if ('nwas_ascs' in target_provision_host_spec.sap_host_type or 'nwas_ers' in target_provision_host_spec.sap_host_type)
+            if (sap_vm_provision_group_nwas_ascs in target_provision_host_spec.sap_host_type or sap_vm_provision_group_nwas_ers in target_provision_host_spec.sap_host_type)
             ) | default(omit) }}"
 
         validate_certs: false # Allow Self-Signed Certificate
@@ -330,13 +330,13 @@
       #   "drivers:multipath": "0"
       group: "{{ (
         (__sap_vm_provision_task_ibmpowervm_collocation_rule.results | selectattr('item','==','hana'))[0].name
-        if ('hana_primary' in target_provision_host_spec.sap_host_type or 'hana_secondary' in target_provision_host_spec.sap_host_type)
+        if (sap_vm_provision_group_hana_primary in target_provision_host_spec.sap_host_type or sap_vm_provision_group_hana_secondary in target_provision_host_spec.sap_host_type)
         else
         (__sap_vm_provision_task_ibmpowervm_collocation_rule.results | selectattr('item','==','anydb'))[0].name
-        if ('anydb_primary' in target_provision_host_spec.sap_host_type or 'anydb_secondary' in target_provision_host_spec.sap_host_type)
+        if (sap_vm_provision_group_anydb_primary in target_provision_host_spec.sap_host_type or sap_vm_provision_group_anydb_secondary in target_provision_host_spec.sap_host_type)
         else
         (__sap_vm_provision_task_ibmpowervm_collocation_rule.results | selectattr('item','==','nwas'))[0].name
-        if ('nwas_ascs' in target_provision_host_spec.sap_host_type or 'nwas_ers' in target_provision_host_spec.sap_host_type)
+        if (sap_vm_provision_group_nwas_ascs in target_provision_host_spec.sap_host_type or sap_vm_provision_group_nwas_ers in target_provision_host_spec.sap_host_type)
         ) | default(omit) }}"
 
     validate_certs: false # Allow Self-Signed Certificate

--- a/roles/sap_vm_provision/tasks/platform_ansible/kubevirt_vm/execute_main.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/kubevirt_vm/execute_main.yml
@@ -39,7 +39,7 @@
 
     - name: Set fact to hold all inventory hosts in all groups
       ansible.builtin.set_fact:
-        groups_merged_list: "{{ [ [ groups['hana_primary'] | default([]) ] , [ groups['hana_secondary'] | default([]) ] , [ groups['nwas_ascs'] | default([]) ] , [ groups['nwas_ers'] | default([]) ] , [ groups['nwas_pas'] | default([]) ] , [ groups['nwas_aas'] | default([]) ] ] | flatten | select() }}"
+        groups_merged_list: "{{ [ [ groups[sap_vm_provision_group_hana_primary] | default([]) ] , [ groups[sap_vm_provision_group_hana_secondary] | default([]) ] , [ groups[sap_vm_provision_group_nwas_ascs] | default([]) ] , [ groups[sap_vm_provision_group_nwas_ers] | default([]) ] , [ groups[sap_vm_provision_group_nwas_pas] | default([]) ] , [ groups[sap_vm_provision_group_nwas_aas] | default([]) ] ] | flatten | select() }}"
 
     - name: Set Ansible Vars
       register: __sap_vm_provision_task_ansible_vars_set
@@ -111,14 +111,14 @@
       ansible.builtin.include_tasks:
         file: common/set_etc_hosts_ha.yml
       when:
-        - (groups["hana_secondary"] is defined and (groups["hana_secondary"] | length>0)) or (groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0)) or (groups["anydb_secondary"] is defined and (groups["anydb_secondary"] | length>0))
+        - (groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary] | length>0)) or (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0)) or (groups[sap_vm_provision_group_anydb_secondary] is defined and (groups[sap_vm_provision_group_anydb_secondary] | length>0))
 
     - name: Set /etc/hosts for Scale-Out
       register: __sap_vm_provision_task_os_etc_hosts_scaleout
       ansible.builtin.include_tasks:
         file: common/set_etc_hosts_scaleout.yml
       when:
-        - (groups["hana_primary"] is defined and (groups["hana_primary"] | length>0)) and (sap_vm_provision_calculate_sap_hana_scaleout_active_coordinator is defined or sap_vm_provision_calculate_sap_hana_scaleout_active_worker is defined or sap_vm_provision_calculate_sap_hana_scaleout_standby is defined)
+        - (groups[sap_vm_provision_group_hana_primary] is defined and (groups[sap_vm_provision_group_hana_primary] | length>0)) and (sap_vm_provision_calculate_sap_hana_scaleout_active_coordinator is defined or sap_vm_provision_calculate_sap_hana_scaleout_active_worker is defined or sap_vm_provision_calculate_sap_hana_scaleout_standby is defined)
 
     - name: Set vars for sap_storage_setup Ansible Role
       register: __sap_vm_provision_task_ansible_vars_storage

--- a/roles/sap_vm_provision/tasks/platform_ansible/msazure_vm/execute_main.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/msazure_vm/execute_main.yml
@@ -64,9 +64,9 @@
         client_id: "{{ sap_vm_provision_msazure_app_client_id }}"
         secret: "{{ sap_vm_provision_msazure_app_client_secret }}"
       loop:
-        - "{{ 'hana'  if 'hana_secondary' in lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan] | json_query('*') | map(attribute='sap_host_type') else '' }}"
-        - "{{ 'anydb' if 'anydb_secondary' in lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan] | json_query('*') | map(attribute='sap_host_type') else '' }}"
-        - "{{ 'nwas'  if 'nwas_ers' in lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan] | json_query('*') | map(attribute='sap_host_type') else '' }}"
+        - "{{ 'hana'  if sap_vm_provision_group_hana_secondary in lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan] | json_query('*') | map(attribute='sap_host_type') else '' }}"
+        - "{{ 'anydb' if sap_vm_provision_group_anydb_secondary in lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan] | json_query('*') | map(attribute='sap_host_type') else '' }}"
+        - "{{ 'nwas'  if sap_vm_provision_group_nwas_ers in lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan] | json_query('*') | map(attribute='sap_host_type') else '' }}"
       when:
         - sap_vm_provision_aws_placement_resource_name is defined
         - sap_vm_provision_aws_placement_strategy_spread
@@ -108,7 +108,7 @@
 
     - name: Set fact to hold all inventory hosts in all groups
       ansible.builtin.set_fact:
-        groups_merged_list: "{{ [ [ groups['hana_primary'] | default([]) ] , [ groups['hana_secondary'] | default([]) ] , [ groups['anydb_primary'] | default([]) ] , [ groups['anydb_secondary'] | default([]) ] , [ groups['nwas_ascs'] | default([]) ] , [ groups['nwas_ers'] | default([]) ] , [ groups['nwas_pas'] | default([]) ] , [ groups['nwas_aas'] | default([]) ] ] | flatten | select() }}"
+        groups_merged_list: "{{ [ [ groups[sap_vm_provision_group_hana_primary] | default([]) ] , [ groups[sap_vm_provision_group_hana_secondary] | default([]) ] , [ groups[sap_vm_provision_group_anydb_primary] | default([]) ] , [ groups[sap_vm_provision_group_anydb_secondary] | default([]) ] , [ groups[sap_vm_provision_group_nwas_ascs] | default([]) ] , [ groups[sap_vm_provision_group_nwas_ers] | default([]) ] , [ groups[sap_vm_provision_group_nwas_pas] | default([]) ] , [ groups[sap_vm_provision_group_nwas_aas] | default([]) ] ] | flatten | select() }}"
 
     - name: Set Ansible Vars
       register: __sap_vm_provision_task_ansible_vars_set
@@ -190,14 +190,14 @@
       ansible.builtin.include_tasks:
         file: common/set_etc_hosts_ha.yml
       when:
-        - (groups["hana_secondary"] is defined and (groups["hana_secondary"] | length>0)) or (groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0)) or (groups["anydb_secondary"] is defined and (groups["anydb_secondary"] | length>0))
+        - (groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary] | length>0)) or (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0)) or (groups[sap_vm_provision_group_anydb_secondary] is defined and (groups[sap_vm_provision_group_anydb_secondary] | length>0))
 
     - name: Set /etc/hosts for Scale-Out
       register: __sap_vm_provision_task_os_etc_hosts_scaleout
       ansible.builtin.include_tasks:
         file: common/set_etc_hosts_scaleout.yml
       when:
-        - (groups["hana_primary"] is defined and (groups["hana_primary"] | length>0)) and (sap_vm_provision_calculate_sap_hana_scaleout_active_coordinator is defined or sap_vm_provision_calculate_sap_hana_scaleout_active_worker is defined or sap_vm_provision_calculate_sap_hana_scaleout_standby is defined)
+        - (groups[sap_vm_provision_group_hana_primary] is defined and (groups[sap_vm_provision_group_hana_primary] | length>0)) and (sap_vm_provision_calculate_sap_hana_scaleout_active_coordinator is defined or sap_vm_provision_calculate_sap_hana_scaleout_active_worker is defined or sap_vm_provision_calculate_sap_hana_scaleout_standby is defined)
 
     - name: Set vars for sap_storage_setup Ansible Role
       register: __sap_vm_provision_task_ansible_vars_storage
@@ -213,7 +213,7 @@
   delegate_to: "{{ inventory_hostname }}"
   when:
     - sap_ha_pacemaker_cluster_msazure_resource_group is defined
-    - (groups["hana_secondary"] is defined and (groups["hana_secondary"] | length>0)) or (groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0)) or (groups["anydb_secondary"] is defined and (groups["anydb_secondary"] | length>0))
+    - (groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary] | length>0)) or (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0)) or (groups[sap_vm_provision_group_anydb_secondary] is defined and (groups[sap_vm_provision_group_anydb_secondary] | length>0))
   block:
 
     # Do not enable TCP timestamps on Azure VMs placed behind Azure Load Balancer.
@@ -258,7 +258,7 @@
     # AZURE_SECRET: "{{ sap_vm_provision_msazure_app_client_secret }}"
   when:
     - sap_ha_pacemaker_cluster_msazure_resource_group is defined
-    - (groups["hana_secondary"] is defined and (groups["hana_secondary"] | length>0)) or (groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0)) or (groups["anydb_secondary"] is defined and (groups["anydb_secondary"] | length>0))
+    - (groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary] | length>0)) or (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0)) or (groups[sap_vm_provision_group_anydb_secondary] is defined and (groups[sap_vm_provision_group_anydb_secondary] | length>0))
   block:
 
     - name: Provision High Availability resources for MS Azure VM hosts

--- a/roles/sap_vm_provision/tasks/platform_ansible/msazure_vm/execute_provision.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/msazure_vm/execute_provision.yml
@@ -48,13 +48,13 @@
     enable_ip_forwarding: "{{ target_provision_host_spec.disable_ip_anti_spoofing }}" # When disable the Anti IP Spoofing = true, then Enable IP Forwarding = true
     availability_set: "{{ (
       (__sap_vm_provision_task_msazure_availability_set.results | selectattr('item','==','hana'))[0].state.name
-      if ('hana_primary' in target_provision_host_spec.sap_host_type or 'hana_secondary' in target_provision_host_spec.sap_host_type)
+      if (sap_vm_provision_group_hana_primary in target_provision_host_spec.sap_host_type or sap_vm_provision_group_hana_secondary in target_provision_host_spec.sap_host_type)
       else
       (__sap_vm_provision_task_msazure_availability_set.results | selectattr('item','==','anydb'))[0].state.name
-      if ('anydb_primary' in target_provision_host_spec.sap_host_type or 'anydb_secondary' in target_provision_host_spec.sap_host_type)
+      if (sap_vm_provision_group_anydb_primary in target_provision_host_spec.sap_host_type or sap_vm_provision_group_anydb_secondary in target_provision_host_spec.sap_host_type)
       else
       (__sap_vm_provision_task_msazure_availability_set.results | selectattr('item','==','nwas'))[0].state.name
-      if ('nwas_ascs' in target_provision_host_spec.sap_host_type or 'nwas_ers' in target_provision_host_spec.sap_host_type)
+      if (sap_vm_provision_group_nwas_ascs in target_provision_host_spec.sap_host_type or sap_vm_provision_group_nwas_ers in target_provision_host_spec.sap_host_type)
       ) | default(omit) }}"
     # Azure credentials
     subscription_id: "{{ sap_vm_provision_msazure_subscription_id }}"

--- a/roles/sap_vm_provision/tasks/platform_ansible/msazure_vm/execute_setup_ha.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/msazure_vm/execute_setup_ha.yml
@@ -27,11 +27,11 @@
 #     tenant: "{{ sap_vm_provision_msazure_tenant_id }}"
 #     client_id: "{{ sap_vm_provision_msazure_app_client_id }}"
 #     secret: "{{ sap_vm_provision_msazure_app_client_secret }}"
-#   loop: "{{ (groups['hana_primary'] | default([])) }}"
+#   loop: "{{ (groups[sap_vm_provision_group_hana_primary] | default([])) }}"
 #   loop_control:
 #     loop_var: host_node
 #   when:
-#     - groups["hana_secondary"] is defined and (groups["hana_secondary"] | length>0)
+#     - groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary] | length>0)
 
 - name: Ansible MS Azure Private DNS Records for SAP HANA HA Virtual Hostname
   no_log: "{{ __sap_vm_provision_no_log }}"
@@ -48,11 +48,11 @@
     tenant: "{{ sap_vm_provision_msazure_tenant_id }}"
     client_id: "{{ sap_vm_provision_msazure_app_client_id }}"
     secret: "{{ sap_vm_provision_msazure_app_client_secret }}"
-  loop: "{{ (groups['hana_primary'] | default([])) }}"
+  loop: "{{ (groups[sap_vm_provision_group_hana_primary] | default([])) }}"
   loop_control:
     loop_var: host_node
   when:
-    - groups["hana_secondary"] is defined and (groups["hana_secondary"]|length>0)
+    - groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary]|length>0)
 
 
 # - name: Ansible MS Azure Route Table append route for SAP AnyDB HA
@@ -70,11 +70,11 @@
 #     tenant: "{{ sap_vm_provision_msazure_tenant_id }}"
 #     client_id: "{{ sap_vm_provision_msazure_app_client_id }}"
 #     secret: "{{ sap_vm_provision_msazure_app_client_secret }}"
-#   loop: "{{ (groups['anydb_primary'] | default([])) }}"
+#   loop: "{{ (groups[sap_vm_provision_group_anydb_primary] | default([])) }}"
 #   loop_control:
 #     loop_var: host_node
 #   when:
-#     - groups["anydb_secondary"] is defined and (groups["anydb_secondary"] | length>0)
+#     - groups[sap_vm_provision_group_anydb_secondary] is defined and (groups[sap_vm_provision_group_anydb_secondary] | length>0)
 
 - name: Ansible MS Azure Private DNS Records for SAP AnyDB HA Virtual Hostname
   no_log: "{{ __sap_vm_provision_no_log }}"
@@ -91,11 +91,11 @@
     tenant: "{{ sap_vm_provision_msazure_tenant_id }}"
     client_id: "{{ sap_vm_provision_msazure_app_client_id }}"
     secret: "{{ sap_vm_provision_msazure_app_client_secret }}"
-  loop: "{{ (groups['anydb_primary'] | default([])) }}"
+  loop: "{{ (groups[sap_vm_provision_group_anydb_primary] | default([])) }}"
   loop_control:
     loop_var: host_node
   when:
-    - groups["anydb_secondary"] is defined and (groups["anydb_secondary"]|length>0)
+    - groups[sap_vm_provision_group_anydb_secondary] is defined and (groups[sap_vm_provision_group_anydb_secondary]|length>0)
 
 
 # - name: Ansible MS Azure Route Table append route for SAP NetWeaver ASCS HA
@@ -113,11 +113,11 @@
 #     tenant: "{{ sap_vm_provision_msazure_tenant_id }}"
 #     client_id: "{{ sap_vm_provision_msazure_app_client_id }}"
 #     secret: "{{ sap_vm_provision_msazure_app_client_secret }}"
-#   loop: "{{ (groups['nwas_ascs'] | default([])) }}"
+#   loop: "{{ (groups[sap_vm_provision_group_nwas_ascs] | default([])) }}"
 #   loop_control:
 #     loop_var: host_node
 #   when:
-#     - groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0)
+#     - groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0)
 
 - name: Ansible MS Azure Private DNS Records for SAP NetWeaver ASCS HA Virtual Hostname
   no_log: "{{ __sap_vm_provision_no_log }}"
@@ -134,11 +134,11 @@
     tenant: "{{ sap_vm_provision_msazure_tenant_id }}"
     client_id: "{{ sap_vm_provision_msazure_app_client_id }}"
     secret: "{{ sap_vm_provision_msazure_app_client_secret }}"
-  loop: "{{ (groups['nwas_ascs'] | default([])) }}"
+  loop: "{{ (groups[sap_vm_provision_group_nwas_ascs] | default([])) }}"
   loop_control:
     loop_var: host_node
   when:
-    - groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
+    - groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers]|length>0)
 
 
 # - name: Ansible MS Azure Route Table append route for SAP NetWeaver ERS HA
@@ -156,11 +156,11 @@
 #     tenant: "{{ sap_vm_provision_msazure_tenant_id }}"
 #     client_id: "{{ sap_vm_provision_msazure_app_client_id }}"
 #     secret: "{{ sap_vm_provision_msazure_app_client_secret }}"
-#   loop: "{{ (groups['nwas_ers'] | default([])) }}"
+#   loop: "{{ (groups[sap_vm_provision_group_nwas_ers] | default([])) }}"
 #   loop_control:
 #     loop_var: host_node
 #   when:
-#     - groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0)
+#     - groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0)
 
 - name: Ansible MS Azure Private DNS Records for SAP NetWeaver ERS HA Virtual Hostname
   no_log: "{{ __sap_vm_provision_no_log }}"
@@ -177,11 +177,11 @@
     tenant: "{{ sap_vm_provision_msazure_tenant_id }}"
     client_id: "{{ sap_vm_provision_msazure_app_client_id }}"
     secret: "{{ sap_vm_provision_msazure_app_client_secret }}"
-  loop: "{{ (groups['nwas_ers'] | default([])) }}"
+  loop: "{{ (groups[sap_vm_provision_group_nwas_ers] | default([])) }}"
   loop_control:
     loop_var: host_node
   when:
-    - groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
+    - groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers]|length>0)
 
 
 ## For HA of PAS and AAS, if required
@@ -201,11 +201,11 @@
 #     tenant: "{{ sap_vm_provision_msazure_tenant_id }}"
 #     client_id: "{{ sap_vm_provision_msazure_app_client_id }}"
 #     secret: "{{ sap_vm_provision_msazure_app_client_secret }}"
-#   loop: "{{ (groups['nwas_pas'] | default([])) }}"
+#   loop: "{{ (groups[sap_vm_provision_group_nwas_pas] | default([])) }}"
 #   loop_control:
 #     loop_var: host_node
 #   when:
-#     - groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0)
+#     - groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0)
 
 # - name: Ansible MS Azure Private DNS Records for SAP NetWeaver PAS HA Virtual Hostname
 #   no_log: "{{ __sap_vm_provision_no_log }}"
@@ -222,11 +222,11 @@
 #     tenant: "{{ sap_vm_provision_msazure_tenant_id }}"
 #     client_id: "{{ sap_vm_provision_msazure_app_client_id }}"
 #     secret: "{{ sap_vm_provision_msazure_app_client_secret }}"
-#   loop: "{{ (groups['nwas_pas'] | default([])) }}"
+#   loop: "{{ (groups[sap_vm_provision_group_nwas_pas] | default([])) }}"
 #   loop_control:
 #     loop_var: host_node
 #   when:
-#     - groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
+#     - groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers]|length>0)
 
 
 # - name: Ansible MS Azure Route Table append route for SAP NetWeaver AAS HA
@@ -244,11 +244,11 @@
 #     tenant: "{{ sap_vm_provision_msazure_tenant_id }}"
 #     client_id: "{{ sap_vm_provision_msazure_app_client_id }}"
 #     secret: "{{ sap_vm_provision_msazure_app_client_secret }}"
-#   loop: "{{ (groups['nwas_aas'] | default([])) }}"
+#   loop: "{{ (groups[sap_vm_provision_group_nwas_aas] | default([])) }}"
 #   loop_control:
 #     loop_var: host_node
 #   when:
-#     - groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0)
+#     - groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0)
 
 # - name: Ansible MS Azure Private DNS Records for SAP NetWeaver AAS HA Virtual Hostname
 #   no_log: "{{ __sap_vm_provision_no_log }}"
@@ -265,11 +265,11 @@
 #     tenant: "{{ sap_vm_provision_msazure_tenant_id }}"
 #     client_id: "{{ sap_vm_provision_msazure_app_client_id }}"
 #     secret: "{{ sap_vm_provision_msazure_app_client_secret }}"
-#   loop: "{{ (groups['nwas_aas'] | default([])) }}"
+#   loop: "{{ (groups[sap_vm_provision_group_nwas_aas] | default([])) }}"
 #   loop_control:
 #     loop_var: host_node
 #   when:
-#     - groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
+#     - groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers]|length>0)
 
 
 - name: MS Azure IAM Role - Prepare IAM Role name
@@ -409,7 +409,7 @@
     # AZURE_SECRET: "{{ sap_vm_provision_msazure_app_client_secret }}"
   when:
     - sap_ha_pacemaker_cluster_msazure_resource_group is defined
-    - (groups["hana_secondary"] is defined and (groups["hana_secondary"] | length>0)) or (groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0)) or (groups["anydb_secondary"] is defined and (groups["anydb_secondary"] | length>0))
+    - (groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary] | length>0)) or (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0)) or (groups[sap_vm_provision_group_anydb_secondary] is defined and (groups[sap_vm_provision_group_anydb_secondary] | length>0))
   block:
 
     - name: Gather MS Azure Subnet ID
@@ -437,7 +437,7 @@
           zones: ["1", "2", "3"] # Zone-redundant
       when:
         - vip_item | length > 0
-        - groups["hana_secondary"] is defined and (groups["hana_secondary"]|length>0)
+        - groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary]|length>0)
       loop:
         - "{{ sap_vm_provision_ha_vip_hana_primary }}"
       loop_control:
@@ -456,7 +456,7 @@
           zones: ["1", "2", "3"] # Zone-redundant
       when:
         - vip_item | length > 0
-        - groups["anydb_secondary"] is defined and (groups["anydb_secondary"]|length>0)
+        - groups[sap_vm_provision_group_anydb_secondary] is defined and (groups[sap_vm_provision_group_anydb_secondary]|length>0)
       loop:
         - "{{ sap_vm_provision_ha_vip_anydb_primary }}"
       loop_control:
@@ -475,7 +475,7 @@
           zones: ["1", "2", "3"] # Zone-redundant
       when:
         - vip_item | length > 0
-        - groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
+        - groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers]|length>0)
       loop:
         - "{{ sap_vm_provision_ha_vip_nwas_abap_ascs }}"
         - "{{ sap_vm_provision_ha_vip_nwas_abap_ers }}"
@@ -496,7 +496,7 @@
           fail_count: 2
       when:
         - sapinstance_item | length > 0
-        - groups["hana_secondary"] is defined and (groups["hana_secondary"]|length>0)
+        - groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary]|length>0)
       loop:
         - "{{ sap_system_hana_db_instance_nr | default() }}"
       loop_control:
@@ -514,7 +514,7 @@
           interval: 5
           fail_count: 2
       when:
-        - groups["anydb_secondary"] is defined and (groups["anydb_secondary"]|length>0)
+        - groups[sap_vm_provision_group_anydb_secondary] is defined and (groups[sap_vm_provision_group_anydb_secondary]|length>0)
 
     - name: Define Ansible Variables for Azure Load Balancer - VIP Health Check for SAP NetWeaver ASCS/ERS
       ansible.builtin.set_fact:
@@ -528,7 +528,7 @@
           fail_count: 2
       when:
         - sapinstance_item | length > 0
-        - groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
+        - groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers]|length>0)
       loop:
         - "{{ sap_system_nwas_abap_ascs_instance_nr | default() }}"
         - "{{ sap_system_nwas_abap_ers_instance_nr | default() }}"
@@ -554,7 +554,7 @@
           enable_floating_ip: true # enable Frontend IP as a Floating IP (aka. Direct Server Return), if disabled then only 1 LB Rule allowed
       when:
         - rule_item | length > 0
-        - groups["hana_secondary"] is defined and (groups["hana_secondary"]|length>0)
+        - groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary]|length>0)
       loop:
         - "{{ sap_vm_provision_ha_vip_hana_primary }}"
       loop_control:
@@ -578,7 +578,7 @@
           enable_floating_ip: true # enable Frontend IP as a Floating IP (aka. Direct Server Return), if disabled then only 1 LB Rule allowed
       when:
         - rule_item | length > 0
-        - groups["anydb_secondary"] is defined and (groups["anydb_secondary"]|length>0)
+        - groups[sap_vm_provision_group_anydb_secondary] is defined and (groups[sap_vm_provision_group_anydb_secondary]|length>0)
       loop:
         - "{{ sap_vm_provision_ha_vip_anydb_primary }}"
       loop_control:
@@ -602,7 +602,7 @@
           enable_floating_ip: true # enable Frontend IP as a Floating IP (aka. Direct Server Return), if disabled then only 1 LB Rule allowed
       when:
         - rule_item | length > 0
-        - groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
+        - groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers]|length>0)
       loop:
         - "{{ sap_vm_provision_ha_vip_nwas_abap_ascs }}"
         - "{{ sap_vm_provision_ha_vip_nwas_abap_ers }}"
@@ -627,7 +627,7 @@
         tenant: "{{ sap_vm_provision_msazure_tenant_id }}"
         client_id: "{{ sap_vm_provision_msazure_app_client_id }}"
         secret: "{{ sap_vm_provision_msazure_app_client_secret }}"
-      when: (groups["hana_secondary"] is defined and (groups["hana_secondary"]|length>0))
+      when: (groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary]|length>0))
 
     - name: MS Azure Load Balancer (network L4) - Create NLB for SAP AnyDB with Virtual IP and Health Probe configuration
       no_log: "{{ __sap_vm_provision_no_log }}"
@@ -646,7 +646,7 @@
         tenant: "{{ sap_vm_provision_msazure_tenant_id }}"
         client_id: "{{ sap_vm_provision_msazure_app_client_id }}"
         secret: "{{ sap_vm_provision_msazure_app_client_secret }}"
-      when: (groups["anydb_secondary"] is defined and (groups["anydb_secondary"]|length>0))
+      when: (groups[sap_vm_provision_group_anydb_secondary] is defined and (groups[sap_vm_provision_group_anydb_secondary]|length>0))
 
     - name: MS Azure Load Balancer (network L4) - Create NLB for SAP NetWeaver with Virtual IP and Health Probe configuration
       no_log: "{{ __sap_vm_provision_no_log }}"
@@ -665,27 +665,27 @@
         tenant: "{{ sap_vm_provision_msazure_tenant_id }}"
         client_id: "{{ sap_vm_provision_msazure_app_client_id }}"
         secret: "{{ sap_vm_provision_msazure_app_client_secret }}"
-      when: (groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0))
+      when: (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers]|length>0))
 
     - name: MS Azure Load Balancer (network L4) - Define Ansible Variable of Load Balancer for Database Server
       ansible.builtin.set_fact:
-        __sap_vm_provision_task_msazure_lb1_info: "{{ __sap_vm_provision_task_msazure_lb1a_info if (groups['hana_secondary'] is defined and (groups['hana_secondary']|length>0)) else __sap_vm_provision_task_msazure_lb1b_info if (groups['anydb_secondary'] is defined and (groups['anydb_secondary']|length>0)) }}"
-      when: (groups["hana_secondary"] is defined and (groups["hana_secondary"]|length>0)) or (groups["anydb_secondary"] is defined and (groups["anydb_secondary"]|length>0))
+        __sap_vm_provision_task_msazure_lb1_info: "{{ __sap_vm_provision_task_msazure_lb1a_info if (groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary]|length>0)) else __sap_vm_provision_task_msazure_lb1b_info if (groups[sap_vm_provision_group_anydb_secondary] is defined and (groups[sap_vm_provision_group_anydb_secondary]|length>0)) }}"
+      when: (groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary]|length>0)) or (groups[sap_vm_provision_group_anydb_secondary] is defined and (groups[sap_vm_provision_group_anydb_secondary]|length>0))
 
     - name: Set fact to hold loop variables from include_tasks when SAP HANA HA
       ansible.builtin.set_fact:
         lb_ha_sap_hana: "{{ __sap_vm_provision_task_msazure_lb1_info.state.backend_address_pools | selectattr('name', '==', sap_vm_provision_ha_load_balancer_name_hana + '-backend-pool') | map(attribute='id') | first }}"
-      when: (groups["hana_secondary"] is defined and (groups["hana_secondary"]|length>0))
+      when: (groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary]|length>0))
 
     - name: Set fact to hold loop variables from include_tasks when SAP AnyDB HA
       ansible.builtin.set_fact:
         lb_ha_sap_anydb: "{{ __sap_vm_provision_task_msazure_lb1_info.state.backend_address_pools | selectattr('name', '==', sap_vm_provision_ha_load_balancer_name_anydb + '-backend-pool') | map(attribute='id') | first }}"
-      when: (groups["anydb_secondary"] is defined and (groups["anydb_secondary"]|length>0))
+      when: (groups[sap_vm_provision_group_anydb_secondary] is defined and (groups[sap_vm_provision_group_anydb_secondary]|length>0))
 
     - name: Set fact to hold loop variables from include_tasks when SAP NetWeaver HA
       ansible.builtin.set_fact:
         lb_ha_sap_nwas: "{{ __sap_vm_provision_task_msazure_lb2_info.state.backend_address_pools | selectattr('name', '==', sap_vm_provision_ha_load_balancer_name_nwas + '-ascs-backend-pool') | map(attribute='id') | first }}"
-      when: (groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0))
+      when: (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers]|length>0))
 
     - name: Update network interfaces for MS Azure VM - for SAP HANA HA with load balancing
       no_log: "{{ __sap_vm_provision_no_log }}"
@@ -715,7 +715,7 @@
         loop_var: host_node
       when:
         - "'hana_' in lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][host_node].sap_host_type" # REPLACE with substring in any of the strings contained in the list
-        - groups["hana_secondary"] is defined and (groups["hana_secondary"]|length>0)
+        - groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary]|length>0)
 
     - name: Update network interfaces for MS Azure VM - for SAP AnyDB HA with load balancing
       no_log: "{{ __sap_vm_provision_no_log }}"
@@ -745,7 +745,7 @@
         loop_var: host_node
       when:
         - "'anydb_' in lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][host_node].sap_host_type" # REPLACE with substring in any of the strings contained in the list
-        - groups["anydb_secondary"] is defined and (groups["anydb_secondary"]|length>0)
+        - groups[sap_vm_provision_group_anydb_secondary] is defined and (groups[sap_vm_provision_group_anydb_secondary]|length>0)
 
     - name: Update network interfaces for MS Azure VM - for SAP NetWeaver HA ASCS/ERS with load balancing
       no_log: "{{ __sap_vm_provision_no_log }}"
@@ -774,5 +774,5 @@
       loop_control:
         loop_var: host_node
       when:
-        - "'nwas_ascs' in lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][host_node].sap_host_type or 'nwas_ers' in lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][host_node].sap_host_type"  # REPLACE with substring in any of the strings contained in the list
-        - groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
+        - "sap_vm_provision_group_nwas_ascs in lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][host_node].sap_host_type or sap_vm_provision_group_nwas_ers in lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][host_node].sap_host_type"  # REPLACE with substring in any of the strings contained in the list
+        - groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers]|length>0)

--- a/roles/sap_vm_provision/tasks/platform_ansible/msazure_vm/post_deployment_execute.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/msazure_vm/post_deployment_execute.yml
@@ -13,7 +13,7 @@
     # AZURE_SECRET: "{{ sap_vm_provision_msazure_app_client_secret }}"
   when:
     - sap_ha_pacemaker_cluster_msazure_resource_group is defined
-    - (groups["hana_secondary"] is defined and (groups["hana_secondary"] | length>0)) or (groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0)) or (groups["anydb_secondary"] is defined and (groups["anydb_secondary"] | length>0))
+    - (groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary] | length>0)) or (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0)) or (groups[sap_vm_provision_group_anydb_secondary] is defined and (groups[sap_vm_provision_group_anydb_secondary] | length>0))
   block:
 
     - name: Inherit variable - set fact for Azure Load Balancer - VIP Health Check - SAP HANA
@@ -71,7 +71,7 @@
           zones: ["1", "2", "3"] # Zone-redundant
       when:
         - vip_item | length > 0
-        - groups["hana_secondary"] is defined and (groups["hana_secondary"]|length>0)
+        - groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary]|length>0)
       loop:
         - "{{ sap_vm_provision_ha_vip_hana_primary }}"
       loop_control:
@@ -90,7 +90,7 @@
           zones: ["1", "2", "3"] # Zone-redundant
       when:
         - vip_item | length > 0
-        - groups["anydb_secondary"] is defined and (groups["anydb_secondary"]|length>0)
+        - groups[sap_vm_provision_group_anydb_secondary] is defined and (groups[sap_vm_provision_group_anydb_secondary]|length>0)
       loop:
         - "{{ sap_vm_provision_ha_vip_anydb_primary }}"
       loop_control:
@@ -109,7 +109,7 @@
           zones: ["1", "2", "3"] # Zone-redundant
       when:
         - vip_item | length > 0
-        - groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
+        - groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers]|length>0)
       loop:
         - "{{ sap_vm_provision_ha_vip_nwas_abap_ascs }}"
         - "{{ sap_vm_provision_ha_vip_nwas_abap_ers }}"
@@ -130,7 +130,7 @@
           fail_count: 2
       when:
         - healthcheck_item | length > 0
-        - groups["hana_secondary"] is defined and (groups["hana_secondary"]|length>0)
+        - groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary]|length>0)
       loop:
         - "{{ lb_frontend_virtual_ip_healthcheck_hana | default() }}"
       loop_control:
@@ -148,7 +148,7 @@
           interval: 5
           fail_count: 2
       when:
-        - groups["anydb_secondary"] is defined and (groups["anydb_secondary"]|length>0)
+        - groups[sap_vm_provision_group_anydb_secondary] is defined and (groups[sap_vm_provision_group_anydb_secondary]|length>0)
 
     - name: Define Ansible Variables for Azure Load Balancer - VIP Health Check for SAP NetWeaver ASCS/ERS
       ansible.builtin.set_fact:
@@ -162,7 +162,7 @@
           fail_count: 2
       when:
         - healthcheck_item | length > 0
-        - groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
+        - groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers]|length>0)
       loop:
         - "{{ lb_frontend_virtual_ip_healthcheck_nwas_ascs | default() }}"
         - "{{ lb_frontend_virtual_ip_healthcheck_nwas_ers | default() }}"
@@ -188,7 +188,7 @@
           enable_floating_ip: true # enable Frontend IP as a Floating IP (aka. Direct Server Return), if disabled then only 1 LB Rule allowed
       when:
         - rule_item | length > 0
-        - groups["hana_secondary"] is defined and (groups["hana_secondary"]|length>0)
+        - groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary]|length>0)
       loop:
         - "{{ sap_vm_provision_ha_vip_hana_primary }}"
       loop_control:
@@ -212,7 +212,7 @@
           enable_floating_ip: true # enable Frontend IP as a Floating IP (aka. Direct Server Return), if disabled then only 1 LB Rule allowed
       when:
         - rule_item | length > 0
-        - groups["anydb_secondary"] is defined and (groups["anydb_secondary"]|length>0)
+        - groups[sap_vm_provision_group_anydb_secondary] is defined and (groups[sap_vm_provision_group_anydb_secondary]|length>0)
       loop:
         - "{{ sap_vm_provision_ha_vip_anydb_primary }}"
       loop_control:
@@ -236,7 +236,7 @@
           enable_floating_ip: true # enable Frontend IP as a Floating IP (aka. Direct Server Return), if disabled then only 1 LB Rule allowed
       when:
         - rule_item | length > 0
-        - groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0)
+        - groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers]|length>0)
       loop:
         - "{{ sap_vm_provision_ha_vip_nwas_abap_ascs }}"
         - "{{ sap_vm_provision_ha_vip_nwas_abap_ers }}"
@@ -262,7 +262,7 @@
         tenant: "{{ sap_vm_provision_msazure_tenant_id }}"
         client_id: "{{ sap_vm_provision_msazure_app_client_id }}"
         secret: "{{ sap_vm_provision_msazure_app_client_secret }}"
-      when: (groups["hana_secondary"] is defined and (groups["hana_secondary"]|length>0))
+      when: (groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary]|length>0))
 
     - name: MS Azure Load Balancer (network L4) - Update NLB for SAP AnyDB with Virtual IP and Health Probe configuration
       no_log: "{{ __sap_vm_provision_no_log }}"
@@ -281,7 +281,7 @@
         tenant: "{{ sap_vm_provision_msazure_tenant_id }}"
         client_id: "{{ sap_vm_provision_msazure_app_client_id }}"
         secret: "{{ sap_vm_provision_msazure_app_client_secret }}"
-      when: (groups["anydb_secondary"] is defined and (groups["anydb_secondary"]|length>0))
+      when: (groups[sap_vm_provision_group_anydb_secondary] is defined and (groups[sap_vm_provision_group_anydb_secondary]|length>0))
 
     - name: MS Azure Load Balancer (network L4) - Update NLB for SAP NetWeaver with Virtual IP and Health Probe configuration
       no_log: "{{ __sap_vm_provision_no_log }}"
@@ -300,4 +300,4 @@
         tenant: "{{ sap_vm_provision_msazure_tenant_id }}"
         client_id: "{{ sap_vm_provision_msazure_app_client_id }}"
         secret: "{{ sap_vm_provision_msazure_app_client_secret }}"
-      when: (groups["nwas_ers"] is defined and (groups["nwas_ers"]|length>0))
+      when: (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers]|length>0))

--- a/roles/sap_vm_provision/tasks/platform_ansible/ovirt_vm/execute_main.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/ovirt_vm/execute_main.yml
@@ -50,7 +50,7 @@
 
     - name: Set fact to hold all inventory hosts in all groups
       ansible.builtin.set_fact:
-        groups_merged_list: "{{ [ [ groups['hana_primary'] | default([]) ] , [ groups['hana_secondary'] | default([]) ] , [ groups['anydb_primary'] | default([]) ] , [ groups['anydb_secondary'] | default([]) ] , [ groups['nwas_ascs'] | default([]) ] , [ groups['nwas_ers'] | default([]) ] , [ groups['nwas_pas'] | default([]) ] , [ groups['nwas_aas'] | default([]) ] ] | flatten | select() }}"
+        groups_merged_list: "{{ [ [ groups[sap_vm_provision_group_hana_primary] | default([]) ] , [ groups[sap_vm_provision_group_hana_secondary] | default([]) ] , [ groups[sap_vm_provision_group_anydb_primary] | default([]) ] , [ groups[sap_vm_provision_group_anydb_secondary] | default([]) ] , [ groups[sap_vm_provision_group_nwas_ascs] | default([]) ] , [ groups[sap_vm_provision_group_nwas_ers] | default([]) ] , [ groups[sap_vm_provision_group_nwas_pas] | default([]) ] , [ groups[sap_vm_provision_group_nwas_aas] | default([]) ] ] | flatten | select() }}"
 
     - name: Set Ansible Vars
       register: __sap_vm_provision_task_ansible_vars_set
@@ -112,14 +112,14 @@
       ansible.builtin.include_tasks:
         file: common/set_etc_hosts_ha.yml
       when:
-        - (groups["hana_secondary"] is defined and (groups["hana_secondary"] | length>0)) or (groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0)) or (groups["anydb_secondary"] is defined and (groups["anydb_secondary"] | length>0))
+        - (groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary] | length>0)) or (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0)) or (groups[sap_vm_provision_group_anydb_secondary] is defined and (groups[sap_vm_provision_group_anydb_secondary] | length>0))
 
     - name: Set /etc/hosts for Scale-Out
       register: __sap_vm_provision_task_os_etc_hosts_scaleout
       ansible.builtin.include_tasks:
         file: common/set_etc_hosts_scaleout.yml
       when:
-        - (groups["hana_primary"] is defined and (groups["hana_primary"] | length>0)) and (sap_vm_provision_calculate_sap_hana_scaleout_active_coordinator is defined or sap_vm_provision_calculate_sap_hana_scaleout_active_worker is defined or sap_vm_provision_calculate_sap_hana_scaleout_standby is defined)
+        - (groups[sap_vm_provision_group_hana_primary] is defined and (groups[sap_vm_provision_group_hana_primary] | length>0)) and (sap_vm_provision_calculate_sap_hana_scaleout_active_coordinator is defined or sap_vm_provision_calculate_sap_hana_scaleout_active_worker is defined or sap_vm_provision_calculate_sap_hana_scaleout_standby is defined)
 
     - name: Set vars for sap_storage_setup Ansible Role
       register: __sap_vm_provision_task_ansible_vars_storage

--- a/roles/sap_vm_provision/tasks/platform_ansible/vmware_vm/execute_main.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/vmware_vm/execute_main.yml
@@ -45,7 +45,7 @@
 
     - name: Set fact to hold all inventory hosts in all groups
       ansible.builtin.set_fact:
-        groups_merged_list: "{{ [ [ groups['hana_primary'] | default([]) ] , [ groups['hana_secondary'] | default([]) ] , [ groups['anydb_primary'] | default([]) ] , [ groups['anydb_secondary'] | default([]) ] , [ groups['nwas_ascs'] | default([]) ] , [ groups['nwas_ers'] | default([]) ] , [ groups['nwas_pas'] | default([]) ] , [ groups['nwas_aas'] | default([]) ] ] | flatten | select() }}"
+        groups_merged_list: "{{ [ [ groups[sap_vm_provision_group_hana_primary] | default([]) ] , [ groups[sap_vm_provision_group_hana_secondary] | default([]) ] , [ groups[sap_vm_provision_group_anydb_primary] | default([]) ] , [ groups[sap_vm_provision_group_anydb_secondary] | default([]) ] , [ groups[sap_vm_provision_group_nwas_ascs] | default([]) ] , [ groups[sap_vm_provision_group_nwas_ers] | default([]) ] , [ groups[sap_vm_provision_group_nwas_pas] | default([]) ] , [ groups[sap_vm_provision_group_nwas_aas] | default([]) ] ] | flatten | select() }}"
 
     - name: Set Ansible Vars
       register: __sap_vm_provision_task_ansible_vars_set
@@ -116,14 +116,14 @@
       ansible.builtin.include_tasks:
         file: common/set_etc_hosts_ha.yml
       when:
-        - (groups["hana_secondary"] is defined and (groups["hana_secondary"] | length>0)) or (groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0)) or (groups["anydb_secondary"] is defined and (groups["anydb_secondary"] | length>0))
+        - (groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary] | length>0)) or (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0)) or (groups[sap_vm_provision_group_anydb_secondary] is defined and (groups[sap_vm_provision_group_anydb_secondary] | length>0))
 
     - name: Set /etc/hosts for Scale-Out
       register: __sap_vm_provision_task_os_etc_hosts_scaleout
       ansible.builtin.include_tasks:
         file: common/set_etc_hosts_scaleout.yml
       when:
-        - (groups["hana_primary"] is defined and (groups["hana_primary"] | length>0)) and (sap_vm_provision_calculate_sap_hana_scaleout_active_coordinator is defined or sap_vm_provision_calculate_sap_hana_scaleout_active_worker is defined or sap_vm_provision_calculate_sap_hana_scaleout_standby is defined)
+        - (groups[sap_vm_provision_group_hana_primary] is defined and (groups[sap_vm_provision_group_hana_primary] | length>0)) and (sap_vm_provision_calculate_sap_hana_scaleout_active_coordinator is defined or sap_vm_provision_calculate_sap_hana_scaleout_active_worker is defined or sap_vm_provision_calculate_sap_hana_scaleout_standby is defined)
 
     - name: Set vars for sap_storage_setup Ansible Role
       register: __sap_vm_provision_task_ansible_vars_storage

--- a/roles/sap_vm_provision/tasks/platform_ansible_to_terraform/aws_ec2_vs/execute_main.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible_to_terraform/aws_ec2_vs/execute_main.yml
@@ -91,7 +91,7 @@
 
     - name: Set fact to hold all inventory hosts in all groups
       ansible.builtin.set_fact:
-        groups_merged_list: "{{ [ [ groups['hana_primary'] | default([]) ] , [ groups['hana_secondary'] | default([]) ] , [ groups['nwas_ascs'] | default([]) ] , [ groups['nwas_ers'] | default([]) ] , [ groups['nwas_pas'] | default([]) ] , [ groups['nwas_aas'] | default([]) ] , [ groups['anydb_primary'] | default([]) ] , [ groups['anydb_secondary'] | default([]) ] ] | flatten | select() }}"
+        groups_merged_list: "{{ [ [ groups[sap_vm_provision_group_hana_primary] | default([]) ] , [ groups[sap_vm_provision_group_hana_secondary] | default([]) ] , [ groups[sap_vm_provision_group_nwas_ascs] | default([]) ] , [ groups[sap_vm_provision_group_nwas_ers] | default([]) ] , [ groups[sap_vm_provision_group_nwas_pas] | default([]) ] , [ groups[sap_vm_provision_group_nwas_aas] | default([]) ] , [ groups[sap_vm_provision_group_anydb_primary] | default([]) ] , [ groups[sap_vm_provision_group_anydb_secondary] | default([]) ] ] | flatten | select() }}"
 
     - name: Set facts for all hosts - use facts from localhost for NFS
       when: sap_vm_provision_terraform_state == "present"
@@ -163,7 +163,7 @@
       ansible.builtin.include_tasks:
         file: common/set_etc_hosts_ha.yml
       when:
-        - (groups["hana_secondary"] is defined and (groups["hana_secondary"] | length>0)) or (groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0)) or (groups["anydb_secondary"] is defined and (groups["anydb_secondary"] | length>0))
+        - (groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary] | length>0)) or (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0)) or (groups[sap_vm_provision_group_anydb_secondary] is defined and (groups[sap_vm_provision_group_anydb_secondary] | length>0))
       args:
         apply:
           delegate_to: "{{ item }}"
@@ -175,7 +175,7 @@
       ansible.builtin.include_tasks:
         file: common/set_etc_hosts_scaleout.yml
       when:
-        - (groups["hana_primary"] is defined and (groups["hana_primary"] | length>0)) and (sap_vm_provision_calculate_sap_hana_scaleout_active_coordinator is defined or sap_vm_provision_calculate_sap_hana_scaleout_active_worker is defined or sap_vm_provision_calculate_sap_hana_scaleout_standby is defined)
+        - (groups[sap_vm_provision_group_hana_primary] is defined and (groups[sap_vm_provision_group_hana_primary] | length>0)) and (sap_vm_provision_calculate_sap_hana_scaleout_active_coordinator is defined or sap_vm_provision_calculate_sap_hana_scaleout_active_worker is defined or sap_vm_provision_calculate_sap_hana_scaleout_standby is defined)
       args:
         apply:
           delegate_to: "{{ item }}"

--- a/roles/sap_vm_provision/tasks/platform_ansible_to_terraform/gcp_ce_vm/execute_main.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible_to_terraform/gcp_ce_vm/execute_main.yml
@@ -87,7 +87,7 @@
 
     - name: Set fact to hold all inventory hosts in all groups
       ansible.builtin.set_fact:
-        groups_merged_list: "{{ [ [ groups['hana_primary'] | default([]) ] , [ groups['hana_secondary'] | default([]) ] , [ groups['nwas_ascs'] | default([]) ] , [ groups['nwas_ers'] | default([]) ] , [ groups['nwas_pas'] | default([]) ] , [ groups['nwas_aas'] | default([]) ] , [ groups['anydb_primary'] | default([]) ] , [ groups['anydb_secondary'] | default([]) ] ] | flatten | select() }}"
+        groups_merged_list: "{{ [ [ groups[sap_vm_provision_group_hana_primary] | default([]) ] , [ groups[sap_vm_provision_group_hana_secondary] | default([]) ] , [ groups[sap_vm_provision_group_nwas_ascs] | default([]) ] , [ groups[sap_vm_provision_group_nwas_ers] | default([]) ] , [ groups[sap_vm_provision_group_nwas_pas] | default([]) ] , [ groups[sap_vm_provision_group_nwas_aas] | default([]) ] , [ groups[sap_vm_provision_group_anydb_primary] | default([]) ] , [ groups[sap_vm_provision_group_anydb_secondary] | default([]) ] ] | flatten | select() }}"
 
     - name: Set facts for all hosts - use facts from localhost for NFS
       when: sap_vm_provision_terraform_state == "present"
@@ -159,7 +159,7 @@
       ansible.builtin.include_tasks:
         file: common/set_etc_hosts_ha.yml
       when:
-        - (groups["hana_secondary"] is defined and (groups["hana_secondary"] | length>0)) or (groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0)) or (groups["anydb_secondary"] is defined and (groups["anydb_secondary"] | length>0))
+        - (groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary] | length>0)) or (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0)) or (groups[sap_vm_provision_group_anydb_secondary] is defined and (groups[sap_vm_provision_group_anydb_secondary] | length>0))
       args:
         apply:
           delegate_to: "{{ item }}"
@@ -171,7 +171,7 @@
       ansible.builtin.include_tasks:
         file: common/set_etc_hosts_scaleout.yml
       when:
-        - (groups["hana_primary"] is defined and (groups["hana_primary"] | length>0)) and (sap_vm_provision_calculate_sap_hana_scaleout_active_coordinator is defined or sap_vm_provision_calculate_sap_hana_scaleout_active_worker is defined or sap_vm_provision_calculate_sap_hana_scaleout_standby is defined)
+        - (groups[sap_vm_provision_group_hana_primary] is defined and (groups[sap_vm_provision_group_hana_primary] | length>0)) and (sap_vm_provision_calculate_sap_hana_scaleout_active_coordinator is defined or sap_vm_provision_calculate_sap_hana_scaleout_active_worker is defined or sap_vm_provision_calculate_sap_hana_scaleout_standby is defined)
       args:
         apply:
           delegate_to: "{{ item }}"

--- a/roles/sap_vm_provision/tasks/platform_ansible_to_terraform/ibmcloud_powervs/execute_main.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible_to_terraform/ibmcloud_powervs/execute_main.yml
@@ -87,7 +87,7 @@
 
     - name: Set fact to hold all inventory hosts in all groups
       ansible.builtin.set_fact:
-        groups_merged_list: "{{ [ [ groups['hana_primary'] | default([]) ] , [ groups['hana_secondary'] | default([]) ] , [ groups['nwas_ascs'] | default([]) ] , [ groups['nwas_ers'] | default([]) ] , [ groups['nwas_pas'] | default([]) ] , [ groups['nwas_aas'] | default([]) ] , [ groups['anydb_primary'] | default([]) ] , [ groups['anydb_secondary'] | default([]) ] ] | flatten | select() }}"
+        groups_merged_list: "{{ [ [ groups[sap_vm_provision_group_hana_primary] | default([]) ] , [ groups[sap_vm_provision_group_hana_secondary] | default([]) ] , [ groups[sap_vm_provision_group_nwas_ascs] | default([]) ] , [ groups[sap_vm_provision_group_nwas_ers] | default([]) ] , [ groups[sap_vm_provision_group_nwas_pas] | default([]) ] , [ groups[sap_vm_provision_group_nwas_aas] | default([]) ] , [ groups[sap_vm_provision_group_anydb_primary] | default([]) ] , [ groups[sap_vm_provision_group_anydb_secondary] | default([]) ] ] | flatten | select() }}"
 
     - name: Set facts for all hosts - use facts from localhost for NFS
       when: sap_vm_provision_terraform_state == "present"
@@ -159,7 +159,7 @@
       ansible.builtin.include_tasks:
         file: common/set_etc_hosts_ha.yml
       when:
-        - (groups["hana_secondary"] is defined and (groups["hana_secondary"] | length>0)) or (groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0)) or (groups["anydb_secondary"] is defined and (groups["anydb_secondary"] | length>0))
+        - (groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary] | length>0)) or (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0)) or (groups[sap_vm_provision_group_anydb_secondary] is defined and (groups[sap_vm_provision_group_anydb_secondary] | length>0))
       args:
         apply:
           delegate_to: "{{ item }}"
@@ -171,7 +171,7 @@
       ansible.builtin.include_tasks:
         file: common/set_etc_hosts_scaleout.yml
       when:
-        - (groups["hana_primary"] is defined and (groups["hana_primary"] | length>0)) and (sap_vm_provision_calculate_sap_hana_scaleout_active_coordinator is defined or sap_vm_provision_calculate_sap_hana_scaleout_active_worker is defined or sap_vm_provision_calculate_sap_hana_scaleout_standby is defined)
+        - (groups[sap_vm_provision_group_hana_primary] is defined and (groups[sap_vm_provision_group_hana_primary] | length>0)) and (sap_vm_provision_calculate_sap_hana_scaleout_active_coordinator is defined or sap_vm_provision_calculate_sap_hana_scaleout_active_worker is defined or sap_vm_provision_calculate_sap_hana_scaleout_standby is defined)
       args:
         apply:
           delegate_to: "{{ item }}"

--- a/roles/sap_vm_provision/tasks/platform_ansible_to_terraform/ibmcloud_vs/execute_main.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible_to_terraform/ibmcloud_vs/execute_main.yml
@@ -87,7 +87,7 @@
 
     - name: Set fact to hold all inventory hosts in all groups
       ansible.builtin.set_fact:
-        groups_merged_list: "{{ [ [ groups['hana_primary'] | default([]) ] , [ groups['hana_secondary'] | default([]) ] , [ groups['nwas_ascs'] | default([]) ] , [ groups['nwas_ers'] | default([]) ] , [ groups['nwas_pas'] | default([]) ] , [ groups['nwas_aas'] | default([]) ] , [ groups['anydb_primary'] | default([]) ] , [ groups['anydb_secondary'] | default([]) ] ] | flatten | select() }}"
+        groups_merged_list: "{{ [ [ groups[sap_vm_provision_group_hana_primary] | default([]) ] , [ groups[sap_vm_provision_group_hana_secondary] | default([]) ] , [ groups[sap_vm_provision_group_nwas_ascs] | default([]) ] , [ groups[sap_vm_provision_group_nwas_ers] | default([]) ] , [ groups[sap_vm_provision_group_nwas_pas] | default([]) ] , [ groups[sap_vm_provision_group_nwas_aas] | default([]) ] , [ groups[sap_vm_provision_group_anydb_primary] | default([]) ] , [ groups[sap_vm_provision_group_anydb_secondary] | default([]) ] ] | flatten | select() }}"
 
     - name: Set facts for all hosts - use facts from localhost for NFS
       when: sap_vm_provision_terraform_state == "present"
@@ -159,7 +159,7 @@
       ansible.builtin.include_tasks:
         file: common/set_etc_hosts_ha.yml
       when:
-        - (groups["hana_secondary"] is defined and (groups["hana_secondary"] | length>0)) or (groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0)) or (groups["anydb_secondary"] is defined and (groups["anydb_secondary"] | length>0))
+        - (groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary] | length>0)) or (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0)) or (groups[sap_vm_provision_group_anydb_secondary] is defined and (groups[sap_vm_provision_group_anydb_secondary] | length>0))
       args:
         apply:
           delegate_to: "{{ item }}"
@@ -171,7 +171,7 @@
       ansible.builtin.include_tasks:
         file: common/set_etc_hosts_scaleout.yml
       when:
-        - (groups["hana_primary"] is defined and (groups["hana_primary"] | length>0)) and (sap_vm_provision_calculate_sap_hana_scaleout_active_coordinator is defined or sap_vm_provision_calculate_sap_hana_scaleout_active_worker is defined or sap_vm_provision_calculate_sap_hana_scaleout_standby is defined)
+        - (groups[sap_vm_provision_group_hana_primary] is defined and (groups[sap_vm_provision_group_hana_primary] | length>0)) and (sap_vm_provision_calculate_sap_hana_scaleout_active_coordinator is defined or sap_vm_provision_calculate_sap_hana_scaleout_active_worker is defined or sap_vm_provision_calculate_sap_hana_scaleout_standby is defined)
       args:
         apply:
           delegate_to: "{{ item }}"

--- a/roles/sap_vm_provision/tasks/platform_ansible_to_terraform/ibmpowervm_vm/execute_main.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible_to_terraform/ibmpowervm_vm/execute_main.yml
@@ -104,7 +104,7 @@
 
     - name: Set fact to hold all inventory hosts in all groups
       ansible.builtin.set_fact:
-        groups_merged_list: "{{ [ [ groups['hana_primary'] | default([]) ] , [ groups['hana_secondary'] | default([]) ] , [ groups['nwas_ascs'] | default([]) ] , [ groups['nwas_ers'] | default([]) ] , [ groups['nwas_pas'] | default([]) ] , [ groups['nwas_aas'] | default([]) ] , [ groups['anydb_primary'] | default([]) ] , [ groups['anydb_secondary'] | default([]) ] ] | flatten | select() }}"
+        groups_merged_list: "{{ [ [ groups[sap_vm_provision_group_hana_primary] | default([]) ] , [ groups[sap_vm_provision_group_hana_secondary] | default([]) ] , [ groups[sap_vm_provision_group_nwas_ascs] | default([]) ] , [ groups[sap_vm_provision_group_nwas_ers] | default([]) ] , [ groups[sap_vm_provision_group_nwas_pas] | default([]) ] , [ groups[sap_vm_provision_group_nwas_aas] | default([]) ] , [ groups[sap_vm_provision_group_anydb_primary] | default([]) ] , [ groups[sap_vm_provision_group_anydb_secondary] | default([]) ] ] | flatten | select() }}"
 
     - name: Set facts for all hosts - use facts from localhost for host specification dictionary
       when: sap_vm_provision_terraform_state == "present"
@@ -161,7 +161,7 @@
       ansible.builtin.include_tasks:
         file: common/set_etc_hosts_ha.yml
       when:
-        - (groups["hana_secondary"] is defined and (groups["hana_secondary"] | length>0)) or (groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0)) or (groups["anydb_secondary"] is defined and (groups["anydb_secondary"] | length>0))
+        - (groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary] | length>0)) or (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0)) or (groups[sap_vm_provision_group_anydb_secondary] is defined and (groups[sap_vm_provision_group_anydb_secondary] | length>0))
       args:
         apply:
           delegate_to: "{{ item }}"
@@ -173,7 +173,7 @@
       ansible.builtin.include_tasks:
         file: common/set_etc_hosts_scaleout.yml
       when:
-        - (groups["hana_primary"] is defined and (groups["hana_primary"] | length>0)) and (sap_vm_provision_calculate_sap_hana_scaleout_active_coordinator is defined or sap_vm_provision_calculate_sap_hana_scaleout_active_worker is defined or sap_vm_provision_calculate_sap_hana_scaleout_standby is defined)
+        - (groups[sap_vm_provision_group_hana_primary] is defined and (groups[sap_vm_provision_group_hana_primary] | length>0)) and (sap_vm_provision_calculate_sap_hana_scaleout_active_coordinator is defined or sap_vm_provision_calculate_sap_hana_scaleout_active_worker is defined or sap_vm_provision_calculate_sap_hana_scaleout_standby is defined)
       args:
         apply:
           delegate_to: "{{ item }}"

--- a/roles/sap_vm_provision/tasks/platform_ansible_to_terraform/msazure_vm/execute_main.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible_to_terraform/msazure_vm/execute_main.yml
@@ -92,7 +92,7 @@
 
     - name: Set fact to hold all inventory hosts in all groups
       ansible.builtin.set_fact:
-        groups_merged_list: "{{ [ [ groups['hana_primary'] | default([]) ] , [ groups['hana_secondary'] | default([]) ] , [ groups['nwas_ascs'] | default([]) ] , [ groups['nwas_ers'] | default([]) ] , [ groups['nwas_pas'] | default([]) ] , [ groups['nwas_aas'] | default([]) ] , [ groups['anydb_primary'] | default([]) ] , [ groups['anydb_secondary'] | default([]) ] ] | flatten | select() }}"
+        groups_merged_list: "{{ [ [ groups[sap_vm_provision_group_hana_primary] | default([]) ] , [ groups[sap_vm_provision_group_hana_secondary] | default([]) ] , [ groups[sap_vm_provision_group_nwas_ascs] | default([]) ] , [ groups[sap_vm_provision_group_nwas_ers] | default([]) ] , [ groups[sap_vm_provision_group_nwas_pas] | default([]) ] , [ groups[sap_vm_provision_group_nwas_aas] | default([]) ] , [ groups[sap_vm_provision_group_anydb_primary] | default([]) ] , [ groups[sap_vm_provision_group_anydb_secondary] | default([]) ] ] | flatten | select() }}"
 
     - name: Set facts for all hosts - use facts from localhost for NFS
       when: sap_vm_provision_terraform_state == "present"
@@ -164,7 +164,7 @@
       ansible.builtin.include_tasks:
         file: common/set_etc_hosts_ha.yml
       when:
-        - (groups["hana_secondary"] is defined and (groups["hana_secondary"] | length>0)) or (groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0)) or (groups["anydb_secondary"] is defined and (groups["anydb_secondary"] | length>0))
+        - (groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary] | length>0)) or (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0)) or (groups[sap_vm_provision_group_anydb_secondary] is defined and (groups[sap_vm_provision_group_anydb_secondary] | length>0))
       args:
         apply:
           delegate_to: "{{ item }}"
@@ -176,7 +176,7 @@
       ansible.builtin.include_tasks:
         file: common/set_etc_hosts_scaleout.yml
       when:
-        - (groups["hana_primary"] is defined and (groups["hana_primary"] | length>0)) and (sap_vm_provision_calculate_sap_hana_scaleout_active_coordinator is defined or sap_vm_provision_calculate_sap_hana_scaleout_active_worker is defined or sap_vm_provision_calculate_sap_hana_scaleout_standby is defined)
+        - (groups[sap_vm_provision_group_hana_primary] is defined and (groups[sap_vm_provision_group_hana_primary] | length>0)) and (sap_vm_provision_calculate_sap_hana_scaleout_active_coordinator is defined or sap_vm_provision_calculate_sap_hana_scaleout_active_worker is defined or sap_vm_provision_calculate_sap_hana_scaleout_standby is defined)
       args:
         apply:
           delegate_to: "{{ item }}"

--- a/roles/sap_vm_provision/tasks/platform_ansible_to_terraform/vmware_vm/execute_main.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible_to_terraform/vmware_vm/execute_main.yml
@@ -105,7 +105,7 @@
 
     - name: Set fact to hold all inventory hosts in all groups
       ansible.builtin.set_fact:
-        groups_merged_list: "{{ [ [ groups['hana_primary'] | default([]) ] , [ groups['hana_secondary'] | default([]) ] , [ groups['nwas_ascs'] | default([]) ] , [ groups['nwas_ers'] | default([]) ] , [ groups['nwas_pas'] | default([]) ] , [ groups['nwas_aas'] | default([]) ] , [ groups['anydb_primary'] | default([]) ] , [ groups['anydb_secondary'] | default([]) ] ] | flatten | select() }}"
+        groups_merged_list: "{{ [ [ groups[sap_vm_provision_group_hana_primary] | default([]) ] , [ groups[sap_vm_provision_group_hana_secondary] | default([]) ] , [ groups[sap_vm_provision_group_nwas_ascs] | default([]) ] , [ groups[sap_vm_provision_group_nwas_ers] | default([]) ] , [ groups[sap_vm_provision_group_nwas_pas] | default([]) ] , [ groups[sap_vm_provision_group_nwas_aas] | default([]) ] , [ groups[sap_vm_provision_group_anydb_primary] | default([]) ] , [ groups[sap_vm_provision_group_anydb_secondary] | default([]) ] ] | flatten | select() }}"
 
     - name: Set facts for all hosts - use facts from localhost for host specification dictionary
       when: sap_vm_provision_terraform_state == "present"
@@ -162,7 +162,7 @@
       ansible.builtin.include_tasks:
         file: common/set_etc_hosts_ha.yml
       when:
-        - (groups["hana_secondary"] is defined and (groups["hana_secondary"] | length>0)) or (groups["nwas_ers"] is defined and (groups["nwas_ers"] | length>0)) or (groups["anydb_secondary"] is defined and (groups["anydb_secondary"] | length>0))
+        - (groups[sap_vm_provision_group_hana_secondary] is defined and (groups[sap_vm_provision_group_hana_secondary] | length>0)) or (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0)) or (groups[sap_vm_provision_group_anydb_secondary] is defined and (groups[sap_vm_provision_group_anydb_secondary] | length>0))
       args:
         apply:
           delegate_to: "{{ item }}"
@@ -174,7 +174,7 @@
       ansible.builtin.include_tasks:
         file: common/set_etc_hosts_scaleout.yml
       when:
-        - (groups["hana_primary"] is defined and (groups["hana_primary"] | length>0)) and (sap_vm_provision_calculate_sap_hana_scaleout_active_coordinator is defined or sap_vm_provision_calculate_sap_hana_scaleout_active_worker is defined or sap_vm_provision_calculate_sap_hana_scaleout_standby is defined)
+        - (groups[sap_vm_provision_group_hana_primary] is defined and (groups[sap_vm_provision_group_hana_primary] | length>0)) and (sap_vm_provision_calculate_sap_hana_scaleout_active_coordinator is defined or sap_vm_provision_calculate_sap_hana_scaleout_active_worker is defined or sap_vm_provision_calculate_sap_hana_scaleout_standby is defined)
       args:
         apply:
           delegate_to: "{{ item }}"

--- a/roles/sap_vm_temp_vip/README.md
+++ b/roles/sap_vm_temp_vip/README.md
@@ -31,7 +31,8 @@ Role can be execute separately or as part of [ansible.playbooks_for_sap](https:/
 <!-- BEGIN Execution Flow -->
 1. Assert that required inputs were provided.
 2. Collect missing inputs using provided inputs (example: Calculate prefix from netmask, if VIP prefix was not defined)
-3. Append VIP to network interface
+3. Append VIP to network interface</br>
+  **NOTE:** Group names can be customized using `sap_vm_temp_vip_group_*` variables in `vars/default.yml` (e.g. `sap_vm_temp_vip_group_hana_primary`, `sap_vm_temp_vip_group_nwas_ascs`, etc.).
     - SAP HANA Primary host if both groups are present: `hana_primary, hana_secondary`
     - SAP AnyDB Primary host if both groups are present: `anydb_primary, anydb_secondary`
     - SAP ASCS host if both groups are present: `nwas_ascs, nwas_ers`

--- a/roles/sap_vm_temp_vip/defaults/main.yml
+++ b/roles/sap_vm_temp_vip/defaults/main.yml
@@ -14,3 +14,15 @@ sap_vm_temp_vip_nwas_abap_ascs: "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_ascs_
 sap_vm_temp_vip_nwas_abap_ers: "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_ers_ip_address | default('') }}"
 # sap_vm_temp_vip_nwas_abap_pas: "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_pas_ip_address | default('') }}"
 # sap_vm_temp_vip_nwas_abap_aas: "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_aas_ip_address | default('') }}"
+
+# Customized group names are used by sap_host_type in host_specifications_dictionary plan during provisioning.
+# Variables are loaded from sap_vm_provision variables first.
+sap_vm_temp_vip_group_hana_primary: "{{ sap_vm_provision_group_hana_primary | d('hana_primary') }}"
+sap_vm_temp_vip_group_hana_secondary: "{{ sap_vm_provision_group_hana_secondary | d('hana_secondary') }}"
+sap_vm_temp_vip_group_nwas_ascs: "{{ sap_vm_provision_group_nwas_ascs | d('nwas_ascs') }}"
+sap_vm_temp_vip_group_nwas_scs: "{{ sap_vm_provision_group_nwas_scs | d('nwas_scs') }}"
+sap_vm_temp_vip_group_nwas_ers: "{{ sap_vm_provision_group_nwas_ers | d('nwas_ers') }}"
+sap_vm_temp_vip_group_nwas_pas: "{{ sap_vm_provision_group_nwas_pas | d('nwas_pas') }}"
+sap_vm_temp_vip_group_nwas_aas: "{{ sap_vm_provision_group_nwas_aas | d('nwas_aas') }}"
+sap_vm_temp_vip_group_anydb_primary: "{{ sap_vm_provision_group_anydb_primary | d('anydb_primary') }}"
+sap_vm_temp_vip_group_anydb_secondary: "{{ sap_vm_provision_group_anydb_secondary | d('anydb_secondary') }}"

--- a/roles/sap_vm_temp_vip/tasks/main.yml
+++ b/roles/sap_vm_temp_vip/tasks/main.yml
@@ -16,7 +16,9 @@
 
 
 - name: Block to ensure that only supported groups are allowed
-  when: group_names | intersect(['hana_primary', 'hana_secondary', 'anydb_primary', 'anydb_secondary', 'nwas_ascs', 'nwas_ers'])
+  when:
+    - group_names | intersect([sap_vm_temp_vip_group_hana_primary, sap_vm_temp_vip_group_hana_secondary, sap_vm_temp_vip_group_anydb_primary,
+      sap_vm_temp_vip_group_anydb_secondary, sap_vm_temp_vip_group_nwas_ascs, sap_vm_temp_vip_group_nwas_ers])
   block:
 
     # - name: Identify OS Primary Network Interface

--- a/roles/sap_vm_temp_vip/tasks/set_temp_vip.yml
+++ b/roles/sap_vm_temp_vip/tasks/set_temp_vip.yml
@@ -18,20 +18,21 @@
 # In all cases, use noprefixroute parameter to avoid automatic creation of OS route table entries (i.e. 'ip route'), which occurs if the IP Address is outside of the existing Subnet Range
 
 # TODO: Add rare scenario for PAS/AAS VIP if needed.
-# (groups["nwas_pas"] is defined and inventory_hostname in groups["nwas_pas"]) and (groups["nwas_pas"] is defined and (groups["nwas_pas"]|length>0))
+# (groups[sap_vm_temp_vip_group_nwas_pas] is defined and inventory_hostname in groups[sap_vm_temp_vip_group_nwas_pas])
+# and (groups[sap_vm_temp_vip_group_nwas_pas] is defined and (groups[sap_vm_temp_vip_group_nwas_pas]|length>0))
 
 
 # Define VIP address based on target host group which is filtered in main.yml
 - name: Set fact for VIP address depending on target host group
   ansible.builtin.set_fact:
     __sap_vm_temp_vip_address: >-
-      {% if groups['hana_secondary'] | d([]) | length > 0 and inventory_hostname in groups["hana_primary"] -%}
+      {% if groups[sap_vm_temp_vip_group_hana_secondary] | d([]) | length > 0 and inventory_hostname in groups[sap_vm_temp_vip_group_hana_primary] -%}
         {{ sap_vm_temp_vip_hana_primary | regex_replace('/.*', '') }}
-      {%- elif groups['anydb_secondary'] | d([]) | length > 0 and inventory_hostname in groups["anydb_primary"] -%}
+      {%- elif groups[sap_vm_temp_vip_group_anydb_secondary] | d([]) | length > 0 and inventory_hostname in groups[sap_vm_temp_vip_group_anydb_primary] -%}
         {{ sap_vm_temp_vip_anydb_primary | regex_replace('/.*', '') }}
-      {%- elif groups["nwas_ers"] | d([]) | length > 0 and inventory_hostname in groups["nwas_ascs"] -%}
+      {%- elif groups[sap_vm_temp_vip_group_nwas_ers] | d([]) | length > 0 and inventory_hostname in groups[sap_vm_temp_vip_group_nwas_ascs] -%}
         {{ sap_vm_temp_vip_nwas_abap_ascs | regex_replace('/.*', '') }}
-      {%- elif groups["nwas_ers"] | d([]) | length > 0 and inventory_hostname in groups["nwas_ers"] -%}
+      {%- elif groups[sap_vm_temp_vip_group_nwas_ers] | d([]) | length > 0 and inventory_hostname in groups[sap_vm_temp_vip_group_nwas_ers] -%}
         {{ sap_vm_temp_vip_nwas_abap_ers | regex_replace('/.*', '') }}
       {%- endif %}
 

--- a/roles/sap_vm_temp_vip/tasks/set_temp_vip_lb_listener.yml
+++ b/roles/sap_vm_temp_vip/tasks/set_temp_vip_lb_listener.yml
@@ -6,13 +6,13 @@
 - name: Set fact for temporary listening port
   ansible.builtin.set_fact:
     __sap_vm_temp_vip_port: >-
-      {% if groups['hana_secondary'] | d([]) | length > 0 and inventory_hostname in groups["hana_primary"] -%}
+      {% if groups[sap_vm_temp_vip_group_hana_secondary] | d([]) | length > 0 and inventory_hostname in groups[sap_vm_temp_vip_group_hana_primary] -%}
         55550
-      {%- elif groups['anydb_secondary'] | d([]) | length > 0 and inventory_hostname in groups["anydb_primary"] -%}
+      {%- elif groups[sap_vm_temp_vip_group_anydb_secondary] | d([]) | length > 0 and inventory_hostname in groups[sap_vm_temp_vip_group_anydb_primary] -%}
         55550
-      {%- elif groups["nwas_ers"] | d([]) | length > 0 and inventory_hostname in groups["nwas_ascs"] -%}
+      {%- elif groups[sap_vm_temp_vip_group_nwas_ers] | d([]) | length > 0 and inventory_hostname in groups[sap_vm_temp_vip_group_nwas_ascs] -%}
         55551
-      {%- elif groups["nwas_ers"] | d([]) | length > 0 and inventory_hostname in groups["nwas_ers"] -%}
+      {%- elif groups[sap_vm_temp_vip_group_nwas_ers] | d([]) | length > 0 and inventory_hostname in groups[sap_vm_temp_vip_group_nwas_ers] -%}
         55552
       {%- endif %}
 


### PR DESCRIPTION
## Changes
- Add new variables `sap_vm_provision_group_*` for `sap_vm_provision` to customize group names
- Add new variables `sap_vm_temp_vip_group_*` for `sap_vm_temp_vip` to customize group names
- Update all `group['']` conditionals and loops to use new variables

**NOTE 1: This does not require any change in AP4S as it adds way to customize provisioning, while retaining previous functionality.**

@sean-freeman  **NOTE 2: Terraform `tf_template_*` files were not changed, because their hardcoded groups are commented out and unused. If it was need to use in future, we would need to switch to jinja template to fill in variable input into terraform files instead of direct copy.**

## Test results
All changes were tested with SLES4SAP 15 SP6 on following platforms:
- AWS
- AZ
- GCP

Tested scenarios:
- SAP HANA HA
- SAP ASCS/ERS HA