### PR TITLE
sap_vm_provision: Add variable validations

### DIFF
--- a/roles/sap_vm_provision/tasks/main.yml
+++ b/roles/sap_vm_provision/tasks/main.yml
@@ -1,24 +1,35 @@
 ---
-
-#### Provision host/s for Deployment of SAP Software (as part of an SAP Software Solution Scenario e.g. SAP S/4HANA Distributed HA) ####
-
-- name: Begin execution
+# Block is required for 'delegate_facts'.
+- name: Main Block
   delegate_to: "{{ sap_vm_provision_execution_host }}"
   delegate_facts: false # keep facts with the original play hosts, not the delegated host
   block:
 
-    - name: Execute to target {{ sap_vm_provision_iac_platform }} using {{ sap_vm_provision_iac_type }}
-      ansible.builtin.include_tasks: "{{ 'platform_' + sap_vm_provision_iac_type }}/{{ sap_vm_provision_iac_platform }}/execute_main.yml"
-      when: not sap_vm_provision_iac_post_deployment is defined or not sap_vm_provision_iac_post_deployment
+    - name: Block with simplified task file variable
+      vars:
+        __sap_vm_provision_task_file: "{{ 'platform_' + sap_vm_provision_iac_type }}/{{ sap_vm_provision_iac_platform }}"
+      block:
+
+        #### Validate required variables ####
+        - name: Validate required variables for platform {{ sap_vm_provision_iac_platform }} using {{ sap_vm_provision_iac_type }}
+          ansible.builtin.include_tasks:
+            file: validate_variables.yml
 
 
-#### Post Deployment of SAP - tasks for GCP, IBM Cloud, MS Azure ####
+        #### Provision host/s for Deployment of SAP Software (as part of an SAP Software Solution Scenario e.g. SAP S/4HANA Distributed HA) ####
+        - name: Provision hosts to platform {{ sap_vm_provision_iac_platform }} using {{ sap_vm_provision_iac_type }}
+          ansible.builtin.include_tasks:
+            file: "{{ __sap_vm_provision_task_file }}/execute_main.yml"
+          when:
+            - sap_vm_provision_iac_post_deployment is not defined or not sap_vm_provision_iac_post_deployment
 
-- name: Begin execution
-  delegate_to: "{{ sap_vm_provision_execution_host }}"
-  delegate_facts: false # keep facts with the original play hosts, not the delegated host
-  block:
 
-    - name: Execute Post Deployment tasks for SAP on target {{ sap_vm_provision_iac_platform }} using {{ sap_vm_provision_iac_type }}
-      ansible.builtin.include_tasks: "{{ 'platform_' + sap_vm_provision_iac_type }}/{{ sap_vm_provision_iac_platform }}/post_deployment_execute.yml"
-      when: sap_vm_provision_iac_post_deployment is defined and sap_vm_provision_iac_post_deployment
+        #### Post Deployment of SAP - tasks for GCP, IBM Cloud, MS Azure ####
+        - name: Execute Post Deployment tasks on platform {{ sap_vm_provision_iac_platform }} using {{ sap_vm_provision_iac_type }}
+          ansible.builtin.include_tasks:
+            file: "{{ 'platform_' + sap_vm_provision_iac_type }}/{{ sap_vm_provision_iac_platform }}/post_deployment_execute.yml"
+          when:
+            - sap_vm_provision_iac_post_deployment is defined
+            - sap_vm_provision_iac_post_deployment
+            # Execute only for files that are present
+            - (role_path ~ '/tasks/' ~ __sap_vm_provision_task_file ~ '/post_deployment_execute.yml') is file

--- a/roles/sap_vm_provision/tasks/validate_variables.yml
+++ b/roles/sap_vm_provision/tasks/validate_variables.yml
@@ -33,7 +33,7 @@
 - name: Block to validate host_specifications_dictionary
   vars:
     __sap_vm_provision_host_dictionary_name: "{{ 'sap_vm_provision_' ~ sap_vm_provision_iac_platform ~ '_host_specifications_dictionary' }}"
-  no_log: true
+  # no_log: true
   block:
     - name: Assert that the variable {{ __sap_vm_provision_host_dictionary_name }} is defined and valid
       ansible.builtin.assert:

--- a/roles/sap_vm_provision/tasks/validate_variables.yml
+++ b/roles/sap_vm_provision/tasks/validate_variables.yml
@@ -1,0 +1,93 @@
+---
+#### Validate required variables ####
+# This file servers starting point for validation of all required variables. Validation order:
+# 1. Mandatory shared variables.
+# 2. Specific to 'sap_vm_provision_iac_type', if file exists.
+# 3. Specific to 'sap_vm_provision_iac_platform', if file exists.
+# 4. Specific to bastion, if 'sap_vm_provision_bastion_execution' is true.
+
+# Lookup if variable is defined is using default 'SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED',
+# which is required to ensure compatibility between ansible-core versions.
+
+- name: Assert that the variable 'sap_vm_provision_iac_type' is defined and valid
+  ansible.builtin.assert:
+    that:
+      - sap_vm_provision_iac_type is defined
+      - sap_vm_provision_iac_type is string
+      - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform']
+    fail_msg: |
+      The variable 'sap_vm_provision_iac_type' is undefined or invalid.
+      Available options: ansible, ansible_to_terraform
+
+- name: Assert that the variable 'sap_vm_provision_iac_platform' is defined and valid
+  ansible.builtin.assert:
+    that:
+      - sap_vm_provision_iac_platform is defined
+      - sap_vm_provision_iac_platform is string
+      - sap_vm_provision_iac_platform in ['aws_ec2_vs', 'gcp_ce_vm', 'msazure_vm', 'ibmcloud_powervs', 'ibmcloud_vs', 'ibmpowervm_vm', 'kubevirt_vm', 'ovirt_vm', 'vmware_vm']
+    fail_msg: |
+      The variable 'sap_vm_provision_iac_platform' is undefined or invalid.
+      Available options: aws_ec2_vs, gcp_ce_vm, msazure_vm, ibmcloud_powervs, ibmcloud_vs, ibmpowervm_vm, kubevirt_vm, ovirt_vm, vmware_vm
+
+
+- name: Block to validate host_specifications_dictionary
+  vars:
+    __sap_vm_provision_host_dictionary_name: "{{ 'sap_vm_provision_' ~ sap_vm_provision_iac_platform ~ '_host_specifications_dictionary' }}"
+  no_log: true
+  block:
+    - name: Assert that the variable {{ __sap_vm_provision_host_dictionary_name }} is defined and valid
+      ansible.builtin.assert:
+        that:
+          - lookup('ansible.builtin.vars', __sap_vm_provision_host_dictionary_name) is defined
+          - lookup('ansible.builtin.vars', __sap_vm_provision_host_dictionary_name) is mapping
+          - lookup('ansible.builtin.vars', __sap_vm_provision_host_dictionary_name) | length > 0
+        fail_msg: |
+          The variable {{ __sap_vm_provision_host_dictionary_name }} is undefined or invalid.
+          It must be a non-empty dictionary.
+
+    - name: Assert that the variable 'sap_vm_provision_host_specification_plan' is defined and valid
+      ansible.builtin.assert:
+        that:
+          - sap_vm_provision_host_specification_plan is defined
+          - sap_vm_provision_host_specification_plan is string
+          - sap_vm_provision_host_specification_plan | trim | length > 0
+        fail_msg: |
+          The variable 'sap_vm_provision_host_specification_plan' is undefined or invalid.
+          It must be a non-empty string.
+
+    - name: Assert that the value of variable 'sap_vm_provision_host_specification_plan' is present in a dictionary
+      ansible.builtin.assert:
+        that:
+          - lookup('ansible.builtin.vars', __sap_vm_provision_host_dictionary_name)[sap_vm_provision_host_specification_plan] is defined
+          - lookup('ansible.builtin.vars', __sap_vm_provision_host_dictionary_name)[sap_vm_provision_host_specification_plan] is mapping
+          - lookup('ansible.builtin.vars', __sap_vm_provision_host_dictionary_name)[sap_vm_provision_host_specification_plan] | length > 0
+        fail_msg: |
+          The value of variable 'sap_vm_provision_host_specification_plan' is not present in a dictionary {{ __sap_vm_provision_host_dictionary_name }}.
+
+    - name: Set fact with content of the key 'sap_vm_provision_host_specification_plan'
+      ansible.builtin.set_fact:
+        __sap_vm_provision_host_dictionary_name:
+          "{{ lookup('ansible.builtin.vars', __sap_vm_provision_host_dictionary_name)[sap_vm_provision_host_specification_plan] }}"
+
+
+# Validation specific to 'sap_vm_provision_iac_type'
+- name: Include task for validation of {{ sap_vm_provision_iac_type }} variables
+  ansible.builtin.include_tasks:
+    file: "validations/platform_{{ sap_vm_provision_iac_type }}.yml"
+  when:
+    - (role_path ~ '/tasks/validations/platform_' ~ sap_vm_provision_iac_type ~ '.yml') is file
+
+
+# Validation specific to 'sap_vm_provision_iac_platform'
+- name: Include task for validation of {{ sap_vm_provision_iac_platform }} variables
+  ansible.builtin.include_tasks:
+    file: "validations/{{ sap_vm_provision_iac_platform }}.yml"
+  when:
+    - (role_path ~ '/tasks/validations/' ~ sap_vm_provision_iac_platform ~ '.yml') is file
+
+
+# Validation specific to bastion
+- name: Include task for validation of bastion variables
+  ansible.builtin.include_tasks:
+    file: "validations/bastion.yml"
+  when: sap_vm_provision_bastion_execution

--- a/roles/sap_vm_provision/tasks/validations/aws_ec2_vs.yml
+++ b/roles/sap_vm_provision/tasks/validations/aws_ec2_vs.yml
@@ -1,0 +1,95 @@
+---
+#### Validate required variables for specific 'sap_vm_provision_iac_platform ####
+
+- name: Assert that string variables are valid for {{ sap_vm_provision_iac_platform }}
+  ansible.builtin.assert:
+    that:
+      - lookup('ansible.builtin.vars', item, default='SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED') != 'SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED'
+      - lookup('ansible.builtin.vars', item) is string
+      - lookup('ansible.builtin.vars', item) | trim | length > 0
+    fail_msg: |
+      {% if lookup('ansible.builtin.vars', item, default='SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED') == 'SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED' %}
+        The variable '{{ item }}' is undefined.
+      {% elif lookup('ansible.builtin.vars', item) is not string %}
+        The variable '{{ item }}' is not a String.
+      {% else %}
+        The variable '{{ item }}' is empty.
+      {% endif %}
+  loop:
+    - sap_vm_provision_aws_access_key
+    - sap_vm_provision_aws_secret_access_key
+    - sap_vm_provision_aws_region
+    - sap_vm_provision_aws_vpc_availability_zone
+    - sap_vm_provision_aws_vpc_subnet_id
+    - sap_vm_provision_aws_ec2_vs_host_os_image
+
+
+- name: Assert that string variables are valid for {{ sap_vm_provision_iac_platform }} using 'ansible'
+  ansible.builtin.assert:
+    that:
+      - lookup('ansible.builtin.vars', item, default='SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED') != 'SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED'
+      - lookup('ansible.builtin.vars', item) is string
+      - lookup('ansible.builtin.vars', item) | trim | length > 0
+    fail_msg: |
+      {% if lookup('ansible.builtin.vars', item, default='SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED') == 'SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED' %}
+        The variable '{{ item }}' is undefined.
+      {% elif lookup('ansible.builtin.vars', item) is not string %}
+        The variable '{{ item }}' is not a String.
+      {% else %}
+        The variable '{{ item }}' is empty.
+      {% endif %}
+  loop:
+    - sap_vm_provision_aws_vpc_sg_names
+    - sap_vm_provision_aws_key_pair_name_ssh_host_public_key
+    - sap_vm_provision_aws_placement_resource_name
+    - sap_vm_provision_aws_ha_iam_role
+    - sap_vm_provision_aws_ha_iam_instance_profile
+  when:
+    - sap_vm_provision_iac_type == 'ansible'
+
+
+- name: Assert that boolean variables are valid for {{ sap_vm_provision_iac_platform }}
+  ansible.builtin.assert:
+    that:
+      - lookup('ansible.builtin.vars', __sap_vm_provision_loop_bool_var, default='SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED') != 'SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED'
+      - lookup('ansible.builtin.vars', __sap_vm_provision_loop_bool_var) is boolean
+      - lookup('ansible.builtin.vars', __sap_vm_provision_loop_bool_var) | trim | length > 0
+    fail_msg: |
+      {% if lookup('ansible.builtin.vars', item, default='SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED') == 'SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED' %}
+        The variable '{{ __sap_vm_provision_loop_bool_var }}' is undefined.
+      {% elif lookup('ansible.builtin.vars', item) is not boolean %}
+        The variable '{{ __sap_vm_provision_loop_bool_var }}' is not a Boolean.
+      {% else %}
+        The variable '{{ __sap_vm_provision_loop_bool_var }}' is empty.
+      {% endif %}
+  loop:
+    - sap_vm_provision_aws_vpc_subnet_create_boolean
+    - sap_vm_provision_aws_placement_strategy_spread
+    - sap_vm_provision_aws_dns_overwrite
+  vars:
+    __sap_vm_provision_loop_bool_var: "{{ item }}"
+
+
+- name: Block to validate host_specifications_dictionary
+  vars:
+    __sap_vm_provision_os_image_dictionary_name: "{{ 'sap_vm_provision_' ~ sap_vm_provision_iac_platform ~ '_host_os_image_dictionary' }}"
+    __sap_vm_provision_os_image_name: "{{ 'sap_vm_provision_' ~ sap_vm_provision_iac_platform ~ '_host_os_image' }}"
+  no_log: true
+  block:
+    - name: Assert that the variable {{ __sap_vm_provision_os_image_dictionary_name }} is defined and valid
+      ansible.builtin.assert:
+        that:
+          - lookup('ansible.builtin.vars', __sap_vm_provision_os_image_dictionary_name) is defined
+          - lookup('ansible.builtin.vars', __sap_vm_provision_os_image_dictionary_name) is mapping
+          - lookup('ansible.builtin.vars', __sap_vm_provision_os_image_dictionary_name) | length > 0
+        fail_msg: |
+          The variable {{ __sap_vm_provision_os_image_dictionary_name }} is undefined or invalid.
+          It must be a non-empty dictionary.
+
+    - name: Assert that the value of variable {{ __sap_vm_provision_os_image_name }} is present in a dictionary
+      ansible.builtin.assert:
+        that:
+          - lookup('ansible.builtin.vars', __sap_vm_provision_os_image_dictionary_name)[__sap_vm_provision_os_image_name] is defined
+          - lookup('ansible.builtin.vars', __sap_vm_provision_os_image_dictionary_name)[__sap_vm_provision_os_image_name] | length > 0
+        fail_msg: |
+          The value of variable {{ __sap_vm_provision_os_image_name }} is not present in a dictionary {{ __sap_vm_provision_os_image_dictionary_name }}.

--- a/roles/sap_vm_provision/tasks/validations/aws_ec2_vs.yml
+++ b/roles/sap_vm_provision/tasks/validations/aws_ec2_vs.yml
@@ -74,7 +74,6 @@
   vars:
     __sap_vm_provision_os_image_dictionary_name: "{{ 'sap_vm_provision_' ~ sap_vm_provision_iac_platform ~ '_host_os_image_dictionary' }}"
     __sap_vm_provision_os_image_name: "{{ 'sap_vm_provision_' ~ sap_vm_provision_iac_platform ~ '_host_os_image' }}"
-  no_log: true
   block:
     - name: Assert that the variable {{ __sap_vm_provision_os_image_dictionary_name }} is defined and valid
       ansible.builtin.assert:

--- a/roles/sap_vm_provision/tasks/validations/bastion.yml
+++ b/roles/sap_vm_provision/tasks/validations/bastion.yml
@@ -1,0 +1,44 @@
+---
+#### Validate required variables for bastion ####
+# Note: 'ansible_to_terraform' uses bastion, but not all variables
+
+- name: Assert that string variables are valid for bastion
+  ansible.builtin.assert:
+    that:
+      - lookup('ansible.builtin.vars', item, default='SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED') != 'SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED'
+      - lookup('ansible.builtin.vars', item) is string
+      - lookup('ansible.builtin.vars', item) | trim | length > 0
+    fail_msg: |
+      {% if lookup('ansible.builtin.vars', item, default='SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED') == 'SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED' %}
+        The variable '{{ item }}' is undefined.
+      {% elif lookup('ansible.builtin.vars', item) is not string %}
+        The variable '{{ item }}' is not a String.
+      {% else %}
+        The variable '{{ item }}' is empty.
+      {% endif %}
+  loop:
+    - sap_vm_provision_bastion_public_ip
+    - sap_vm_provision_bastion_user
+    - sap_vm_provision_ssh_bastion_private_key_file_path
+  when:
+    - sap_vm_provision_iac_type == 'ansible'
+
+
+- name: Assert that string or integer variables are valid for bastion
+  ansible.builtin.assert:
+    that:
+      - lookup('ansible.builtin.vars', item, default='SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED') != 'SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED'
+      - lookup('ansible.builtin.vars', item) is string or lookup('ansible.builtin.vars', item) is integer
+      - lookup('ansible.builtin.vars', item) | trim | length > 0
+    fail_msg: |
+      {% if lookup('ansible.builtin.vars', item, default='SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED') == 'SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED' %}
+        The variable '{{ item }}' is undefined.
+      {% elif lookup('ansible.builtin.vars', item) is not string and lookup('ansible.builtin.vars', item) is not integer %}
+        The variable '{{ item }}' is not a String or an Integer.
+      {% else %}
+        The variable '{{ item }}' is empty.
+      {% endif %}
+  loop:
+    - sap_vm_provision_bastion_ssh_port
+  when:
+    - sap_vm_provision_iac_type == 'ansible'

--- a/roles/sap_vm_provision/tasks/validations/gcp_ce_vm.yml
+++ b/roles/sap_vm_provision/tasks/validations/gcp_ce_vm.yml
@@ -69,7 +69,6 @@
   vars:
     __sap_vm_provision_os_image_dictionary_name: "{{ 'sap_vm_provision_' ~ sap_vm_provision_iac_platform ~ '_host_os_image_dictionary' }}"
     __sap_vm_provision_os_image_name: "{{ 'sap_vm_provision_' ~ sap_vm_provision_iac_platform ~ '_host_os_image' }}"
-  no_log: true
   block:
     - name: Assert that the variable {{ __sap_vm_provision_os_image_dictionary_name }} is defined and valid
       ansible.builtin.assert:

--- a/roles/sap_vm_provision/tasks/validations/gcp_ce_vm.yml
+++ b/roles/sap_vm_provision/tasks/validations/gcp_ce_vm.yml
@@ -1,0 +1,90 @@
+---
+#### Validate required variables for specific 'sap_vm_provision_iac_platform ####
+# Default lookup value ensures that undefined variables are validated.
+
+- name: Assert that string variables are valid for {{ sap_vm_provision_iac_platform }}
+  ansible.builtin.assert:
+    that:
+      - lookup('ansible.builtin.vars', item, default='SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED') != 'SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED'
+      - lookup('ansible.builtin.vars', item) is string
+      - lookup('ansible.builtin.vars', item) | trim | length > 0
+    fail_msg: |
+      {% if lookup('ansible.builtin.vars', item, default='SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED') == 'SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED' %}
+        The variable '{{ item }}' is undefined.
+      {% elif lookup('ansible.builtin.vars', item) is not string %}
+        The variable '{{ item }}' is not a String.
+      {% else %}
+        The variable '{{ item }}' is empty.
+      {% endif %}
+  loop:
+    - sap_vm_provision_gcp_credentials_json
+    - sap_vm_provision_gcp_project
+    - sap_vm_provision_gcp_region
+    - sap_vm_provision_gcp_region_zone
+    - sap_vm_provision_gcp_vpc_name
+    - sap_vm_provision_gcp_vpc_subnet_name
+    - sap_vm_provision_gcp_placement_resource_name
+    - sap_vm_provision_gcp_ce_vm_host_os_image
+
+
+- name: Assert that string variables are valid for {{ sap_vm_provision_iac_platform }} using 'ansible'
+  ansible.builtin.assert:
+    that:
+      - lookup('ansible.builtin.vars', item, default='SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED') != 'SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED'
+      - lookup('ansible.builtin.vars', item) is string
+      - lookup('ansible.builtin.vars', item) | trim | length > 0
+    fail_msg: |
+      {% if lookup('ansible.builtin.vars', item, default='SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED') == 'SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED' %}
+        The variable '{{ item }}' is undefined.
+      {% elif lookup('ansible.builtin.vars', item) is not string %}
+        The variable '{{ item }}' is not a String.
+      {% else %}
+        The variable '{{ item }}' is empty.
+      {% endif %}
+  loop:
+    - sap_vm_provision_ssh_host_public_key_file_path
+
+
+- name: Assert that boolean variables are valid for {{ sap_vm_provision_iac_platform }}
+  ansible.builtin.assert:
+    that:
+      - lookup('ansible.builtin.vars', __sap_vm_provision_loop_bool_var, default='SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED') != 'SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED'
+      - lookup('ansible.builtin.vars', __sap_vm_provision_loop_bool_var) is boolean
+      - lookup('ansible.builtin.vars', __sap_vm_provision_loop_bool_var) | trim | length > 0
+    fail_msg: |
+      {% if lookup('ansible.builtin.vars', item, default='SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED') == 'SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED' %}
+        The variable '{{ __sap_vm_provision_loop_bool_var }}' is undefined.
+      {% elif lookup('ansible.builtin.vars', item) is not boolean %}
+        The variable '{{ __sap_vm_provision_loop_bool_var }}' is not a Boolean.
+      {% else %}
+        The variable '{{ __sap_vm_provision_loop_bool_var }}' is empty.
+      {% endif %}
+  loop:
+    - sap_vm_provision_gcp_placement_strategy_spread
+  vars:
+    __sap_vm_provision_loop_bool_var: "{{ item }}"
+
+
+- name: Block to validate host_specifications_dictionary
+  vars:
+    __sap_vm_provision_os_image_dictionary_name: "{{ 'sap_vm_provision_' ~ sap_vm_provision_iac_platform ~ '_host_os_image_dictionary' }}"
+    __sap_vm_provision_os_image_name: "{{ 'sap_vm_provision_' ~ sap_vm_provision_iac_platform ~ '_host_os_image' }}"
+  no_log: true
+  block:
+    - name: Assert that the variable {{ __sap_vm_provision_os_image_dictionary_name }} is defined and valid
+      ansible.builtin.assert:
+        that:
+          - lookup('ansible.builtin.vars', __sap_vm_provision_os_image_dictionary_name) is defined
+          - lookup('ansible.builtin.vars', __sap_vm_provision_os_image_dictionary_name) is mapping
+          - lookup('ansible.builtin.vars', __sap_vm_provision_os_image_dictionary_name) | length > 0
+        fail_msg: |
+          The variable {{ __sap_vm_provision_os_image_dictionary_name }} is undefined or invalid.
+          It must be a non-empty dictionary.
+
+    - name: Assert that the value of variable {{ __sap_vm_provision_os_image_name }} is present in a dictionary
+      ansible.builtin.assert:
+        that:
+          - lookup('ansible.builtin.vars', __sap_vm_provision_os_image_dictionary_name)[__sap_vm_provision_os_image_name] is defined
+          - lookup('ansible.builtin.vars', __sap_vm_provision_os_image_dictionary_name)[__sap_vm_provision_os_image_name] | length > 0
+        fail_msg: |
+          The value of variable {{ __sap_vm_provision_os_image_name }} is not present in a dictionary {{ __sap_vm_provision_os_image_dictionary_name }}.

--- a/roles/sap_vm_provision/tasks/validations/ibmcloud_powervs.yml
+++ b/roles/sap_vm_provision/tasks/validations/ibmcloud_powervs.yml
@@ -71,7 +71,6 @@
   vars:
     __sap_vm_provision_os_image_dictionary_name: "{{ 'sap_vm_provision_' ~ sap_vm_provision_iac_platform ~ '_host_os_image_dictionary' }}"
     __sap_vm_provision_os_image_name: "{{ 'sap_vm_provision_' ~ sap_vm_provision_iac_platform ~ '_host_os_image' }}"
-  no_log: true
   block:
     - name: Assert that the variable {{ __sap_vm_provision_os_image_dictionary_name }} is defined and valid
       ansible.builtin.assert:

--- a/roles/sap_vm_provision/tasks/validations/ibmcloud_powervs.yml
+++ b/roles/sap_vm_provision/tasks/validations/ibmcloud_powervs.yml
@@ -1,0 +1,92 @@
+---
+#### Validate required variables for specific 'sap_vm_provision_iac_platform ####
+
+- name: Assert that string variables are valid for {{ sap_vm_provision_iac_platform }}
+  ansible.builtin.assert:
+    that:
+      - lookup('ansible.builtin.vars', item, default='SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED') != 'SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED'
+      - lookup('ansible.builtin.vars', item) is string
+      - lookup('ansible.builtin.vars', item) | trim | length > 0
+    fail_msg: |
+      {% if lookup('ansible.builtin.vars', item, default='SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED') == 'SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED' %}
+        The variable '{{ item }}' is undefined.
+      {% elif lookup('ansible.builtin.vars', item) is not string %}
+        The variable '{{ item }}' is not a String.
+      {% else %}
+        The variable '{{ item }}' is empty.
+      {% endif %}
+  loop:
+    - sap_vm_provision_ibmcloud_powervs_location
+    - sap_vm_provision_ibmcloud_powervs_host_os_image
+    - sap_vm_provision_ibmcloud_api_key
+    - sap_vm_provision_ibmcloud_resource_group_name
+
+
+- name: Assert that string variables are valid for {{ sap_vm_provision_iac_platform }} using 'ansible'
+  ansible.builtin.assert:
+    that:
+      - lookup('ansible.builtin.vars', item, default='SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED') != 'SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED'
+      - lookup('ansible.builtin.vars', item) is string
+      - lookup('ansible.builtin.vars', item) | trim | length > 0
+    fail_msg: |
+      {% if lookup('ansible.builtin.vars', item, default='SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED') == 'SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED' %}
+        The variable '{{ item }}' is undefined.
+      {% elif lookup('ansible.builtin.vars', item) is not string %}
+        The variable '{{ item }}' is not a String.
+      {% else %}
+        The variable '{{ item }}' is empty.
+      {% endif %}
+  loop:
+    - sap_vm_provision_ibmcloud_powervs_workspace_name
+    - sap_vm_provision_ibmcloud_powervs_vlan_subnet_name
+    - sap_vm_provision_ibmcloud_powervs_key_pair_name_ssh_host_public_key
+    - sap_vm_provision_ibmcloud_private_dns_instance_name
+    - sap_vm_provision_ibmcloud_private_dns_custom_resolver_ip
+    - sap_vm_provision_ibmcloud_placement_resource_name
+  when:
+    - sap_vm_provision_iac_type == 'ansible'
+
+
+- name: Assert that boolean variables are valid for {{ sap_vm_provision_iac_platform }}
+  ansible.builtin.assert:
+    that:
+      - lookup('ansible.builtin.vars', __sap_vm_provision_loop_bool_var, default='SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED') != 'SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED'
+      - lookup('ansible.builtin.vars', __sap_vm_provision_loop_bool_var) is boolean
+      - lookup('ansible.builtin.vars', __sap_vm_provision_loop_bool_var) | trim | length > 0
+    fail_msg: |
+      {% if lookup('ansible.builtin.vars', item, default='SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED') == 'SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED' %}
+        The variable '{{ __sap_vm_provision_loop_bool_var }}' is undefined.
+      {% elif lookup('ansible.builtin.vars', item) is not boolean %}
+        The variable '{{ __sap_vm_provision_loop_bool_var }}' is not a Boolean.
+      {% else %}
+        The variable '{{ __sap_vm_provision_loop_bool_var }}' is empty.
+      {% endif %}
+  loop:
+    - sap_vm_provision_ibmcloud_placement_strategy_spread
+  vars:
+    __sap_vm_provision_loop_bool_var: "{{ item }}"
+
+
+- name: Block to validate host_specifications_dictionary
+  vars:
+    __sap_vm_provision_os_image_dictionary_name: "{{ 'sap_vm_provision_' ~ sap_vm_provision_iac_platform ~ '_host_os_image_dictionary' }}"
+    __sap_vm_provision_os_image_name: "{{ 'sap_vm_provision_' ~ sap_vm_provision_iac_platform ~ '_host_os_image' }}"
+  no_log: true
+  block:
+    - name: Assert that the variable {{ __sap_vm_provision_os_image_dictionary_name }} is defined and valid
+      ansible.builtin.assert:
+        that:
+          - lookup('ansible.builtin.vars', __sap_vm_provision_os_image_dictionary_name) is defined
+          - lookup('ansible.builtin.vars', __sap_vm_provision_os_image_dictionary_name) is mapping
+          - lookup('ansible.builtin.vars', __sap_vm_provision_os_image_dictionary_name) | length > 0
+        fail_msg: |
+          The variable {{ __sap_vm_provision_os_image_dictionary_name }} is undefined or invalid.
+          It must be a non-empty dictionary.
+
+    - name: Assert that the value of variable {{ __sap_vm_provision_os_image_name }} is present in a dictionary
+      ansible.builtin.assert:
+        that:
+          - lookup('ansible.builtin.vars', __sap_vm_provision_os_image_dictionary_name)[__sap_vm_provision_os_image_name] is defined
+          - lookup('ansible.builtin.vars', __sap_vm_provision_os_image_dictionary_name)[__sap_vm_provision_os_image_name] | length > 0
+        fail_msg: |
+          The value of variable {{ __sap_vm_provision_os_image_name }} is not present in a dictionary {{ __sap_vm_provision_os_image_dictionary_name }}.

--- a/roles/sap_vm_provision/tasks/validations/ibmcloud_vs.yml
+++ b/roles/sap_vm_provision/tasks/validations/ibmcloud_vs.yml
@@ -1,0 +1,93 @@
+---
+#### Validate required variables for specific 'sap_vm_provision_iac_platform ####
+
+- name: Assert that string variables are valid for {{ sap_vm_provision_iac_platform }}
+  ansible.builtin.assert:
+    that:
+      - lookup('ansible.builtin.vars', item, default='SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED') != 'SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED'
+      - lookup('ansible.builtin.vars', item) is string
+      - lookup('ansible.builtin.vars', item) | trim | length > 0
+    fail_msg: |
+      {% if lookup('ansible.builtin.vars', item, default='SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED') == 'SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED' %}
+        The variable '{{ item }}' is undefined.
+      {% elif lookup('ansible.builtin.vars', item) is not string %}
+        The variable '{{ item }}' is not a String.
+      {% else %}
+        The variable '{{ item }}' is empty.
+      {% endif %}
+  loop:
+    - sap_vm_provision_ibmcloud_api_key
+    - sap_vm_provision_ibmcloud_resource_group_name
+    - sap_vm_provision_ibmcloud_region
+    - sap_vm_provision_ibmcloud_availability_zone
+    - sap_vm_provision_ibmcloud_private_dns_instance_name
+    - sap_vm_provision_ibmcloud_vpc_name
+    - sap_vm_provision_ibmcloud_vpc_subnet_name
+    - sap_vm_provision_ibmcloud_placement_resource_name
+    - sap_vm_provision_ibmcloud_vs_host_os_image
+
+
+- name: Assert that string variables are valid for {{ sap_vm_provision_iac_platform }} using 'ansible'
+  ansible.builtin.assert:
+    that:
+      - lookup('ansible.builtin.vars', item, default='SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED') != 'SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED'
+      - lookup('ansible.builtin.vars', item) is string
+      - lookup('ansible.builtin.vars', item) | trim | length > 0
+    fail_msg: |
+      {% if lookup('ansible.builtin.vars', item, default='SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED') == 'SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED' %}
+        The variable '{{ item }}' is undefined.
+      {% elif lookup('ansible.builtin.vars', item) is not string %}
+        The variable '{{ item }}' is not a String.
+      {% else %}
+        The variable '{{ item }}' is empty.
+      {% endif %}
+  loop:
+    - sap_vm_provision_ibmcloud_vpc_sg_names
+    - sap_vm_provision_ibmcloud_key_pair_name_ssh_host_public_key
+  when:
+    - sap_vm_provision_iac_type == 'ansible'
+
+
+- name: Assert that boolean variables are valid for {{ sap_vm_provision_iac_platform }}
+  ansible.builtin.assert:
+    that:
+      - lookup('ansible.builtin.vars', __sap_vm_provision_loop_bool_var, default='SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED') != 'SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED'
+      - lookup('ansible.builtin.vars', __sap_vm_provision_loop_bool_var) is boolean
+      - lookup('ansible.builtin.vars', __sap_vm_provision_loop_bool_var) | trim | length > 0
+    fail_msg: |
+      {% if lookup('ansible.builtin.vars', item, default='SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED') == 'SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED' %}
+        The variable '{{ __sap_vm_provision_loop_bool_var }}' is undefined.
+      {% elif lookup('ansible.builtin.vars', item) is not boolean %}
+        The variable '{{ __sap_vm_provision_loop_bool_var }}' is not a Boolean.
+      {% else %}
+        The variable '{{ __sap_vm_provision_loop_bool_var }}' is empty.
+      {% endif %}
+  loop:
+    - sap_vm_provision_ibmcloud_placement_strategy_spread
+  vars:
+    __sap_vm_provision_loop_bool_var: "{{ item }}"
+
+
+- name: Block to validate host_specifications_dictionary
+  vars:
+    __sap_vm_provision_os_image_dictionary_name: "{{ 'sap_vm_provision_' ~ sap_vm_provision_iac_platform ~ '_host_os_image_dictionary' }}"
+    __sap_vm_provision_os_image_name: "{{ 'sap_vm_provision_' ~ sap_vm_provision_iac_platform ~ '_host_os_image' }}"
+  no_log: true
+  block:
+    - name: Assert that the variable {{ __sap_vm_provision_os_image_dictionary_name }} is defined and valid
+      ansible.builtin.assert:
+        that:
+          - lookup('ansible.builtin.vars', __sap_vm_provision_os_image_dictionary_name) is defined
+          - lookup('ansible.builtin.vars', __sap_vm_provision_os_image_dictionary_name) is mapping
+          - lookup('ansible.builtin.vars', __sap_vm_provision_os_image_dictionary_name) | length > 0
+        fail_msg: |
+          The variable {{ __sap_vm_provision_os_image_dictionary_name }} is undefined or invalid.
+          It must be a non-empty dictionary.
+
+    - name: Assert that the value of variable {{ __sap_vm_provision_os_image_name }} is present in a dictionary
+      ansible.builtin.assert:
+        that:
+          - lookup('ansible.builtin.vars', __sap_vm_provision_os_image_dictionary_name)[__sap_vm_provision_os_image_name] is defined
+          - lookup('ansible.builtin.vars', __sap_vm_provision_os_image_dictionary_name)[__sap_vm_provision_os_image_name] | length > 0
+        fail_msg: |
+          The value of variable {{ __sap_vm_provision_os_image_name }} is not present in a dictionary {{ __sap_vm_provision_os_image_dictionary_name }}.

--- a/roles/sap_vm_provision/tasks/validations/ibmcloud_vs.yml
+++ b/roles/sap_vm_provision/tasks/validations/ibmcloud_vs.yml
@@ -72,7 +72,6 @@
   vars:
     __sap_vm_provision_os_image_dictionary_name: "{{ 'sap_vm_provision_' ~ sap_vm_provision_iac_platform ~ '_host_os_image_dictionary' }}"
     __sap_vm_provision_os_image_name: "{{ 'sap_vm_provision_' ~ sap_vm_provision_iac_platform ~ '_host_os_image' }}"
-  no_log: true
   block:
     - name: Assert that the variable {{ __sap_vm_provision_os_image_dictionary_name }} is defined and valid
       ansible.builtin.assert:

--- a/roles/sap_vm_provision/tasks/validations/ibmpowervm_vm.yml
+++ b/roles/sap_vm_provision/tasks/validations/ibmpowervm_vm.yml
@@ -1,0 +1,70 @@
+---
+#### Validate required variables for specific 'sap_vm_provision_iac_platform ####
+
+- name: Assert that string variables are valid for {{ sap_vm_provision_iac_platform }}
+  ansible.builtin.assert:
+    that:
+      - lookup('ansible.builtin.vars', item, default='SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED') != 'SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED'
+      - lookup('ansible.builtin.vars', item) is string
+      - lookup('ansible.builtin.vars', item) | trim | length > 0
+    fail_msg: |
+      {% if lookup('ansible.builtin.vars', item, default='SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED') == 'SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED' %}
+        The variable '{{ item }}' is undefined.
+      {% elif lookup('ansible.builtin.vars', item) is not string %}
+        The variable '{{ item }}' is not a String.
+      {% else %}
+        The variable '{{ item }}' is empty.
+      {% endif %}
+  loop:
+    - sap_vm_provision_ibmpowervm_vc_auth_endpoint
+    - sap_vm_provision_ibmpowervm_vc_user
+    - sap_vm_provision_ibmpowervm_vc_user_password
+    - sap_vm_provision_ibmpowervm_vc_project_name
+    - sap_vm_provision_ibmpowervm_host_group_name
+    - sap_vm_provision_ibmpowervm_host_group_shared_procesor_pool_name
+    - sap_vm_provision_ibmpowervm_network_name
+    - sap_vm_provision_ibmpowervm_network_vnic_type
+    - sap_vm_provision_ibmpowervm_storage_template_name
+    - sap_vm_provision_ibmpowervm_placement_resource_name
+    - sap_vm_provision_ibmpowervm_vm_host_os_image
+
+
+- name: Assert that string variables are valid for {{ sap_vm_provision_iac_platform }} using 'ansible'
+  ansible.builtin.assert:
+    that:
+      - lookup('ansible.builtin.vars', item, default='SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED') != 'SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED'
+      - lookup('ansible.builtin.vars', item) is string
+      - lookup('ansible.builtin.vars', item) | trim | length > 0
+    fail_msg: |
+      {% if lookup('ansible.builtin.vars', item, default='SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED') == 'SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED' %}
+        The variable '{{ item }}' is undefined.
+      {% elif lookup('ansible.builtin.vars', item) is not string %}
+        The variable '{{ item }}' is not a String.
+      {% else %}
+        The variable '{{ item }}' is empty.
+      {% endif %}
+  loop:
+    - sap_vm_provision_ibmpowervm_key_pair_name_ssh_host_public_key
+    - sap_vm_provision_ssh_host_public_key_file_path
+  when:
+    - sap_vm_provision_iac_type == 'ansible'
+
+
+- name: Assert that boolean variables are valid for {{ sap_vm_provision_iac_platform }}
+  ansible.builtin.assert:
+    that:
+      - lookup('ansible.builtin.vars', __sap_vm_provision_loop_bool_var, default='SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED') != 'SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED'
+      - lookup('ansible.builtin.vars', __sap_vm_provision_loop_bool_var) is boolean
+      - lookup('ansible.builtin.vars', __sap_vm_provision_loop_bool_var) | trim | length > 0
+    fail_msg: |
+      {% if lookup('ansible.builtin.vars', item, default='SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED') == 'SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED' %}
+        The variable '{{ __sap_vm_provision_loop_bool_var }}' is undefined.
+      {% elif lookup('ansible.builtin.vars', item) is not boolean %}
+        The variable '{{ __sap_vm_provision_loop_bool_var }}' is not a Boolean.
+      {% else %}
+        The variable '{{ __sap_vm_provision_loop_bool_var }}' is empty.
+      {% endif %}
+  loop:
+    - sap_vm_provision_ibmpowervm_placement_strategy_spread
+  vars:
+    __sap_vm_provision_loop_bool_var: "{{ item }}"

--- a/roles/sap_vm_provision/tasks/validations/msazure_vm.yml
+++ b/roles/sap_vm_provision/tasks/validations/msazure_vm.yml
@@ -73,7 +73,6 @@
   vars:
     __sap_vm_provision_os_image_dictionary_name: "{{ 'sap_vm_provision_' ~ sap_vm_provision_iac_platform ~ '_host_os_image_dictionary' }}"
     __sap_vm_provision_os_image_name: "{{ 'sap_vm_provision_' ~ sap_vm_provision_iac_platform ~ '_host_os_image' }}"
-  no_log: true
   block:
     - name: Assert that the variable {{ __sap_vm_provision_os_image_dictionary_name }} is defined and valid
       ansible.builtin.assert:

--- a/roles/sap_vm_provision/tasks/validations/msazure_vm.yml
+++ b/roles/sap_vm_provision/tasks/validations/msazure_vm.yml
@@ -1,0 +1,94 @@
+---
+#### Validate required variables for specific 'sap_vm_provision_iac_platform ####
+
+- name: Assert that string variables are valid for {{ sap_vm_provision_iac_platform }}
+  ansible.builtin.assert:
+    that:
+      - lookup('ansible.builtin.vars', item, default='SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED') != 'SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED'
+      - lookup('ansible.builtin.vars', item) is string
+      - lookup('ansible.builtin.vars', item) | trim | length > 0
+    fail_msg: |
+      {% if lookup('ansible.builtin.vars', item, default='SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED') == 'SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED' %}
+        The variable '{{ item }}' is undefined.
+      {% elif lookup('ansible.builtin.vars', item) is not string %}
+        The variable '{{ item }}' is not a String.
+      {% else %}
+        The variable '{{ item }}' is empty.
+      {% endif %}
+  loop:
+    - sap_vm_provision_msazure_subscription_id
+    - sap_vm_provision_msazure_tenant_id
+    - sap_vm_provision_msazure_app_client_id
+    - sap_vm_provision_msazure_app_client_secret
+    - sap_vm_provision_msazure_resource_group_name
+    - sap_vm_provision_msazure_location_region
+    - sap_vm_provision_msazure_vnet_name
+    - sap_vm_provision_msazure_vnet_subnet_name
+    - sap_vm_provision_msazure_vm_host_os_image
+
+
+- name: Assert that string variables are valid for {{ sap_vm_provision_iac_platform }} using 'ansible'
+  ansible.builtin.assert:
+    that:
+      - lookup('ansible.builtin.vars', item, default='SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED') != 'SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED'
+      - lookup('ansible.builtin.vars', item) is string
+      - lookup('ansible.builtin.vars', item) | trim | length > 0
+    fail_msg: |
+      {% if lookup('ansible.builtin.vars', item, default='SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED') == 'SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED' %}
+        The variable '{{ item }}' is undefined.
+      {% elif lookup('ansible.builtin.vars', item) is not string %}
+        The variable '{{ item }}' is not a String.
+      {% else %}
+        The variable '{{ item }}' is empty.
+      {% endif %}
+  loop:
+    - sap_vm_provision_msazure_key_pair_name_ssh_host_public_key
+    - sap_vm_provision_msazure_placement_resource_name
+    - sap_vm_provision_msazure_ha_iam_role
+  when:
+    - sap_vm_provision_iac_type == 'ansible'
+
+
+- name: Assert that boolean variables are valid for {{ sap_vm_provision_iac_platform }}
+  ansible.builtin.assert:
+    that:
+      - lookup('ansible.builtin.vars', __sap_vm_provision_loop_bool_var, default='SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED') != 'SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED'
+      - lookup('ansible.builtin.vars', __sap_vm_provision_loop_bool_var) is boolean
+      - lookup('ansible.builtin.vars', __sap_vm_provision_loop_bool_var) | trim | length > 0
+    fail_msg: |
+      {% if lookup('ansible.builtin.vars', item, default='SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED') == 'SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED' %}
+        The variable '{{ __sap_vm_provision_loop_bool_var }}' is undefined.
+      {% elif lookup('ansible.builtin.vars', item) is not boolean %}
+        The variable '{{ __sap_vm_provision_loop_bool_var }}' is not a Boolean.
+      {% else %}
+        The variable '{{ __sap_vm_provision_loop_bool_var }}' is empty.
+      {% endif %}
+  loop:
+    - sap_vm_provision_msazure_placement_strategy_spread
+  vars:
+    __sap_vm_provision_loop_bool_var: "{{ item }}"
+
+
+- name: Block to validate host_specifications_dictionary
+  vars:
+    __sap_vm_provision_os_image_dictionary_name: "{{ 'sap_vm_provision_' ~ sap_vm_provision_iac_platform ~ '_host_os_image_dictionary' }}"
+    __sap_vm_provision_os_image_name: "{{ 'sap_vm_provision_' ~ sap_vm_provision_iac_platform ~ '_host_os_image' }}"
+  no_log: true
+  block:
+    - name: Assert that the variable {{ __sap_vm_provision_os_image_dictionary_name }} is defined and valid
+      ansible.builtin.assert:
+        that:
+          - lookup('ansible.builtin.vars', __sap_vm_provision_os_image_dictionary_name) is defined
+          - lookup('ansible.builtin.vars', __sap_vm_provision_os_image_dictionary_name) is mapping
+          - lookup('ansible.builtin.vars', __sap_vm_provision_os_image_dictionary_name) | length > 0
+        fail_msg: |
+          The variable {{ __sap_vm_provision_os_image_dictionary_name }} is undefined or invalid.
+          It must be a non-empty dictionary.
+
+    - name: Assert that the value of variable {{ __sap_vm_provision_os_image_name }} is present in a dictionary
+      ansible.builtin.assert:
+        that:
+          - lookup('ansible.builtin.vars', __sap_vm_provision_os_image_dictionary_name)[__sap_vm_provision_os_image_name] is defined
+          - lookup('ansible.builtin.vars', __sap_vm_provision_os_image_dictionary_name)[__sap_vm_provision_os_image_name] | length > 0
+        fail_msg: |
+          The value of variable {{ __sap_vm_provision_os_image_name }} is not present in a dictionary {{ __sap_vm_provision_os_image_dictionary_name }}.

--- a/roles/sap_vm_provision/tasks/validations/platform_ansible.yml
+++ b/roles/sap_vm_provision/tasks/validations/platform_ansible.yml
@@ -1,0 +1,19 @@
+---
+#### Validate required variables for specific 'sap_vm_provision_iac_type ####
+
+- name: Assert that string variables are valid for {{ sap_vm_provision_iac_type }}
+  ansible.builtin.assert:
+    that:
+      - lookup('ansible.builtin.vars', item, default='SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED') != 'SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED'
+      - lookup('ansible.builtin.vars', item) is string
+      - lookup('ansible.builtin.vars', item) | trim | length > 0
+    fail_msg: |
+      {% if lookup('ansible.builtin.vars', item, default='SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED') == 'SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED' %}
+        The variable '{{ item }}' is undefined.
+      {% elif lookup('ansible.builtin.vars', item) is not string %}
+        The variable '{{ item }}' is not a String.
+      {% else %}
+        The variable '{{ item }}' is empty.
+      {% endif %}
+  loop:
+    - sap_vm_provision_ssh_host_private_key_file_path

--- a/roles/sap_vm_provision/tasks/validations/platform_ansible_to_terraform.yml
+++ b/roles/sap_vm_provision/tasks/validations/platform_ansible_to_terraform.yml
@@ -1,0 +1,20 @@
+---
+#### Validate required variables for specific 'sap_vm_provision_iac_type ####
+
+- name: Assert that string variables are valid for {{ sap_vm_provision_iac_type }}
+  ansible.builtin.assert:
+    that:
+      - lookup('ansible.builtin.vars', item, default='SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED') != 'SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED'
+      - lookup('ansible.builtin.vars', item) is string
+      - lookup('ansible.builtin.vars', item) | trim | length > 0
+    fail_msg: |
+      {% if lookup('ansible.builtin.vars', item, default='SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED') == 'SAP_VM_PROVISION_UNDEFINED_VARIABLE_DETECTED' %}
+        The variable '{{ item }}' is undefined.
+      {% elif lookup('ansible.builtin.vars', item) is not string %}
+        The variable '{{ item }}' is not a String.
+      {% else %}
+        The variable '{{ item }}' is empty.
+      {% endif %}
+  loop:
+    - sap_vm_provision_terraform_work_dir_path
+    - sap_vm_provision_terraform_state


### PR DESCRIPTION
## Changes
- Add dedicated tasks for validation of variable for each supported combination.
  - Validate if variable is defined, correct type and not empty
  - Separation of validation for extra variables that are required only for `ansible`.
- Add validation for variables that are used as keys in dictionaries. (Solves https://github.com/sap-linuxlab/community.sap_infrastructure/issues/79)

## Tested
Tested on AWS using `ansible-core 2.18 and 2.19`