### PR TITLE
sap_vm_provision: AWS tag pacemaker for fence agent stonith:external/ec2

### DIFF
--- a/roles/sap_vm_provision/tasks/platform_ansible/aws_ec2_vs/execute_setup_ha.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/aws_ec2_vs/execute_setup_ha.yml
@@ -1,8 +1,10 @@
 ---
 
-# Requirement for fence agent: stonith:external/ec2
+# (SUSE specific) Requirement for fence agent: stonith:external/ec2
 # All instances in cluster need to be tagged with tag configured in agent
 # sap_ha_pacemaker_cluster role configures default tag name 'pacemaker' with value of 'inventory_hostname_short'
+# https://documentation.suse.com/sbp/sap-15/html/SLES4SAP-hana-sr-guide-perfopt-15-aws/index.html#id-tagging-the-ec2-instances
+# https://docs.aws.amazon.com/sap/latest/sap-hana/sap-hana-on-aws-stonith-device.html
 - name: AWS EC2 Instances - Ensure pacemaker tag is present
   no_log: "{{ __sap_vm_provision_no_log }}"
   amazon.aws.ec2_tag:
@@ -23,6 +25,7 @@
     }}"
   loop_control:
     loop_var: host_node
+  when: ansible_os_family == 'Suse'
 
 
 - name: Gather information about AWS account

--- a/roles/sap_vm_provision/tasks/platform_ansible/aws_ec2_vs/execute_setup_ha.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/aws_ec2_vs/execute_setup_ha.yml
@@ -1,5 +1,30 @@
 ---
 
+# Requirement for fence agent: stonith:external/ec2
+# All instances in cluster need to be tagged with tag configured in agent
+# sap_ha_pacemaker_cluster role configures default tag name 'pacemaker' with value of 'inventory_hostname_short'
+- name: AWS EC2 Instances - Ensure pacemaker tag is present
+  no_log: "{{ __sap_vm_provision_no_log }}"
+  amazon.aws.ec2_tag:
+    access_key: "{{ sap_vm_provision_aws_access_key }}"
+    secret_key: "{{ sap_vm_provision_aws_secret_access_key }}"
+    resource: "{{ hostvars[host_node].ansible_board_asset_tag }}"
+    state: present
+    tags:
+      pacemaker: "{{ inventory_hostname_short }}"
+  loop:
+    "{{
+      (groups[sap_vm_provision_group_hana_primary] + groups[sap_vm_provision_group_hana_secondary]
+      if groups[sap_vm_provision_group_hana_secondary] is defined and groups[sap_vm_provision_group_hana_secondary] else [])
+      + (groups[sap_vm_provision_group_anydb_primary] + groups[sap_vm_provision_group_anydb_secondary]
+      if groups[sap_vm_provision_group_anydb_secondary] is defined and groups[sap_vm_provision_group_anydb_secondary] else [])
+      + (groups[sap_vm_provision_group_nwas_ascs] + groups[sap_vm_provision_group_nwas_ers]
+      if groups[sap_vm_provision_group_nwas_ers] is defined and groups[sap_vm_provision_group_nwas_ers] else [])
+    }}"
+  loop_control:
+    loop_var: host_node
+
+
 - name: Gather information about AWS account
   register: __sap_vm_provision_task_aws_account_info
   no_log: "{{ __sap_vm_provision_no_log }}"


### PR DESCRIPTION
## Description
Adds tagging for fencing agent `stonith:external/ec2` which has to be same as configured in `sap_ha_pacemaker_cluster` role.
Selected tag name `pacemaker` is present in documentation sources.

SUSE: https://documentation.suse.com/sbp/sap-15/html/SLES4SAP-hana-sr-guide-perfopt-15-aws/index.html#id-tagging-the-ec2-instances
AWS: https://docs.aws.amazon.com/sap/latest/sap-hana/sap-hana-on-aws-stonith-device.html

## Test results
Tested on SLES4SAP 15 SP6 on ASCS/ERS cluster
```console
TASK [community.sap_infrastructure.sap_vm_provision : AWS EC2 Instances - Ensure pacemaker tag is present] **************************************************
 [started TASK: community.sap_infrastructure.sap_vm_provision : AWS EC2 Instances - Ensure pacemaker tag is present on ae1ascs]
ok: [ae1ascs -> localhost] => (item=ae1ascs)
changed: [ae1ascs -> localhost] => (item=ae1ers)

```

## Note
@sean-freeman This is also example of improvements I am planning for whole role:
1. Rework loops to remove duplicate tasks as shown in this PR.
2. Add tagging so we are not forced to do it outside of role (example: owner, environment, team, etc.)