### PR TITLE
collection: Adjust roles for ansible-core 2.19

### DIFF
--- a/roles/sap_vm_provision/tasks/common/set_etc_hosts_ha.yml
+++ b/roles/sap_vm_provision/tasks/common/set_etc_hosts_ha.yml
@@ -89,7 +89,7 @@
 #        - "{{ sap_vm_provision_dynamic_inventory_nw_pas_ip }}\t{{ sap_vm_provision_dynamic_inventory_nw_pas_hostname }}.{{ ansible_domain }}\t{{ sap_vm_provision_dynamic_inventory_nw_pas_hostname }}"
         # Allows to build ASCS ERS cluster without PAS if PAS details are not provided
         - "{{ sap_vm_provision_dynamic_inventory_nw_pas_ip | string + '\t' + sap_vm_provision_dynamic_inventory_nw_pas_hostname + '.' + ansible_domain + '\t' + sap_vm_provision_dynamic_inventory_nw_pas_hostname
-            if (sap_vm_provision_dynamic_inventory_nw_pas_hostname is defined and sap_vm_provision_dynamic_inventory_nw_pas_hostname | length > 0 )
+            if (sap_vm_provision_dynamic_inventory_nw_pas_hostname is defined and sap_vm_provision_dynamic_inventory_nw_pas_hostname is not none and sap_vm_provision_dynamic_inventory_nw_pas_hostname | length > 0 )
             and (sap_vm_provision_dynamic_inventory_nw_pas_ip is defined and sap_vm_provision_dynamic_inventory_nw_pas_ip | length > 0) else ''}}"
       when:
         - (groups[sap_vm_provision_group_nwas_ers] is defined and (groups[sap_vm_provision_group_nwas_ers] | length>0))

--- a/roles/sap_vm_temp_vip/tasks/get_temp_vip_details.yml
+++ b/roles/sap_vm_temp_vip/tasks/get_temp_vip_details.yml
@@ -12,7 +12,8 @@
   ansible.builtin.shell:
     cmd: set -o pipefail && ip -oneline address show {{ __sap_vm_temp_vip_get_route.stdout }} | grep {{ sap_vm_temp_vip_default_ip }}
   when:
-    - __sap_vm_temp_vip_get_route.stdout is defined  and __sap_vm_temp_vip_get_route.stdout | length > 0
+    - __sap_vm_temp_vip_get_route.stdout is defined
+    - __sap_vm_temp_vip_get_route.stdout | length > 0
   register: __sap_vm_temp_vip_get_ips
   changed_when: false
   failed_when: false

--- a/roles/sap_vm_temp_vip/tasks/main.yml
+++ b/roles/sap_vm_temp_vip/tasks/main.yml
@@ -17,8 +17,8 @@
 
 - name: Block to ensure that only supported groups are allowed
   when:
-    - group_names | intersect([sap_vm_temp_vip_group_hana_primary, sap_vm_temp_vip_group_hana_secondary, sap_vm_temp_vip_group_anydb_primary,
-      sap_vm_temp_vip_group_anydb_secondary, sap_vm_temp_vip_group_nwas_ascs, sap_vm_temp_vip_group_nwas_ers])
+    - (group_names | intersect([sap_vm_temp_vip_group_hana_primary, sap_vm_temp_vip_group_hana_secondary, sap_vm_temp_vip_group_anydb_primary,
+      sap_vm_temp_vip_group_anydb_secondary, sap_vm_temp_vip_group_nwas_ascs, sap_vm_temp_vip_group_nwas_ers])) | length > 0
   block:
 
     # - name: Identify OS Primary Network Interface

--- a/roles/sap_vm_temp_vip/tasks/set_temp_vip.yml
+++ b/roles/sap_vm_temp_vip/tasks/set_temp_vip.yml
@@ -41,7 +41,9 @@
   ansible.builtin.shell:
     cmd: set -o pipefail && ip -oneline address show | grep {{ __sap_vm_temp_vip_address }}
   when:
-    - __sap_vm_temp_vip_address is defined and __sap_vm_temp_vip_address | length > 0
+    - __sap_vm_temp_vip_address is defined
+    - __sap_vm_temp_vip_address is not none
+    - __sap_vm_temp_vip_address | length > 0
   register: __sap_vm_temp_vip_get_vip
   changed_when: false
   ignore_errors: true
@@ -72,7 +74,7 @@
     __vip_multiple: "{{ true if __sap_vm_temp_vip_get_vip.stdout_lines | length > 1 else false }}"
   when:
     - __sap_vm_temp_vip_get_vip.stdout is defined and __sap_vm_temp_vip_get_vip.stdout | length > 0
-    - __sap_vm_temp_vip_address is defined and __sap_vm_temp_vip_address | length > 0
+    - __sap_vm_temp_vip_address is not none and __sap_vm_temp_vip_address | length > 0
 
 
 # Dynamically generate IP creation command depending on values gathered before:
@@ -88,7 +90,7 @@
         ip address add {{ __sap_vm_temp_vip_address }}/{{ __sap_vm_temp_vip_prefix }} brd + dev {{ sap_vm_temp_vip_default_interface }} noprefixroute
       {%- endif -%}
   when:
-    - __sap_vm_temp_vip_address is defined and __sap_vm_temp_vip_address | length > 0
+    - __sap_vm_temp_vip_address is not none and __sap_vm_temp_vip_address | length > 0
     - __sap_vm_temp_vip_prefix | length > 0
     - __sap_vm_temp_vip_get_vip.stdout is defined and __sap_vm_temp_vip_get_vip.stdout | length == 0
 


### PR DESCRIPTION
## Reason
Details about upcoming `ansible-core 2.19` are listed in https://github.com/sap-linuxlab/community.sap_infrastructure/issues/107

## Changes
- Add missing conditionals, where Truthy value was missing

**NOTES:**
- Internally defined `__vars` are always defined, when no conditional is present, but if they contain jinja2, then they can be empty as `NoneType`, which requires check for `none`, not `if defined`.

## Tested
Changes were tested on ansible-core `2.18` and `2.19` with `Python 3.13`.