### PR TITLE
sap_vm_provision: Add SLES 16 images, fix sshd_config and add python311 workaround

### DIFF
--- a/roles/sap_vm_provision/defaults/main.yml
+++ b/roles/sap_vm_provision/defaults/main.yml
@@ -347,6 +347,8 @@ sap_vm_provision_aws_ec2_vs_host_os_image_dictionary:
   sles-15-6-sap-ha: "*suse-sles-sap-15-sp6-v202*-hvm-ssd-x86_64*"
   sles-15-7: "*suse-sles-15-sp7-v202*-hvm-ssd-x86_64*"
   sles-15-7-sap-ha: "*suse-sles-sap-15-sp7-v202*-hvm-ssd-x86_64*"
+  sles-16-0: "*suse-sles-16-0-v202*-hvm-ssd-x86_64*"
+  sles-16-0-sap-ha: "*suse-sles-sap-16-0-v202*-hvm-ssd-x86_64*"
 
   # SUSE - Bring-your-own-subscription (BYOS)
   sles-15-5-byos: "*suse-sles-15-sp5-byos-v202*-hvm-ssd-x86_64*"
@@ -355,6 +357,8 @@ sap_vm_provision_aws_ec2_vs_host_os_image_dictionary:
   sles-15-6-sap-ha-byos: "*suse-sles-sap-15-sp6-byos-v202*-hvm-ssd-x86_64*"
   sles-15-7-byos: "*suse-sles-15-sp7-byos-v202*-hvm-ssd-x86_64*"
   sles-15-7-sap-ha-byos: "*suse-sles-sap-15-sp7-byos-v202*-hvm-ssd-x86_64*"
+  sles-16-0-byos: "*suse-sles-16-0-byos-v202*-hvm-ssd-x86_64*"
+  sles-16-0-sap-ha-byos: "*suse-sles-sap-16-0-byos-v202*-hvm-ssd-x86_64*"
 
 
 # OS Images - Google Cloud
@@ -401,6 +405,12 @@ sap_vm_provision_gcp_ce_vm_host_os_image_dictionary:
   sles-15-7-sap-ha:
     project: "suse-sap-cloud"
     family: "sles-15-sp7-sap"
+  sles-16-0:
+    project: "suse-cloud"
+    family: "sles-16-0-x86-64"
+  sles-16-0-sap-ha:
+    project: "suse-sap-cloud"
+    family: "sles-sap-16-0-x86-64"
 
   # SUSE - Bring-your-own-subscription (BYOS)
   sles-15-5-byos:
@@ -421,6 +431,12 @@ sap_vm_provision_gcp_ce_vm_host_os_image_dictionary:
   sles-15-7-sap-byos:
     project: "suse-byos-cloud"
     family: "sles-15-sp7-sap-byos"
+  sles-16-0-byos:
+    project: "suse-byos-cloud"
+    family: "sles-16-0-byos-x86-64"
+  sles-16-0-sap-byos:
+    project: "suse-byos-cloud"
+    family: "sles-sap-16-0-byos-x86-64"
 
 
 # OS Images - IBM Cloud
@@ -606,6 +622,14 @@ sap_vm_provision_msazure_vm_host_os_image_dictionary:
     publisher: "SUSE"
     offer: "sles-sap-15-sp7"
     sku: "gen2"
+  sles-16-0:
+    publisher: "SUSE"
+    offer: "sles-16-0-x86-64"
+    sku: "gen2"
+  sles-16-0-sap-ha:
+    publisher: "SUSE"
+    offer: "sles-sap-16-0-x86-64"
+    sku: "gen2"
 
   # SUSE - Bring-your-own-subscription (BYOS)
   sles-15-5-byos:
@@ -631,6 +655,14 @@ sap_vm_provision_msazure_vm_host_os_image_dictionary:
   sles-15-7-sap-byos:
     publisher: "SUSE"
     offer: "sles-sap-15-sp7-byos"
+    sku: "gen2"
+  sles-16-0-byos:
+    publisher: "SUSE"
+    offer: "sles-16-0-byos-x86-64"
+    sku: "gen2"
+  sles-16-0-sap-byos:
+    publisher: "SUSE"
+    offer: "sles-sap-16-0-byos-x86-64"
     sku: "gen2"
 
 

--- a/roles/sap_vm_provision/tasks/platform_ansible/aws_ec2_vs/execute_provision.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/aws_ec2_vs/execute_provision.yml
@@ -210,7 +210,7 @@
         replace: 'ssh-'
 
     # We cannot obtain these facts from delegate without registering them first.
-    # NOTE: Ansible 2.20 deprecation warning for ansible_ facts does not seem to apply here.
+    # NOTE: Ansible 2.20 deprecation warning for ansible_facts does not seem to apply here.
     - name: Get OS distribution facts on delegate host
       ansible.builtin.setup:
         gather_subset:

--- a/roles/sap_vm_provision/tasks/platform_ansible/aws_ec2_vs/execute_provision.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/aws_ec2_vs/execute_provision.yml
@@ -209,12 +209,29 @@
         regexp: '(^.*command.* ssh-)'
         replace: 'ssh-'
 
+    # We cannot obtain these facts from delegate without registering them first.
+    # NOTE: Ansible 2.20 deprecation warning for ansible_ facts does not seem to apply here.
+    - name: Get OS distribution facts on delegate host
+      ansible.builtin.setup:
+        gather_subset:
+          - 'distribution_major_version'
+          - 'os_family'
+      register: __sap_vm_provision_register_delegate_facts
+
     - name: Permit root login
       register: __sap_vm_provision_task_os_sshd_config
       ansible.builtin.replace:
-        path: /etc/ssh/sshd_config
+        path: "{{ __ssh_config }}"
         regexp: '(^PermitRootLogin no)'
         replace: 'PermitRootLogin yes'
+      vars:
+        # With SLES 16, the sshd_config file is located in /usr/etc/ssh/sshd_config.
+        # TODO: Move this conditional to vars/main.yml during refactoring of the role.
+        __ssh_config: >-
+          {{ '/usr/etc/ssh/sshd_config'
+             if __sap_vm_provision_register_delegate_facts.ansible_facts['ansible_os_family'] == 'Suse' and
+              (__sap_vm_provision_register_delegate_facts.ansible_facts['ansible_distribution_major_version'] | int) >= 16
+             else '/etc/ssh/sshd_config' }}
 
     - name: Reload sshd service
       ansible.builtin.service:

--- a/roles/sap_vm_provision/tasks/platform_ansible/gcp_ce_vm/execute_provision.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/gcp_ce_vm/execute_provision.yml
@@ -168,6 +168,26 @@
     - sap_vm_provision_ssh_bastion_private_key_file_path is defined or not sap_vm_provision_ssh_bastion_private_key_file_path == ''
 
 
+- name: Wait for SSH port on provisioned host to become available
+  # This task runs a native ssh command from the execution host to check for connectivity before proceeding.
+  # It uses a retry loop and conditionally adds a ProxyCommand for bastion scenarios.
+  # Other modules and solutions are not suitable for this purpose, because:
+  # - 'wait_for' does not support ProxyCommand.
+  # - 'wait_for_connection' requires Python on the target, which may not be installed yet.
+  ansible.builtin.command: >
+    ssh
+    {{ delegate_ssh_args_bastion if delegate_ssh_args_bastion is defined else '' }}
+    -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
+    -i {{ sap_vm_provision_ssh_host_private_key_file_path }}
+    admin@{{ provisioned_private_ip }} "exit"
+  vars:
+    delegate_ssh_args_bastion: -o ProxyCommand='ssh -W %h:%p {{ sap_vm_provision_bastion_user }}@{{ sap_vm_provision_bastion_public_ip }} -p {{ sap_vm_provision_bastion_ssh_port }} -i {{ sap_vm_provision_ssh_bastion_private_key_file_path }} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
+  register: __sap_vm_provision_register_ssh_port_check
+  until: __sap_vm_provision_register_ssh_port_check.rc == 0
+  retries: 30
+  delay: 10
+  changed_when: false
+
 ### begin block, parameters will be applied to each task within the block
 - name: Allow login from root OS User
   remote_user: admin
@@ -204,6 +224,9 @@
     - name: Install required Python 3.11 on SLES 15 SP5-SP7 host
       ansible.builtin.raw: "zypper -n install python311"
       register: __sap_vm_provision_register_sles15_python311_install
+      # Retry loop in case package manager is locked after provisioning.
+      retries: 30
+      delay: 10
       changed_when:
         - __sap_vm_provision_register_sles15_python311_install.rc == 0
         - "'nothing to do' not in __sap_vm_provision_register_sles15_python311_install.stdout"
@@ -230,7 +253,7 @@
           {{ lookup('ansible.builtin.file', sap_vm_provision_ssh_host_public_key_file_path ) }}
 
     # We cannot obtain these facts from delegate without registering them first.
-    # NOTE: Ansible 2.20 deprecation warning for ansible_ facts does not seem to apply here.
+    # NOTE: Ansible 2.20 deprecation warning for ansible_facts does not seem to apply here.
     - name: Get OS distribution facts on delegate host
       ansible.builtin.setup:
         gather_subset:

--- a/roles/sap_vm_provision/tasks/platform_ansible/gcp_ce_vm/execute_provision.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/gcp_ce_vm/execute_provision.yml
@@ -180,6 +180,36 @@
     ansible_ssh_common_args: -o ConnectTimeout=180 -o ControlMaster=auto -o ControlPersist=3600s -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ForwardX11=no {{ delegate_ssh_args_bastion if delegate_ssh_args_bastion is defined else '' }}
   block:
 
+    # SUSE Specific workaround to install Python 3.11 on SLES 15 images that do not have it pre-installed.
+    # This is required for Ansible modules to work. Using raw module as python is not yet available.
+    # PAYG images do not have it pre-installed, BYOS images do have it pre-installed.
+    - name: Check if provisioned host is SLES 15 SP5-SP7 without Python 3.11 installed
+      ansible.builtin.raw: >-
+        grep -q 'ID="sles"' /etc/os-release &&
+        grep -qE 'VERSION_ID="15\.[5-7]"' /etc/os-release &&
+        ! rpm -q python311
+      register: __sap_vm_provision_register_sles15_python311_check
+      changed_when: false
+      failed_when: false
+
+    - name: Inform that SLES 15 SP5-SP7 without Python 3.11 installed was detected
+      ansible.builtin.debug:
+        msg: |
+          INFO: Provisioned host is SLES 15 SP5-7 without Python 3.11 installed.
+          Some Google Cloud images do not have Python 3.11 pre-installed which is required for Ansible modules to work.
+          Proceeding to install Python 3.11...
+      when:
+        - __sap_vm_provision_register_sles15_python311_check.rc == 0
+
+    - name: Install required Python 3.11 on SLES 15 SP5-SP7 host
+      ansible.builtin.raw: "zypper -n install python311"
+      register: __sap_vm_provision_register_sles15_python311_install
+      changed_when:
+        - __sap_vm_provision_register_sles15_python311_install.rc == 0
+        - "'nothing to do' not in __sap_vm_provision_register_sles15_python311_install.stdout"
+      when:
+        - __sap_vm_provision_register_sles15_python311_check.rc == 0
+
     # Required as state: present on Ansible Module gcp_compute_instance does not allow for waiting until VM has booted
     # wait_for_connection is used instead to ensure connection is available before proceeding.
     - name: Wait until SSH connection is available
@@ -199,12 +229,29 @@
         content: |
           {{ lookup('ansible.builtin.file', sap_vm_provision_ssh_host_public_key_file_path ) }}
 
+    # We cannot obtain these facts from delegate without registering them first.
+    # NOTE: Ansible 2.20 deprecation warning for ansible_ facts does not seem to apply here.
+    - name: Get OS distribution facts on delegate host
+      ansible.builtin.setup:
+        gather_subset:
+          - 'distribution_major_version'
+          - 'os_family'
+      register: __sap_vm_provision_register_delegate_facts
+
     - name: Permit root login
       register: __sap_vm_provision_task_os_sshd_config
       ansible.builtin.replace:
-        path: /etc/ssh/sshd_config
+        path: "{{ __ssh_config }}"
         regexp: '(^PermitRootLogin no)'
         replace: 'PermitRootLogin yes'
+      vars:
+        # With SLES 16, the sshd_config file is located in /usr/etc/ssh/sshd_config.
+        # TODO: Move this conditional to vars/main.yml during refactoring of the role.
+        __ssh_config: >-
+          {{ '/usr/etc/ssh/sshd_config'
+             if __sap_vm_provision_register_delegate_facts.ansible_facts['ansible_os_family'] == 'Suse' and
+              (__sap_vm_provision_register_delegate_facts.ansible_facts['ansible_distribution_major_version'] | int) >= 16
+             else '/etc/ssh/sshd_config' }}
 
     - name: Reload sshd service
       ansible.builtin.service:

--- a/roles/sap_vm_provision/tasks/platform_ansible/ibmcloud_powervs/execute_provision.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/ibmcloud_powervs/execute_provision.yml
@@ -236,7 +236,7 @@
           {{ __sap_vm_provision_task_ibmcloud_pi_ssh_public_key.resource.ssh_key }}
 
     # We cannot obtain these facts from delegate without registering them first.
-    # NOTE: Ansible 2.20 deprecation warning for ansible_ facts does not seem to apply here.
+    # NOTE: Ansible 2.20 deprecation warning for ansible_facts does not seem to apply here.
     - name: Get OS distribution facts on delegate host
       ansible.builtin.setup:
         gather_subset:

--- a/roles/sap_vm_provision/tasks/platform_ansible/ibmcloud_powervs/execute_provision.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/ibmcloud_powervs/execute_provision.yml
@@ -235,12 +235,29 @@
         content: |
           {{ __sap_vm_provision_task_ibmcloud_pi_ssh_public_key.resource.ssh_key }}
 
+    # We cannot obtain these facts from delegate without registering them first.
+    # NOTE: Ansible 2.20 deprecation warning for ansible_ facts does not seem to apply here.
+    - name: Get OS distribution facts on delegate host
+      ansible.builtin.setup:
+        gather_subset:
+          - 'distribution_major_version'
+          - 'os_family'
+      register: __sap_vm_provision_register_delegate_facts
+
     - name: Permit root login
       register: __sap_vm_provision_task_os_sshd_config
       ansible.builtin.replace:
-        path: /etc/ssh/sshd_config
+        path: "{{ __ssh_config }}"
         regexp: '(^PermitRootLogin no)'
         replace: 'PermitRootLogin yes'
+      vars:
+        # With SLES 16, the sshd_config file is located in /usr/etc/ssh/sshd_config.
+        # TODO: Move this conditional to vars/main.yml during refactoring of the role.
+        __ssh_config: >-
+          {{ '/usr/etc/ssh/sshd_config'
+             if __sap_vm_provision_register_delegate_facts.ansible_facts['ansible_os_family'] == 'Suse' and
+              (__sap_vm_provision_register_delegate_facts.ansible_facts['ansible_distribution_major_version'] | int) >= 16
+             else '/etc/ssh/sshd_config' }}
 
     - name: Reload sshd service
       ansible.builtin.service:

--- a/roles/sap_vm_provision/tasks/platform_ansible/ibmcloud_vs/execute_provision.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/ibmcloud_vs/execute_provision.yml
@@ -208,12 +208,29 @@
         content: |
           {{ __sap_vm_provision_task_ibmcloud_ssh_public_key.resource.public_key }}
 
+    # We cannot obtain these facts from delegate without registering them first.
+    # NOTE: Ansible 2.20 deprecation warning for ansible_ facts does not seem to apply here.
+    - name: Get OS distribution facts on delegate host
+      ansible.builtin.setup:
+        gather_subset:
+          - 'distribution_major_version'
+          - 'os_family'
+      register: __sap_vm_provision_register_delegate_facts
+
     - name: Permit root login
       register: __sap_vm_provision_task_os_sshd_config
       ansible.builtin.replace:
-        path: /etc/ssh/sshd_config
+        path: "{{ __ssh_config }}"
         regexp: '(^PermitRootLogin no)'
         replace: 'PermitRootLogin yes'
+      vars:
+        # With SLES 16, the sshd_config file is located in /usr/etc/ssh/sshd_config.
+        # TODO: Move this conditional to vars/main.yml during refactoring of the role.
+        __ssh_config: >-
+          {{ '/usr/etc/ssh/sshd_config'
+             if __sap_vm_provision_register_delegate_facts.ansible_facts['ansible_os_family'] == 'Suse' and
+              (__sap_vm_provision_register_delegate_facts.ansible_facts['ansible_distribution_major_version'] | int) >= 16
+             else '/etc/ssh/sshd_config' }}
 
     - name: Reload sshd service
       ansible.builtin.service:

--- a/roles/sap_vm_provision/tasks/platform_ansible/ibmcloud_vs/execute_provision.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/ibmcloud_vs/execute_provision.yml
@@ -209,7 +209,7 @@
           {{ __sap_vm_provision_task_ibmcloud_ssh_public_key.resource.public_key }}
 
     # We cannot obtain these facts from delegate without registering them first.
-    # NOTE: Ansible 2.20 deprecation warning for ansible_ facts does not seem to apply here.
+    # NOTE: Ansible 2.20 deprecation warning for ansible_facts does not seem to apply here.
     - name: Get OS distribution facts on delegate host
       ansible.builtin.setup:
         gather_subset:

--- a/roles/sap_vm_provision/tasks/platform_ansible/msazure_vm/execute_provision.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/msazure_vm/execute_provision.yml
@@ -295,7 +295,7 @@
         replace: 'ssh-'
 
     # We cannot obtain these facts from delegate without registering them first.
-    # NOTE: Ansible 2.20 deprecation warning for ansible_ facts does not seem to apply here.
+    # NOTE: Ansible 2.20 deprecation warning for ansible_facts does not seem to apply here.
     - name: Get OS distribution facts on delegate host
       ansible.builtin.setup:
         gather_subset:

--- a/roles/sap_vm_provision/tasks/platform_ansible/msazure_vm/execute_provision.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/msazure_vm/execute_provision.yml
@@ -294,12 +294,29 @@
         regexp: '(^.*ssh-)' # Allow ssh-rsa , ssh-ed25519 etc.
         replace: 'ssh-'
 
+    # We cannot obtain these facts from delegate without registering them first.
+    # NOTE: Ansible 2.20 deprecation warning for ansible_ facts does not seem to apply here.
+    - name: Get OS distribution facts on delegate host
+      ansible.builtin.setup:
+        gather_subset:
+          - 'distribution_major_version'
+          - 'os_family'
+      register: __sap_vm_provision_register_delegate_facts
+
     - name: Permit root login
       register: __sap_vm_provision_task_os_sshd_config
       ansible.builtin.replace:
-        path: /etc/ssh/sshd_config
+        path: "{{ __ssh_config }}"
         regexp: '(^PermitRootLogin no)'
         replace: 'PermitRootLogin yes'
+      vars:
+        # With SLES 16, the sshd_config file is located in /usr/etc/ssh/sshd_config.
+        # TODO: Move this conditional to vars/main.yml during refactoring of the role.
+        __ssh_config: >-
+          {{ '/usr/etc/ssh/sshd_config'
+             if __sap_vm_provision_register_delegate_facts.ansible_facts['ansible_os_family'] == 'Suse' and
+              (__sap_vm_provision_register_delegate_facts.ansible_facts['ansible_distribution_major_version'] | int) >= 16
+             else '/etc/ssh/sshd_config' }}
 
     - name: Reload sshd service
       ansible.builtin.service:


### PR DESCRIPTION
## Changes

- Add SLES 16 images that were recently published in Clouds providers
- Add conditional for SLES 16 to load correct `/usr/etc/ssh/sshd_config` instead of `/etc/ssh/sshd_config`
- Add fix for missing `python311` for SLES 15 GCP images https://github.com/sap-linuxlab/community.sap_infrastructure/issues/117

## Tests
This change was tested on AWS, GCP and AZ for SLES_SAP 15 SP7 and SLES_SAP 16.0 images.