### PR TITLE
sap_vm_provision: Update SLES images and add SLES 15 SP7

### DIFF
--- a/roles/sap_vm_provision/defaults/main.yml
+++ b/roles/sap_vm_provision/defaults/main.yml
@@ -319,8 +319,8 @@ sap_vm_provision_ibmpowervm_vm_host_os_image: ""
 
 # OS Images - AWS AMI
 sap_vm_provision_aws_ec2_vs_host_os_image_dictionary:
+  # Red Hat
   rhel-8-1: "*RHEL-8.1*_HVM*x86_64*"
-  # rhel-8-2: "*RHEL-8.2*_HVM*x86_64*" # removed
   rhel-8-4: "*RHEL-8.4*_HVM*x86_64*"
   rhel-8-6: "*RHEL-8.6*_HVM*x86_64*"
   rhel-8-8: "*RHEL-8.8*_HVM*x86_64*"
@@ -330,14 +330,6 @@ sap_vm_provision_aws_ec2_vs_host_os_image_dictionary:
   rhel-9-2: "*RHEL-9.2*_HVM*x86_64*"
   rhel-9-3: "*RHEL-9.3*_HVM*x86_64*"
   rhel-9-4: "*RHEL-9.4*_HVM*x86_64*"
-  sles-12-5: "*suse-sles-12-sp5-v202*-hvm-ssd-x86_64*"
-  # sles-15-2: "*suse-sles-15-sp2-v202*-hvm-ssd-x86_64*" # removed
-  # sles-15-3: "*suse-sles-15-sp3-v202*-hvm-ssd-x86_64*" # removed
-  # sles-15-4: "*suse-sles-15-sp4-v202*-hvm-ssd-x86_64*" # removed
-  sles-15-5: "*suse-sles-15-sp5-v202*-hvm-ssd-x86_64*"
-  sles-15-6: "*suse-sles-15-sp6-v202*-hvm-ssd-x86_64*"
-  # rhel-7-7-sap-ha: "*RHEL-SAP-8.1.0*" # removed
-  # rhel-7-9-sap-ha: "*RHEL-SAP-8.1.0*" # removed
   rhel-8-1-sap-ha: "*RHEL-SAP-8.1.0*"
   rhel-8-2-sap-ha: "*RHEL-SAP-8.2.0*"
   rhel-8-4-sap-ha: "*RHEL-SAP-8.4.0*"
@@ -347,40 +339,36 @@ sap_vm_provision_aws_ec2_vs_host_os_image_dictionary:
   rhel-9-0-sap-ha: "*RHEL-SAP-9.0.0*"
   rhel-9-2-sap-ha: "*RHEL-SAP-9.2.0*"
   rhel-9-4-sap-ha: "*RHEL-SAP-9.4.0*"
-  sles-12-5-sap-ha: "*suse-sles-sap-12-sp5-v202*-hvm-ssd-x86_64*"
-  sles-15-1-sap-ha: "*suse-sles-sap-15-sp1-v202*-hvm-ssd-x86_64*"
-  sles-15-2-sap-ha: "*suse-sles-sap-15-sp2-v202*-hvm-ssd-x86_64*"
-  sles-15-3-sap-ha: "*suse-sles-sap-15-sp3-v202*-hvm-ssd-x86_64*"
-  sles-15-4-sap-ha: "*suse-sles-sap-15-sp4-v202*-hvm-ssd-x86_64*"
+
+  # SUSE - Pay-as-you-go (PAYG)
+  sles-15-5: "*suse-sles-15-sp5-v202*-hvm-ssd-x86_64*"
   sles-15-5-sap-ha: "*suse-sles-sap-15-sp5-v202*-hvm-ssd-x86_64*"
+  sles-15-6: "*suse-sles-15-sp6-v202*-hvm-ssd-x86_64*"
   sles-15-6-sap-ha: "*suse-sles-sap-15-sp6-v202*-hvm-ssd-x86_64*"
-  sles-15-4-sap-ha-byos: "*suse-sles-sap-15-sp4-byos-v202*-hvm-ssd-x86_64*"
+  sles-15-7: "*suse-sles-15-sp7-v202*-hvm-ssd-x86_64*"
+  sles-15-7-sap-ha: "*suse-sles-sap-15-sp7-v202*-hvm-ssd-x86_64*"
+
+  # SUSE - Bring-your-own-subscription (BYOS)
+  sles-15-5-byos: "*suse-sles-15-sp5-byos-v202*-hvm-ssd-x86_64*"
   sles-15-5-sap-ha-byos: "*suse-sles-sap-15-sp5-byos-v202*-hvm-ssd-x86_64*"
+  sles-15-6-byos: "*suse-sles-15-sp6-byos-v202*-hvm-ssd-x86_64*"
   sles-15-6-sap-ha-byos: "*suse-sles-sap-15-sp6-byos-v202*-hvm-ssd-x86_64*"
+  sles-15-7-byos: "*suse-sles-15-sp7-byos-v202*-hvm-ssd-x86_64*"
+  sles-15-7-sap-ha-byos: "*suse-sles-sap-15-sp7-byos-v202*-hvm-ssd-x86_64*"
+
 
 # OS Images - Google Cloud
 sap_vm_provision_gcp_ce_vm_host_os_image_dictionary:
+  # Red Hat
   rhel-8-latest:
     project: "rhel-cloud"
     family: "rhel-8"
   rhel-9-latest:
     project: "rhel-cloud"
     family: "rhel-9"
-  sles-12-latest:
-    project: "suse-cloud"
-    family: "sles-12"
-  sles-15-latest:
-    project: "suse-cloud"
-    family: "sles-15"
-  # rhel-7-7-sap-ha: # removed
-  #   project: "rhel-sap-cloud"
-  #   family: "rhel-7-7-sap-ha"
   rhel-7-9-sap-ha:
     project: "rhel-sap-cloud"
     family: "rhel-7-9-sap-ha"
-  # rhel-8-1-sap-ha: # removed
-  #   project: "rhel-sap-cloud"
-  #   family: "rhel-8-1-sap-ha"
   rhel-8-2-sap-ha:
     project: "rhel-sap-cloud"
     family: "rhel-8-2-sap-ha"
@@ -390,48 +378,54 @@ sap_vm_provision_gcp_ce_vm_host_os_image_dictionary:
   rhel-8-6-sap-ha:
     project: "rhel-sap-cloud"
     family: "rhel-8-6-sap-ha"
-  sles-12-5-sap-ha:
-    project: "suse-sap-cloud"
-    family: "sles-12-sp5-sap"
-  # sles-15-1-sap-ha: # removed
-  #   project: "suse-sap-cloud"
-  #   family: "sles-15-sp1-sap"
-  sles-15-2-sap-ha:
-    project: "suse-sap-cloud"
-    family: "sles-15-sp2-sap"
-  sles-15-3-sap-ha:
-    project: "suse-sap-cloud"
-    family: "sles-15-sp3-sap"
-  sles-15-4-sap-ha:
-    project: "suse-sap-cloud"
-    family: "sles-15-sp4-sap"
+
+  # SUSE - Pay-as-you-go (PAYG)
+  sles-15-latest:
+    project: "suse-cloud"
+    family: "sles-15"
+  sles-15-5:
+    project: "suse-cloud"
+    family: "sles-15-sp5"
   sles-15-5-sap-ha:
     project: "suse-sap-cloud"
     family: "sles-15-sp5-sap"
+  sles-15-6:
+    project: "suse-cloud"
+    family: "sles-15-sp6"
   sles-15-6-sap-ha:
     project: "suse-sap-cloud"
     family: "sles-15-sp6-sap"
-  sles-12-5-sap-ha-byos:
+  sles-15-7:
+    project: "suse-cloud"
+    family: "sles-15"
+  sles-15-7-sap-ha:
+    project: "suse-sap-cloud"
+    family: "sles-15-sp7-sap"
+
+  # SUSE - Bring-your-own-subscription (BYOS)
+  sles-15-5-byos:
     project: "suse-byos-cloud"
-    family: "sles-12-sp5-sap-byos"
-  sles-15-2-sap-byos:
-    project: "suse-byos-cloud"
-    family: "sles-15-sp2-sap-byos"
-  sles-15-3-sap-byos:
-    project: "suse-byos-cloud"
-    family: "sles-15-sp3-sap-byos"
-  sles-15-4-sap-byos:
-    project: "suse-byos-cloud"
-    family: "sles-15-sp4-sap-byos"
+    family: "sles-15-sp5-byos"
   sles-15-5-sap-byos:
     project: "suse-byos-cloud"
     family: "sles-15-sp5-sap-byos"
+  sles-15-6-byos:
+    project: "suse-byos-cloud"
+    family: "sles-15-sp6-byos"
   sles-15-6-sap-byos:
     project: "suse-byos-cloud"
     family: "sles-15-sp6-sap-byos"
+  sles-15-7-byos:
+    project: "suse-byos-cloud"
+    family: "sles-15-sp7-byos"
+  sles-15-7-sap-byos:
+    project: "suse-byos-cloud"
+    family: "sles-15-sp7-sap-byos"
+
 
 # OS Images - IBM Cloud
 sap_vm_provision_ibmcloud_vs_host_os_image_dictionary:
+  # Red Hat
   rhel-8-4: ".*redhat.*8-4.*minimal.*amd64.*"
   rhel-8-6: ".*redhat.*8-6.*minimal.*amd64.*"
   rhel-8-8: ".*redhat.*8-8.*minimal.*amd64.*"
@@ -439,12 +433,6 @@ sap_vm_provision_ibmcloud_vs_host_os_image_dictionary:
   rhel-9-0: ".*redhat.*9-0.*minimal.*amd64.*"
   rhel-9-2: ".*redhat.*9-2.*minimal.*amd64.*"
   rhel-9-4: ".*redhat.*9-4.*minimal.*amd64.*"
-  sles-15-5: ".*sles.*15-5.*amd64-[0-9]"
-  sles-15-6: ".*sles.*15-6.*amd64-[0-9]"
-  # rhel-7-6-sap-ha: ".*redhat.*7-6.*amd64.*hana.*" # retrievable from deprecated list
-  # rhel-7-9-sap-ha: ".*redhat.*7-9.*amd64.*hana.*" # retrievable from deprecated list
-  # rhel-8-1-sap-ha: ".*redhat.*8-1.*amd64.*hana.*" # retrievable from deprecated list
-  # rhel-8-2-sap-ha: ".*redhat.*8-2.*amd64.*hana.*" # retrievable from deprecated list
   rhel-8-4-sap-ha: ".*redhat.*8-4.*amd64.*hana.*"
   rhel-8-6-sap-ha: ".*redhat.*8-6.*amd64.*hana.*"
   rhel-8-8-sap-ha: ".*redhat.*8-8.*amd64.*hana.*"
@@ -452,39 +440,46 @@ sap_vm_provision_ibmcloud_vs_host_os_image_dictionary:
   rhel-9-0-sap-ha: ".*redhat.*9-0.*amd64.*hana.*"
   rhel-9-2-sap-ha: ".*redhat.*9-2.*amd64.*hana.*"
   rhel-9-4-sap-ha: ".*redhat.*9-4.*amd64.*hana.*"
-  # sles-12-4-sap-ha: ".*sles.*12-4.*amd64.*hana.*" # retrievable from deprecated list
-  # sles-12-5-sap-ha: ".*sles.*12-5.*amd64.*hana.*" # retrievable from deprecated list
-  # sles-15-1-sap-ha: ".*sles.*15-1.*amd64.*hana.*" # retrievable from deprecated list
-  sles-15-3-sap-ha: ".*sles.*15-3.*amd64.*hana.*"
-  sles-15-4-sap-ha: ".*sles.*15-4.*amd64.*hana.*"
+
+  # SUSE
+  # sles-15-5: ".*sles.*15-5.*amd64-[0-9]"  # EOL
   sles-15-5-sap-ha: ".*sles.*15-5.*amd64.*hana.*"
+  sles-15-6: ".*sles.*15-6.*amd64-[0-9]"
   sles-15-6-sap-ha: ".*sles.*15-6.*amd64.*hana.*"
+  sles-15-7: ".*sles.*15-7.*amd64-[0-9]"
+  # sles-15-7-sap-ha: ".*sles.*15-7.*amd64.*hana.*"  # Not available yet
+
 
 # OS Images - IBM Cloud, IBM Power VS 'Full Linux subscription' with support and activation keys
 sap_vm_provision_ibmcloud_powervs_host_os_image_dictionary:
+  # Red Hat
   rhel-8-8: ".*RHEL.*8.*8"
   rhel-9-2: ".*RHEL.*9.*2"
   rhel-9-4: ".*RHEL.*9.*4"
-  sles-15-5: ".*SLES.*15.*5$"
   rhel-8-4-sap-ha: "RHEL8-SP4-SAP"
   rhel-8-6-sap-ha: ".*RHEL.*8.*6.*SAP$" # ensure string suffix using $
   rhel-8-8-sap-ha: ".*RHEL.*8.*8.*SAP$" # ensure string suffix using $
   rhel-9-2-sap-ha: ".*RHEL.*9.*2.*SAP$" # ensure string suffix using $
-  sles-15-2-sap-ha: ".*SLES.*15.*2.*SAP$" # ensure string suffix using $
-  sles-15-3-sap-ha: ".*SLES.*15.*3.*SAP$" # ensure string suffix using $
-  sles-15-4-sap-ha: ".*SLES.*15.*4.*SAP$" # ensure string suffix using $
-  sles-15-5-sap-ha: "SLES15-SP5-SAP"
   # rhel-8-4-sap-ha-byol: "RHEL8-SP4-SAP-BYOL"
   # rhel-8-6-sap-ha-byol: ".*RHEL.*8.*6.*SAP-BYOL$" # ensure string suffix using $
   # rhel-8-8-sap-ha-byol: ".*RHEL.*8.*8.*SAP-BYOL$" # ensure string suffix using $
   # rhel-9-2-sap-ha-byol: ".*RHEL.*9.*2.*SAP-BYOL$" # ensure string suffix using $
-  # sles-15-2-sap-ha-byol: ".*SLES.*15.*2.*SAP-BYOL$" # ensure string suffix using $
-  # sles-15-3-sap-ha-byol: ".*SLES.*15.*3.*SAP-BYOL$" # ensure string suffix using $
-  # sles-15-4-sap-ha-byol: ".*SLES.*15.*4.*SAP-BYOL$" # ensure string suffix using $
+
+  # SUSE
+  sles-15-5: ".*SLES.*15.*5$"
+  sles-15-5-sap-ha: "SLES15-SP5-SAP"
+  sles-15-6: ".*SLES.*15.*6$"
+  sles-15-6-sap-ha: "SLES15-SP6-SAP"
+  sles-15-7: ".*SLES.*15.*7$"
+  sles-15-7-sap-ha: "SLES15-SP7-SAP"
   # sles-15-5-sap-ha-byol: "SLES15-SP5-SAP-BYOL"
+  # sles-15-6-sap-ha-byol: "SLES15-SP6-SAP-BYOL"
+  # sles-15-7-sap-ha-byol: "SLES15-SP7-SAP-BYOL"
+
 
 # OS Images - MS Azure
 sap_vm_provision_msazure_vm_host_os_image_dictionary:
+  # Red Hat
   rhel-8-0:
     publisher: "RedHat"
     offer: "RHEL"
@@ -549,34 +544,6 @@ sap_vm_provision_msazure_vm_host_os_image_dictionary:
     publisher: "RedHat"
     offer: "RHEL"
     sku: "94-gen2"
-  sles-12-5:
-    publisher: "SUSE"
-    offer: "sles-12-sp5"
-    sku: "gen2"
-  sles-15-1:
-    publisher: "SUSE"
-    offer: "sles-15-sp1"
-    sku: "gen2"
-  sles-15-2:
-    publisher: "SUSE"
-    offer: "sles-15-sp2"
-    sku: "gen2"
-  sles-15-3:
-    publisher: "SUSE"
-    offer: "sles-15-sp3"
-    sku: "gen2"
-  sles-15-4:
-    publisher: "SUSE"
-    offer: "sles-15-sp4"
-    sku: "gen2"
-  sles-15-5:
-    publisher: "SUSE"
-    offer: "sles-15-sp5"
-    sku: "gen2"
-  sles-15-6:
-    publisher: "SUSE"
-    offer: "sles-15-sp6"
-    sku: "gen2"
   rhel-8-1-sap-ha:
     publisher: "RedHat"
     offer: "RHEL-SAP-HA"
@@ -613,57 +580,57 @@ sap_vm_provision_msazure_vm_host_os_image_dictionary:
     publisher: "RedHat"
     offer: "RHEL-SAP-HA"
     sku: "94sapha-gen2"
-  sles-12-5-sap-ha:
+
+  # SUSE - Pay-as-you-go (PAYG)
+  sles-15-5:
     publisher: "SUSE"
-    offer: "sles-sap-12-sp5"
-    sku: "gen2"
-  sles-15-1-sap-ha:
-    publisher: "SUSE"
-    offer: "sles-sap-15-sp1"
-    sku: "gen2"
-  sles-15-2-sap-ha:
-    publisher: "SUSE"
-    offer: "sles-sap-15-sp2"
-    sku: "gen2"
-  sles-15-3-sap-ha:
-    publisher: "SUSE"
-    offer: "sles-sap-15-sp3"
-    sku: "gen2"
-  sles-15-4-sap-ha:
-    publisher: "SUSE"
-    offer: "sles-sap-15-sp4"
+    offer: "sles-15-sp5"
     sku: "gen2"
   sles-15-5-sap-ha:
     publisher: "SUSE"
     offer: "sles-sap-15-sp5"
     sku: "gen2"
+  sles-15-6:
+    publisher: "SUSE"
+    offer: "sles-15-sp6"
+    sku: "gen2"
   sles-15-6-sap-ha:
     publisher: "SUSE"
     offer: "sles-sap-15-sp6"
     sku: "gen2"
-  sles-15-1-sap-byos:
+  sles-15-7:
     publisher: "SUSE"
-    offer: "sles-sap-15-sp1-byos"
+    offer: "sles-15-sp7"
     sku: "gen2"
-  sles-15-2-sap-byos:
+  sles-15-7-sap-ha:
     publisher: "SUSE"
-    offer: "sles-sap-15-sp2-byos"
+    offer: "sles-sap-15-sp7"
     sku: "gen2"
-  sles-15-3-sap-byos:
+
+  # SUSE - Bring-your-own-subscription (BYOS)
+  sles-15-5-byos:
     publisher: "SUSE"
-    offer: "sles-sap-15-sp3-byos"
-    sku: "gen2"
-  sles-15-4-sap-byos:
-    publisher: "SUSE"
-    offer: "sles-sap-15-sp4-byos"
+    offer: "sles-15-sp5-byos"
     sku: "gen2"
   sles-15-5-sap-byos:
     publisher: "SUSE"
     offer: "sles-sap-15-sp5-byos"
     sku: "gen2"
+  sles-15-6-byos:
+    publisher: "SUSE"
+    offer: "sles-15-sp6-byos"
+    sku: "gen2"
   sles-15-6-sap-byos:
     publisher: "SUSE"
     offer: "sles-sap-15-sp6-byos"
+    sku: "gen2"
+  sles-15-7-byos:
+    publisher: "SUSE"
+    offer: "sles-15-sp7-byos"
+    sku: "gen2"
+  sles-15-7-sap-byos:
+    publisher: "SUSE"
+    offer: "sles-sap-15-sp7-byos"
     sku: "gen2"
 
 


### PR DESCRIPTION
## Changes
- Cleanup unsupported SLES images from dictionaries
- Add SP7 images
- Reorganize items to their own categories based on OS Family.

## Tests
Image names were validated in AWS, AZ, GCP and IBM Cloud VS (Power images were not available to search).