### PR TITLE
Updated sap_vm_provision(kubevirt_vm)

### DIFF
--- a/playbooks/sample-sap-vm-provision-redhat-ocpv.yml
+++ b/playbooks/sample-sap-vm-provision-redhat-ocpv.yml
@@ -8,25 +8,18 @@
     sap_vm_provision_iac_platform: kubevirt_vm
   pre_tasks:
     # Alternative to executing ansible-playbook with -e for Ansible Extravars file
-#    - name: Include sample variables for Red Hat Openshift Virtualization
-#      ansible.builtin.include_vars: ./vars/sample-variables-sap-vm-provision-redhat-ocpv.yml
+    # - name: Include sample variables for Red Hat Openshift Virtualization
+    #   ansible.builtin.include_vars: ./vars/sample-variables-sap-vm-provision-redhat-ocpv.yml
   tasks:
 
     - name: Save inventory_host as execution_host
       ansible.builtin.set_fact:
         sap_vm_provision_execution_host: "{{ inventory_hostname }}"
+      when: sap_vm_provision_execution_host is not defined
 
     - name: Save ansible_user as execution_host user
       ansible.builtin.set_fact:
-        __sap_vm_provision_kubevirt_vm_register_execution_host_user: "{{ ansible_user }}"
-
-    - name: Use kubeconfig file specified in environment variable K8S_AUTH_KUBECONFIG if sap_vm_provision_kubevirt_vm_kubeconfig_path is not defined
-      when: >
-        sap_vm_provision_kubevirt_vm_kubeconfig_path is not defined or
-        sap_vm_provision_kubevirt_vm_kubeconfig_path == None or
-        sap_vm_provision_kubevirt_vm_kubeconfig_path == ''
-      ansible.builtin.set_fact:
-        sap_vm_provision_kubevirt_vm_kubeconfig_path: "{{ lookup('env', 'K8S_AUTH_KUBECONFIG') | default(None) }}"
+        __sap_vm_provision_kubevirt_vm_register_execution_host_user: "{{ ansible_user | default(lookup('env', 'USER')) }}"
 
     - name: Create Tempdir
       ansible.builtin.tempfile:
@@ -34,83 +27,40 @@
         suffix: "_sap_vm_provision_kubevirt_vm"
       register: __sap_vm_provision_kubevirt_vm_register_tmpdir
 
-    - name: Set kubeconfig file variable
+    - name: Use kubeconfig file specified in environment variable K8S_AUTH_KUBECONFIG | KUBECONFIG if sap_vm_provision_kubevirt_vm_kubeconfig_path is not defined
+      when: >
+        sap_vm_provision_kubevirt_vm_kubeconfig is not defined or
+        sap_vm_provision_kubevirt_vm_kubeconfig == None or
+        sap_vm_provision_kubevirt_vm_kubeconfig == ''
       ansible.builtin.set_fact:
-        __sap_vm_provision_kubevirt_vm_register_kubeconfig: "{{ __sap_vm_provision_kubevirt_vm_register_tmpdir.path }}/kubeconfig"
+         sap_vm_provision_kubevirt_vm_kubeconfig: "{{ lookup('env', 'K8S_AUTH_KUBECONFIG') | default(lookup('env', 'KUBECONFIG'), true) }}"
 
-    - name: Read content of kubeconfig file
-      ansible.builtin.set_fact:
-        __sap_vm_provision_kubevirt_vm_register_kubeconfig_data:
-          "{{ lookup('file', sap_vm_provision_kubevirt_vm_kubeconfig_path) | from_yaml }}"
+    - name: Ensure that kubeconfig is set
+      assert:
+        that:
+          - sap_vm_provision_kubevirt_vm_kubeconfig is defined
+          - sap_vm_provision_kubevirt_vm_kubeconfig is not none
+          - sap_vm_provision_kubevirt_vm_kubeconfig | length > 0
+        fail_msg: "sap_vm_provision_kubevirt_vm_kubeconfig is required."
 
-    - name: Read cluster endpoint and CA certificate from kubeconfig if either is not defined
-      when: sap_vm_provision_kubevirt_vm_extract_kubeconfig
-      block:
-
-        - name: Set sap_vm_provision_kubevirt_vm_api_endpoint from kubeconfig
-          ansible.builtin.set_fact:
-            __sap_vm_provision_kubevirt_vm_register_api_endpoint:
-              "{{ __sap_vm_provision_kubevirt_vm_register_kubeconfig_data['clusters'][0]['cluster']['server'] }}"
-
-        - name: Write the certificate-authority-data to temp dir
-          ansible.builtin.copy:
-            content: "{{ __sap_vm_provision_kubevirt_vm_register_kubeconfig_data['clusters'][0]['cluster']['certificate-authority-data'] | b64decode }}"
-            dest: "{{ __sap_vm_provision_kubevirt_vm_register_tmpdir.path }}/cluster-ca-cert.pem"
-            mode: "0600"
-
-        - name: Set CA file variable
-          ansible.builtin.set_fact:
-            __sap_vm_provision_kubevirt_vm_register_ca_cert: "{{ __sap_vm_provision_kubevirt_vm_register_tmpdir.path }}/cluster-ca-cert.pem"
-
-    - name: Use predefined CA cert and API endpoint
-      when: not sap_vm_provision_kubevirt_vm_extract_kubeconfig
-      block:
-        - name: Set predefined OCP API Endpoint
-          ansible.builtin.set_fact:
-            __sap_vm_provision_kubevirt_vm_register_api_endpoint: "{{ sap_vm_provision_kubevirt_vm_api_endpoint }}"
-
-        - name: Set predefined CA file
-          ansible.builtin.set_fact:
-            __sap_vm_provision_kubevirt_vm_register_ca_cert: "{{ sap_vm_provision_kubevirt_vm_ca_cert }}"
-
-    - name: Log into Red Hat OpenShift cluster (obtain access token)
-      community.okd.openshift_auth:
-        host: "{{ __sap_vm_provision_kubevirt_vm_register_api_endpoint }}"
-        username: "{{ sap_vm_provision_kubevirt_vm_admin_username }}"
-        password: "{{ sap_vm_provision_kubevirt_vm_admin_password }}"
-        ca_cert: "{{ __sap_vm_provision_kubevirt_vm_register_ca_cert }}"
-      register: __sap_vm_provision_kubevirt_vm_register_kubevirt_vm_auth_results
-
-    - name: Set token in kubeconfig
-      ansible.builtin.set_fact:
-        __sap_vm_provision_kubevirt_vm_register_kubeconfig_data: >-
-          {{
-            __sap_vm_provision_kubevirt_vm_register_kubeconfig_data | combine({
-              'users':  __sap_vm_provision_kubevirt_vm_register_kubeconfig_data.users | map('combine', [{'user': {'token': __sap_vm_provision_kubevirt_vm_register_kubevirt_vm_auth_results.openshift_auth.api_key }}] )
-            }, recursive=True)
-          }}
-
-    - name: Write the updated kubeconfig
-      ansible.builtin.copy:
-        content: "{{ __sap_vm_provision_kubevirt_vm_register_kubeconfig_data | to_nice_yaml }}"
-        dest: "{{ __sap_vm_provision_kubevirt_vm_register_kubeconfig }}"
-        mode: "0600"
-
-    - name: Create dynamic inventory group for Ansible Role sap_vm_provision and provide execution_host and api token
+    - name: Create dynamic inventory group for Ansible Role sap_vm_provision and provide configuration such as execution_host, kubeconfig, etc.
       ansible.builtin.add_host:
         name: "{{ item }}"
         group: sap_vm_provision_target_inventory_group
+        sap_vm_provision_iac_type: ansible
+        sap_vm_provision_iac_platform: kubevirt_vm
         sap_vm_provision_execution_host: "{{ sap_vm_provision_execution_host }}"
         __sap_vm_provision_kubevirt_vm_register_execution_host_user: "{{ __sap_vm_provision_kubevirt_vm_register_execution_host_user }}"
         __sap_vm_provision_kubevirt_vm_register_tmpdir: "{{ __sap_vm_provision_kubevirt_vm_register_tmpdir }}"
-        __sap_vm_provision_kubevirt_vm_register_kubeconfig: "{{ __sap_vm_provision_kubevirt_vm_register_kubeconfig }}"
+        sap_vm_provision_kubevirt_vm_kubeconfig: "{{ sap_vm_provision_kubevirt_vm_kubeconfig }}"
       loop: "{{ sap_vm_provision_kubevirt_vm_host_specifications_dictionary[sap_vm_provision_host_specification_plan].keys() }}"
 
 - name: Ansible Play to provision VMs for SAP
   hosts: sap_vm_provision_target_inventory_group # Ansible Play target hosts pattern, use Inventory Group created by previous Ansible Task (add_host)
   gather_facts: false
   environment:
-    K8S_AUTH_KUBECONFIG: "{{ __sap_vm_provision_kubevirt_vm_register_kubeconfig }}"
+    K8S_AUTH_KUBECONFIG: "{{ sap_vm_provision_kubevirt_vm_kubeconfig }}"
+    KUBECONFIG: "{{ sap_vm_provision_kubevirt_vm_kubeconfig }}"
   tasks:
 
     - name: Execute Ansible Role sap_vm_provision

--- a/playbooks/vars/sample-variables-sap-vm-provision-redhat-ocpv.yml
+++ b/playbooks/vars/sample-variables-sap-vm-provision-redhat-ocpv.yml
@@ -3,6 +3,11 @@
 # Red Hat OpenShift Virtualization         #
 ############################################
 
+# kubeconfig for Red Hat OpenShift cluster connection.
+# If not provided, the kubeconfig will be read from the environment variables
+# KUBECONFIG or K8S_AUTH_KUBECONFIG
+# sap_vm_provision_kubevirt_vm_kubeconfig: /path/to/clusterconfigs/kubeconfig
+
 # Namespace where the VM should be created in
 sap_vm_provision_kubevirt_vm_target_namespace: sap
 
@@ -12,50 +17,18 @@ sap_vm_provision_kubevirt_vm_os_user: cloud-user
 # Password for the above user
 sap_vm_provision_kubevirt_vm_os_user_password: ""
 
-# how to authenticate to the guest vm [password|private_key|private_key_data]
-# password: uses provided password in sap_vm_provision_kubevirt_vm_os_user_password, make sure your ssh config allows password authentication
-# private_key: use the private ssh key at the location defined by sap_vm_provision_ssh_host_private_key_file_path
-# private_key_data: use the private ssh key provided in sap_vm_provision_ssh_host_private_key_data and write it to the location defined in sap_vm_provision_ssh_host_private_key_file_path
-sap_vm_provision_kubevirt_vm_guest_ssh_auth_mechanism: private-key
-
-# Private SSH key file, must be accessible on the ansible controller
-# sap_vm_provision_ssh_host_private_key_file_path: <your private ssh key file>
-
-# private ssh key, make sure the indentation is correct, here it's two spaces at the beginning of every line
-# sap_vm_provision_ssh_host_private_key_data: |
-#  < your key data>
-
-# Should the CA cert and the API endpoint be extracted from the kubeconfig file?
-sap_vm_provision_kubevirt_vm_extract_kubeconfig: true
-
-# Should an existing VM be overwritten?
-sap_vm_provision_kubevirt_vm_overwrite_vm: false
-
-# Kubeconfig file for cluster where VMs should be created
-sap_vm_provision_kubevirt_vm_kubeconfig_path: /path/to/clusterconfigs/kubeconfig
-
-# In order to use secured communication, provide the CA cert bundle for the cluster.
-# This can be extracted from the kubeconfig file with the following command from the
-# kubeconfig file:
-#   grep certificate-authority-data ${KUBECONFIG} | awk '{ print $2 }' | base64 --decode > cluster-ca-cert.pem
-# This variable will not be used if sap_vm_provision_kubevirt_vm_extract_kubeconfig = true
-# sap_vm_provision_kubevirt_vm_ca_cert: /path/to/clusterconfigs/cluster-ca-cert.pem
-
-# API endpoint of the cluster
-# This variable will not be used if sap_vm_provision_kubevirt_vm_extract_kubeconfig = true
-# sap_vm_provision_kubevirt_vm_api_endpoint: https://api.cluster.domain.tld:6443
-
-# Admin username for the cluster communication
-sap_vm_provision_kubevirt_vm_admin_username: kubeadmin
-
-# Password for the above admin user
-sap_vm_provision_kubevirt_vm_admin_password: AAAAA-BBBBB-CCCCC-DDDDD
+# SSH key files, must be accessible on the ansible controller
+sap_vm_provision_ssh_host_private_key_file_path: /path/to/id_rsa 
+sap_vm_provision_ssh_host_public_key_file_path: /path/to/id_rsa.pub
 
 # RAM Overhead [GiB] for virt-launcher container, this can be small for VMs < 1 TB and without SRIOV but should be increased to 16 or more for VMs > 1TB
 sap_vm_provision_kubevirt_vm_container_memory_overhead: 1
 
 # hostname of the ansible controller
-sap_vm_provision_kubevirt_vm_ansible_controller: localhost # on AAP, this is localhost
+sap_vm_provision_execution_host: localhost # on AAP, this is localhost
+
+# What's the host specification plan that should be rolled out?
+sap_vm_provision_host_specification_plan: example_host_specification_plan
 
 sap_vm_provision_kubevirt_vm_host_specifications_dictionary:
   example_host_specification_plan:
@@ -69,11 +42,17 @@ sap_vm_provision_kubevirt_vm_host_specifications_dictionary:
       # Provide either an existing PVC or a URL for an OS image
       os_image: # either url or source_pvc_name have to be provided
         # URL for an image to be used
-        url: "docker://registry.redhat.io/rhel8/rhel-guest-image:8.8.0"
+        #url: "docker://registry.redhat.io/rhel8/rhel-guest-image:8.8.0"
+        #url: "docker://registry.redhat.io/rhel8/rhel-guest-image:8.10.0"
+        #url: "docker://registry.redhat.io/rhel9/rhel-guest-image:9.4"
+        url: "docker://registry.redhat.io/rhel9/rhel-guest-image:9.6"
+        #url: "docker://registry.redhat.io/rhel10/rhel-guest-image:10.0"
         # Name for a PVC to be cloned
         # source_pvc_name: "rhel-8.8"
         namespace: openshift-virtualization-os-images
         size: "50Gi"
+        access_modes:                    # e.g. ReadWriteMany | ReadWriteOnce
+          - ReadWriteMany
       network_definition:
         - name: sapbridge
           type: bridge
@@ -84,21 +63,22 @@ sap_vm_provision_kubevirt_vm_host_specifications_dictionary:
           mountpoint: /hana
           disk_count: 1                  # default: 1
           disk_size: 2048                # size in GB, integer
-          disk_type: nas                 # KubeVirt Storage Class
+          disk_type: sapstorage          # KubeVirt Storage Class
+          access_modes:                  # e.g. ReadWriteMany | ReadWriteOnce
+            - ReadWriteMany
       cloudinit:
         userData: |-
           #cloud-config
           timezone: Europe/Berlin
-          hostname: "{{ scaleout_origin_host_spec }}"
+          hostname: host1
           user: {{ sap_vm_provision_kubevirt_vm_os_user if sap_vm_provision_kubevirt_vm_os_user is defined }}
           password: {{ sap_vm_provision_kubevirt_vm_os_user_password if sap_vm_provision_kubevirt_vm_os_user_password is defined }}
           chpasswd:
             expire: false
           ssh_authorized_keys:
-            - "{{ lookup('ansible.builtin.file', sap_vm_provision_ssh_host_public_key_file_path ) }}"
+            - "{{ lookup('ansible.builtin.file', sap_vm_provision_ssh_host_public_key_file_path ) if sap_vm_provision_ssh_host_public_key_file_path is defined }}"
         networkData: |-
-          network:
-            version: 2
-            ethernets:
-              eth0:
-                dhcp4: true
+          version: 2
+          ethernets:
+            eth0:
+              dhcp4: true

--- a/roles/sap_vm_provision/PLATFORM_GUIDANCE.md
+++ b/roles/sap_vm_provision/PLATFORM_GUIDANCE.md
@@ -129,13 +129,9 @@ See below for the drop-down list of required environment resources on an Infrast
 }
 ```
 
-- Kubeconfig file, kubeadmin user and password for the cluster you want to deploy. Default behavior is to extract CA certificate and API endpoint from kubeconfig (`sap_vm_provision_kubevirt_vm_extract_kubeconfig: true`). Kubeconfig location will be read from `sap_vm_provision_kubevirt_vm_kubeconfig_path` and if that variable is not defined from environment variable `K8S_AUTH_KUBECONFIG`.
+- Kubeconfig file, kubeadmin user and password for the cluster you want to deploy. Default behavior is to extract CA certificate and API endpoint from kubeconfig (`sap_vm_provision_kubevirt_vm_extract_kubeconfig: true`). Kubeconfig location will be read from `sap_vm_provision_kubevirt_vm_kubeconfig` and if that variable is not defined from environment variable `K8S_AUTH_KUBECONFIG` or `KUBECONFIG`.
 
-- SSH Key Pair for VMs or provide a password
-  - `sap_vm_provision_ocp_guest_ssh_auth_mechanism`: Authentication mechanism to be used to connect to the guest. Possible options are:
-    - `password`: Make sure to set password in `sap_vm_provision_ocp_os_user_password`.
-    - `private_key`: Use the private ssh key at the location defined by `sap_vm_provision_ssh_host_private_key_file_path`.
-    - `private_key_data`: use the private ssh key provided in `sap_vm_provision_ssh_host_private_key_data` and write it to the location defined in `sap_vm_provision_ssh_host_private_key_file_path`.
+- SSH Key Pair for VMs
 
 - Optional: Ansible Control Node host with access to OpenShift cluster. 
 

--- a/roles/sap_vm_provision/README.md
+++ b/roles/sap_vm_provision/README.md
@@ -17,7 +17,7 @@ A series of choices is provided by the Ansible Role:
 - Host Specification Dictionary, containing 1..n Plans
 - Host OS Image Dictionary
 
-Dependent on the choices made by the end user, host/s will be provisioend to the target Infrastructure Platform.
+Dependent on the choices made by the end user, host/s will be provisioned to the target Infrastructure Platform.
 
 ## Scope
 
@@ -86,7 +86,6 @@ For a list of requirements and recommended authorizations on each Infrastructure
         - `openstack.cloud`
         - `ovirt.ovirt`
         - `vmware.vmware_rest` <sup>_(requires `cloud.common`)_</sup>
-        - `community.okd` for Red Hat OpenShift Virtualization
 
 TODO: Split up above dependencies per platform.
 

--- a/roles/sap_vm_provision/defaults/main.yml
+++ b/roles/sap_vm_provision/defaults/main.yml
@@ -266,13 +266,8 @@ sap_vm_provision_ibmpowervm_key_pair_name_ssh_host_public_key: ""
 sap_vm_provision_ibmpowervm_placement_resource_name: "sap-collocation-rule-spread"
 sap_vm_provision_ibmpowervm_placement_strategy_spread: false
 
-# Kubevirt
-sap_vm_provision_kubevirt_api_key: ""
-sap_vm_provision_kubevirt_cluster_url: ""
-sap_vm_provision_kubevirt_vm_host_os_image_url: "" # e.g. docker://registry.redhat.io/rhel8/rhel-guest-image:8.6.0
-sap_vm_provision_kubevirt_os_user: ""
-sap_vm_provision_kubevirt_os_user_password: ""
-sap_vm_provision_kubevirt_target_namespace: ""
+# Kubevirt, see below
+# sap_vm_provision_kubevirt_vm_kubeconfig: /path/to/clusterconfigs/kubeconfig
 
 # OVirt
 sap_vm_provision_ovirt_engine_cafile: ""
@@ -782,6 +777,11 @@ sap_vm_provision_ibmpowervm_vm_host_specifications_dictionary:
 # kubevirt / Red Hat OpenShift Virtualization         #
 #######################################################
 
+# kubeconfig for Red Hat OpenShift cluster connection.
+# If not provided, the kubeconfig will be read from the environment variables
+# KUBECONFIG or K8S_AUTH_KUBECONFIG
+# sap_vm_provision_kubevirt_vm_kubeconfig: /path/to/clusterconfigs/kubeconfig
+
 # Namespace where the VM should be created in
 sap_vm_provision_kubevirt_vm_target_namespace: sap
 
@@ -791,50 +791,22 @@ sap_vm_provision_kubevirt_vm_os_user: cloud-user
 # Password for the above user
 sap_vm_provision_kubevirt_vm_os_user_password: ""
 
-# how to authenticate to the guest vm [password|private_key|private_key_data]
-# password: uses provided password in sap_vm_provision_kubevirt_vm_os_user_password, make sure your ssh config allows password authentication
-# private_key: use the private ssh key at the location defined by sap_vm_provision_ssh_host_private_key_file_path
-# private_key_data: use the private ssh key provided in sap_vm_provision_ssh_host_private_key_data and write it to the location defined in sap_vm_provision_ssh_host_private_key_file_path
-sap_vm_provision_kubevirt_vm_guest_ssh_auth_mechanism: private-key
-
-# Private SSH key file, must be accessible on the ansible controller
-# sap_vm_provision_ssh_host_private_key_file_path: <your private ssh key file>
-
-# private ssh key, make sure the indentation is correct, here it's two spaces at the beginning of every line
-# sap_vm_provision_ssh_host_private_key_data: |
-#  < your key data>
-
-# Should the CA cert and the API endpoint be extracted from the kubeconfig file?
-sap_vm_provision_kubevirt_vm_extract_kubeconfig: true
-
-# Should an existing VM be overwritten?
-sap_vm_provision_kubevirt_vm_overwrite_vm: false
-
-# Kubeconfig file for cluster where VMs should be created
-sap_vm_provision_kubevirt_vm_kubeconfig_path: /path/to/clusterconfigs/kubeconfig
-
-# In order to use secured communication, provide the CA cert bundle for the cluster.
-# This can be extracted from the kubeconfig file with the following command from the
-# kubeconfig file:
-#   grep certificate-authority-data ${KUBECONFIG} | awk '{ print $2 }' | base64 --decode > cluster-ca-cert.pem
-# This variable will not be used if sap_vm_provision_kubevirt_vm_extract_kubeconfig = true
-# sap_vm_provision_kubevirt_vm_ca_cert: /path/to/clusterconfigs/cluster-ca-cert.pem
-
-# API endpoint of the cluster
-# This variable will not be used if sap_vm_provision_kubevirt_vm_extract_kubeconfig = true
-# sap_vm_provision_kubevirt_api_vm_endpoint: https://api.cluster.domain.tld:6443
-
-# Admin username for the cluster communication
-sap_vm_provision_kubevirt_vm_admin_username: kubeadmin
-
-# Password for the above admin user
-sap_vm_provision_kubevirt_vm_admin_password: AAAAA-BBBBB-CCCCC-DDDDD
-
 # RAM Overhead [GiB] for virt-launcher container, this can be small for VMs < 1 TB and without SRIOV but should be increased to 16 or more for VMs > 1TB
 sap_vm_provision_kubevirt_vm_container_memory_overhead: 1
 
-# hostname of the ansible controller
-sap_vm_provision_kubevirt_vm_ansible_controller: localhost # on AAP, this is localhost
+# CPU performance settings which are applied to VM
+sap_vm_provision_kubevirt_vm_performance_cpu_settings:
+  dedicatedCpuPlacement: true
+  model: host-passthrough
+  numa:
+    guestMappingPassthrough: {}
+  features:
+    - name: x2apic
+      policy: require
+    - name: rdtscp
+      policy: require
+    - name: invtsc
+      policy: require
 
 sap_vm_provision_kubevirt_vm_host_specifications_dictionary:
   example_host_specification_plan:
@@ -848,11 +820,17 @@ sap_vm_provision_kubevirt_vm_host_specifications_dictionary:
       # Provide either an existing PVC or a URL for an OS image
       os_image: # either url or source_pvc_name have to be provided
         # URL for an image to be used
-        url: "docker://registry.redhat.io/rhel8/rhel-guest-image:8.8.0"
+        #url: "docker://registry.redhat.io/rhel8/rhel-guest-image:8.8.0"
+        #url: "docker://registry.redhat.io/rhel8/rhel-guest-image:8.10.0"
+        #url: "docker://registry.redhat.io/rhel9/rhel-guest-image:9.4"
+        url: "docker://registry.redhat.io/rhel9/rhel-guest-image:9.6"
+        #url: "docker://registry.redhat.io/rhel10/rhel-guest-image:10.0"
         # Name for a PVC to be cloned
         # source_pvc_name: "rhel-8.8"
         namespace: openshift-virtualization-os-images
         size: "50Gi"
+        access_modes:                    # e.g. ReadWriteMany | ReadWriteOnce
+          - ReadWriteMany
       network_definition:
         - name: sapbridge
           type: bridge
@@ -863,24 +841,25 @@ sap_vm_provision_kubevirt_vm_host_specifications_dictionary:
           mountpoint: /hana
           disk_count: 1                  # default: 1
           disk_size: 2048                # size in GB, integer
-          disk_type: nas                 # KubeVirt Storage Class
+          disk_type: sapstorage          # KubeVirt Storage Class
+          access_modes:                  # e.g. ReadWriteMany | ReadWriteOnce
+            - ReadWriteMany
       cloudinit:
         userData: |-
           #cloud-config
           timezone: Europe/Berlin
-          hostname: "{{ scaleout_origin_host_spec }}"
+          hostname: host1
           user: {{ sap_vm_provision_kubevirt_vm_os_user if sap_vm_provision_kubevirt_vm_os_user is defined }}
           password: {{ sap_vm_provision_kubevirt_vm_os_user_password if sap_vm_provision_kubevirt_vm_os_user_password is defined }}
           chpasswd:
             expire: false
           ssh_authorized_keys:
-            - "{{ lookup('ansible.builtin.file', sap_vm_provision_ssh_host_public_key_file_path ) }}"
+            - "{{ lookup('ansible.builtin.file', sap_vm_provision_ssh_host_public_key_file ) if sap_vm_provision_ssh_host_public_key_file is defined }}"
         networkData: |-
-          network:
-            version: 2
-            ethernets:
-              eth0:
-                dhcp4: true
+          version: 2
+          ethernets:
+            eth0:
+              dhcp4: true
 
 # OVirt
 sap_vm_provision_ovirt_vm_boot_menu: false

--- a/roles/sap_vm_provision/tasks/platform_ansible/kubevirt_vm/execute_main.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/kubevirt_vm/execute_main.yml
@@ -1,11 +1,4 @@
 ---
-- name: Fail if sap_vm_provision_kubevirt_vm_os_user_password is not set and sap_vm_provision_kubevirt_vm_guest_ssh_auth_mechanism is set to password
-  ansible.builtin.fail:
-    msg: Password is not allowed to be empty or undefined (sap_vm_provision_kubevirt_vm_os_user_password).
-  when:
-    - sap_vm_provision_kubevirt_vm_guest_ssh_auth_mechanism == "password"
-    - sap_vm_provision_kubevirt_vm_os_user_password == "" or sap_vm_provision_kubevirt_vm_os_user_password == null
-
 - name: Ansible Task block for looped provisioning of KubeVirt Virtual Machines
   any_errors_fatal: true
   # Using environment, no_log is ineffective and log will show 'EXEC /bin/sh -c 'ENV_VAR=value python3 /AnsiballZ_ansible_module_name.py && sleep 0'
@@ -68,24 +61,14 @@
         - not lookup('ansible.builtin.vars', loop_item, default='') is skipped
         - lookup('ansible.builtin.vars', loop_item, default='') is failed
 
-- name: Write private ssh key to ansible_controller
-  delegate_to: "{{ sap_vm_provision_kubevirt_vm_ansible_controller }}"
-  no_log: true
-  ansible.builtin.copy:
-    dest: "{{ sap_vm_provision_ssh_host_private_key_file_path }}"
-    content: "{{ sap_vm_provision_ssh_host_private_key_data }}"
-    mode: "0600"
-  when: sap_vm_provision_kubevirt_vm_guest_ssh_auth_mechanism == "private_key_data"
-
 - name: Ansible Task block to execute on target inventory hosts
   remote_user: "{{ sap_vm_provision_kubevirt_vm_os_user }}"
   become: true
   become_user: root
   delegate_to: "{{ inventory_hostname }}"
   vars:
-    ansible_password: "{{ sap_vm_provision_kubevirt_vm_os_user_password }}"
     ansible_ssh_private_key_file: "{{ sap_vm_provision_ssh_host_private_key_file_path }}"
-    ansible_ssh_common_args: "-o ConnectTimeout=180 -o ControlMaster=auto -o ControlPersist=3600s -o UserKnownHostsFile=/dev/null -o ForwardX11=no -o ProxyJump={{ __sap_vm_provision_kubevirt_vm_register_execution_host_user }}@{{ sap_vm_provision_execution_host }}"
+    ansible_ssh_common_args: "-o StrictHostKeyChecking=no -o ConnectTimeout=180 -o ControlMaster=auto -o ControlPersist=3600s -o UserKnownHostsFile=/dev/null -o ForwardX11=no -o ProxyJump={{ __sap_vm_provision_kubevirt_vm_register_execution_host_user }}@{{ sap_vm_provision_execution_host }}"
 
   block:
 
@@ -132,13 +115,3 @@
     - name: Register Package Repositories
       ansible.builtin.include_tasks:
         file: common/register_os.yml
-
-  always:
-
-    - name: Delete private ssh key from ansible_controller
-      delegate_to: "{{ sap_vm_provision_register_ansible_controller }}"
-      become: false
-      ansible.builtin.file:
-        path: "{{ sap_vm_provision_ssh_host_private_key_file_path }}"
-        state: absent
-      when: sap_vm_provision_kubevirt_vm_guest_ssh_auth_mechanism == "private_key_data"

--- a/roles/sap_vm_provision/tasks/platform_ansible/kubevirt_vm/execute_provision.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/kubevirt_vm/execute_provision.yml
@@ -34,7 +34,7 @@
               },
             },
             'storage' : {
-              'accessModes': ['ReadWriteMany'],
+              'accessModes': __sap_vm_provision_register_vm_config.os_image.access_modes,
               'resources': {
                 'requests': {
                   'storage': __sap_vm_provision_register_vm_config.os_image.size
@@ -61,7 +61,7 @@
               },
             },
             'storage' : {
-              'accessModes': ['ReadWriteMany'],
+              'accessModes': __sap_vm_provision_register_vm_config.os_image.access_modes,
               'resources': {
                 'requests': {
                   'storage': __sap_vm_provision_register_vm_config.os_image.size
@@ -89,7 +89,7 @@
                     'blank' : {}
                   },
                   'storage' : {
-                    'accessModes': ['ReadWriteMany'],
+                    'accessModes': storage_item.access_modes,
                     'resources': {
                       'requests': {
                         'storage': ((storage_item.disk_size | default(0)) | string) + 'Gi'
@@ -243,22 +243,16 @@
         cpu:
           cores: "{{ __sap_vm_provision_register_vm_config.kubevirt_vm_cpu_cores }}"
           threads: "{{ __sap_vm_provision_register_vm_config.kubevirt_vm_cpu_smt }}"
-          dedicatedCpuPlacement: true
-          model: host-passthrough
-          numa:
-            guestMappingPassthrough: {}
-          features:
-            - name: x2apic
-              policy: require
-            - name: rdtscp
-              policy: require
-            - name: invtsc
-              policy: require
 
         memory:
           guest: "{{ __sap_vm_provision_register_vm_config.kubevirt_vm_memory_gib }}Gi"
           hugepages:
             pageSize: 1Gi
+
+- name: Apply CPU performance settings
+  ansible.builtin.set_fact:
+    __sap_vm_provision_register_vm_deploy_config: >-
+      {{ __sap_vm_provision_register_vm_deploy_config | combine({'domain': { 'cpu': __sap_vm_provision_register_vm_deploy_config.domain.cpu | combine(sap_vm_provision_kubevirt_vm_performance_cpu_settings)}}, recursive=True) }}
 
 - name: Provision KubeVirt Virtual Machine
   kubevirt.core.kubevirt_vm:


### PR DESCRIPTION
Updated sap_vm_provision(kubevirt_vm)
    - Added assert for kubeconfig 
    - Unified storageclass to sapstorage for both trident and hpp and make configurable 
    - trident: make parameters configurable in role - Renamed default namespace for VMs to sap
    - Define public ssh key explicitly - fixed network config cloudinit 
    - added sap_vm_provision_host_specification_plan to sample var file 
    - make disk access_modes configurable 
    - make CPU performance settings configurable