### PR TITLE
Add ansible.posix in requirements

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -39,3 +39,6 @@ collections:
   - name: community.okd
     type: galaxy
     version: 3.0.1
+  - name: ansible.posix
+    type: galaxy
+    version: '>=1.5.4,<=2.1.0' # check galaxy for the best supported version


### PR DESCRIPTION
- Used by sap_vm_provision

This is used in roles/sap_vm_provision/tasks/platform_ansible/msazure_vm/execute_main.yml
range bracket is set to get support from all ansible versions starting 2.9 onwards.