### PR TITLE
sap_hypervisor_node_preconfigure: Update until conditional for ansible-core 2.19

### DIFF
--- a/roles/sap_hypervisor_node_preconfigure/tasks/platform/redhat_ocp_virt/operators/install-cnv-operator.yml
+++ b/roles/sap_hypervisor_node_preconfigure/tasks/platform/redhat_ocp_virt/operators/install-cnv-operator.yml
@@ -103,7 +103,7 @@
   register: webhook_service
   retries: 2
   delay: 60
-  until: webhook_service.resources
+  until: webhook_service.resources | default([]) | length > 0
 
 - name: Create CNV HyperConverged
   kubernetes.core.k8s:

--- a/roles/sap_hypervisor_node_preconfigure/tasks/platform/redhat_ocp_virt/operators/install-nmstate-operator.yml
+++ b/roles/sap_hypervisor_node_preconfigure/tasks/platform/redhat_ocp_virt/operators/install-nmstate-operator.yml
@@ -39,7 +39,7 @@
   register: operatorgroup_status
   retries: 30
   delay: 10
-  until: operatorgroup_status.resources | length > 0
+  until: operatorgroup_status.resources | default([]) | length > 0
 
 - name: Subscribe to the nmstate Operator
   kubernetes.core.k8s:
@@ -98,7 +98,7 @@
   register: nmstate_status
   retries: 30
   delay: 10
-  until: nmstate_status.resources | length > 0
+  until: nmstate_status.resources | default([]) | length > 0
 
 - name: Wait and check for pod with label name nmstate-webhook under the namespace "{{ sap_hypervisor_node_preconfigure_nmstate_namespace }}"
   kubernetes.core.k8s_info:

--- a/roles/sap_hypervisor_node_preconfigure/tasks/platform/redhat_ocp_virt/operators/install-sriov-operator.yml
+++ b/roles/sap_hypervisor_node_preconfigure/tasks/platform/redhat_ocp_virt/operators/install-sriov-operator.yml
@@ -68,7 +68,7 @@
   register: operatorgroup_status
   retries: 30
   delay: 10
-  until: operatorgroup_status.resources
+  until: operatorgroup_status.resources | default([]) | length > 0
 
 - name: Check if SriovOperatorConfig exists  # noqa: ignore-errors
   kubernetes.core.k8s_info:


### PR DESCRIPTION
## Changes
Made the until checks in the operator install tasks to use length comparisons so that it works consistent with all ansible versions. 

## Tested
These changes are tested with 2.19 and worked as expected 


