### PR TITLE
collection: Add linting rule to ignore stricter var naming rule in 2.20

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -44,3 +44,5 @@ skip_list:
   - yaml[line-length]
   - no-tabs
   # - var-naming[no-jinja]
+  # Rule for variable naming is required because of stricter linting requirements.
+  - var-naming[no-role-prefix]


### PR DESCRIPTION
## Changes
- Add `var-naming[no-role-prefix]` to linting rules, because `sap_vm_provision` uses facts and variables without role prefix.

```bash
var-naming[no-role-prefix]: Variables names from within roles should use sap_vm_provision_ as a prefix. (register: register_etc_hosts_file_scaleout)
roles/sap_vm_provision/tasks/platform_ansible_to_terraform/vmware_vm/execute_main.yml:172:17 Task/Handler: Set /etc/hosts for Scale-Out

var-naming[no-role-prefix]: Variables names from within roles should use sap_vm_provision_ as a prefix. (register: register_ansible_vars_storage)
roles/sap_vm_provision/tasks/platform_ansible_to_terraform/vmware_vm/execute_main.yml:184:17 Task/Handler: Set vars for sap_storage_setup Ansible Role

Read documentation for instructions on how to ignore specific rule violations.

# Rule Violation Summary

277 var-naming profile:basic tags:idiom

Failed: 277 failure(s), 0 warning(s) in 119 files processed of 163 encountered.
```

## Tests
Linting was tested in github workflow: https://github.com/marcelmamula/community.sap_infrastructure/actions/runs/19666870345

```bash
Passed: 0 failure(s), 0 warning(s) in 119 files processed of 163 encountered. Last profile that met the validation criteria was 'production'.
```