### PR TITLE
sap_hypervisor_node_preconfigure/kubevirt_vm: Fix installation of CNV operator

### DIFF
--- a/roles/sap_hypervisor_node_preconfigure/tasks/platform/redhat_ocp_virt/operators/install-cnv-operator.yml
+++ b/roles/sap_hypervisor_node_preconfigure/tasks/platform/redhat_ocp_virt/operators/install-cnv-operator.yml
@@ -95,20 +95,10 @@
   delay: 60
   until: __sap_hypervisor_node_preconfigure_register_hco_webhook_pod.resources | selectattr('status.phase', 'equalto', 'Running') | list | length == __sap_hypervisor_node_preconfigure_register_hco_webhook_pod.resources | length
 
-- name: Wait and check if hco-webhook-service exists in the namespace "{{ sap_hypervisor_node_preconfigure_ocpv_namespace }}"
-  kubernetes.core.k8s_info:
-    kind: Service
-    namespace: "{{ sap_hypervisor_node_preconfigure_ocpv_namespace }}"
-    name: hco-webhook-service
-  register: webhook_service
-  retries: 2
-  delay: 60
-  until: webhook_service.resources | default([]) | length > 0
-
-- name: Check if CNV webhook endpoint is available
+- name: Check if hco-webhook-service webhook endpoint is available
   ansible.builtin.include_tasks: wait_for_webhook_endpoints.yml
   vars:
-    sap_hypervisor_node_preconfigure_webhook_service_name: virt-api
+    sap_hypervisor_node_preconfigure_webhook_service_name: hco-webhook-service
     sap_hypervisor_node_preconfigure_webhook_namespace: "{{ sap_hypervisor_node_preconfigure_ocpv_namespace }}"
 
 - name: Create CNV HyperConverged


### PR DESCRIPTION
~~Changed order of CNV HyperConverged instance creation and changed webhook endpoint name waiting.~~

This fixes [issue 146](https://github.com/sap-linuxlab/community.sap_infrastructure/issues/146) by adding more conditionals that have to be `true` when waiting for webhook endpoint in order to continue.
