### PR TITLE
sap_vm_provision: update ms az req

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -9,7 +9,7 @@ collections:
     version: 9.0.0
   - name: azure.azcollection
     type: galaxy
-    version: 3.0.0
+    version: 3.2.0
   - name: google.cloud
     type: galaxy
     version: 1.1.3


### PR DESCRIPTION
Cite logic flaw that disrupts all provision of Azure VM block storage from an Ansible Playbook, and any re-run of Ansible Playbooks:
- https://github.com/ansible-collections/azure/issues/1751
- https://github.com/ansible-collections/azure/issues/1811