### PR TITLE
sap_vm_provision: Update ibmcloud PowerVS image dictionaries

### DIFF
--- a/roles/sap_vm_provision/defaults/main.yml
+++ b/roles/sap_vm_provision/defaults/main.yml
@@ -469,13 +469,14 @@ sap_vm_provision_ibmcloud_vs_host_os_image_dictionary:
 # OS Images - IBM Cloud, IBM Power VS 'Full Linux subscription' with support and activation keys
 sap_vm_provision_ibmcloud_powervs_host_os_image_dictionary:
   # Red Hat
-  rhel-8-8: ".*RHEL.*8.*8"
-  rhel-9-2: ".*RHEL.*9.*2"
+  rhel-8-10: ".*RHEL.*8.*10"
   rhel-9-4: ".*RHEL.*9.*4"
-  rhel-8-4-sap-ha: "RHEL8-SP4-SAP"
   rhel-8-6-sap-ha: ".*RHEL.*8.*6.*SAP$" # ensure string suffix using $
   rhel-8-8-sap-ha: ".*RHEL.*8.*8.*SAP$" # ensure string suffix using $
+  rhel-8-10-sap-ha: ".*RHEL.*8.*10.*SAP$" # ensure string suffix using $
   rhel-9-2-sap-ha: ".*RHEL.*9.*2.*SAP$" # ensure string suffix using $
+  rhel-9-4-sap-ha: ".*RHEL.*9.*4.*SAP$" # ensure string suffix using $
+  rhel-9-6-sap-ha: ".*RHEL.*9.*6.*SAP$" # ensure string suffix using $
   # rhel-8-4-sap-ha-byol: "RHEL8-SP4-SAP-BYOL"
   # rhel-8-6-sap-ha-byol: ".*RHEL.*8.*6.*SAP-BYOL$" # ensure string suffix using $
   # rhel-8-8-sap-ha-byol: ".*RHEL.*8.*8.*SAP-BYOL$" # ensure string suffix using $


### PR DESCRIPTION
Update according to the OS images available in the IBM Power Virtual Server image catalog (January 2026).