### PR TITLE
sap_vm_temp_vip: Fix NoneType broadcast variable

### DIFF
--- a/roles/sap_vm_temp_vip/tasks/get_temp_vip_details.yml
+++ b/roles/sap_vm_temp_vip/tasks/get_temp_vip_details.yml
@@ -84,6 +84,8 @@
   when:
     - sap_vm_temp_vip_default_broadcast == ''
     - __sap_vm_temp_vip_get_ips.stdout is defined and __sap_vm_temp_vip_get_ips.stdout | length > 0
+    # regex_search is 'NoneType' when string is not found, therefore we have to skip it.
+    - __sap_vm_temp_vip_brd is not none
   changed_when: false
 
 # Combine final broadcast IP based on decision below:


### PR DESCRIPTION
## Changes
- Added missing conditional to sanitize detected broadcast if regex does not find expected string.
  Previous check attempted length templating directly on `NoneType`, resulting in failure.