### PR TITLE
sap_vm_temp_vip: Refactor variables and improve logic for skipping hosts

### DIFF
--- a/roles/sap_vm_temp_vip/README.md
+++ b/roles/sap_vm_temp_vip/README.md
@@ -8,6 +8,7 @@
 The Ansible role `sap_vm_temp_vip` is used to enable installation of SAP Application and Database on High Availability clusters provisioned by [sap_vm_provision](https://github.com/sap-linuxlab/community.sap_infrastructure/tree/main/roles/sap_vm_provision) role.
 
 Installation of cluster environment requires temporary assignment of Virtual IP (VIP) before executing installation roles [sap_hana_install](https://github.com/sap-linuxlab/community.sap_install/tree/main/roles/sap_hana_install) and [sap_swpm](https://github.com/sap-linuxlab/community.sap_install/tree/main/roles/sap_swpm).
+
 - This is temporary and it will be replaced by Cluster VIP resource once cluster is configured by [sap_ha_pacemaker_cluster](https://github.com/sap-linuxlab/community.sap_install/tree/main/roles/sap_ha_pacemaker_cluster) role.
 
 This role does not update `/etc/hosts` or DNS records, as these steps are performed by the [sap_vm_provision](https://github.com/sap-linuxlab/community.sap_infrastructure/tree/main/roles/sap_vm_provision) role.
@@ -25,6 +26,7 @@ This role does not update `/etc/hosts` or DNS records, as these steps are perfor
 ## Prerequisites
 <!-- BEGIN Prerequisites -->
 Environment:
+
 - Assign hosts to correct groups, which are also used in other roles in our project
   - Supported cluster groups: `hana_primary, hana_secondary, anydb_primary, anydb_secondary, nwas_ascs, nwas_ers`
 <!-- END Prerequisites -->
@@ -35,7 +37,8 @@ Environment:
 
 <!-- BEGIN Execution Recommended -->
 ### Recommended
-It is recommended to execute this role together with other roles in this collection, in the following order:</br>
+It is recommended to execute this role together with other roles in this collection, in the following order:
+
 1. [sap_vm_provision](https://github.com/sap-linuxlab/community.sap_infrastructure/tree/main/roles/sap_vm_provision)
 2. *`sap_vm_temp_vip`*
 <!-- END Execution Recommended -->
@@ -93,59 +96,73 @@ Apache 2.0
 <!-- BEGIN Role Variables -->
 ### sap_vm_temp_vip_default_ip
 - _Type:_ `string`
-- _Default:_ `ansible_default_ipv4.address`
+- _Default:_ `ansible_facts['default_ipv4'].address`
 
 Specifies the IP Address of the default network interface.
 
 ### sap_vm_temp_vip_default_netmask
 - _Type:_ `string`
-- _Default:_ `ansible_default_ipv4.netmask`
+- _Default:_ `ansible_facts['default_ipv4'].netmask`
 
 Specifies the Netmask of the default network interface.
 
 ### sap_vm_temp_vip_default_prefix
 - _Type:_ `string`
-- _Default:_ `ansible_default_ipv4.prefix`
+- _Default:_ `ansible_facts['default_ipv4'].prefix`
 
 Specifies the prefix of the default network interface.
 
 ### sap_vm_temp_vip_default_broadcast
 - _Type:_ `string`
-- _Default:_ `ansible_default_ipv4.broadcast`
+- _Default:_ `ansible_facts['default_ipv4'].broadcast`
 
 Specifies the broadcast of the default network interface.</br>
 This parameter is empty on some cloud platforms and VIP is created without broadcast if attempt to calculate fails.
 
 ### sap_vm_temp_vip_default_interface
 - _Type:_ `string`
-- _Default:_ `ansible_default_ipv4.interface` or `eth0`
+- _Default:_ `ansible_facts['default_ipv4'].interface` or `eth0`
 
 Specifies the default network interface name.</br>
 Ensure to use correct network interface if default interface from Ansible Facts does not represent desired network interface.
 
 ### sap_vm_temp_vip_hana_primary
 - _Type:_ `string`
-- _Default:_ `sap_ha_pacemaker_cluster_vip_hana_primary_ip_address`
+- _Default:_ `sap_vm_provision_ha_vip_hana_primary`
 
 This variable is mandatory for SAP HANA cluster setup.</br>
-The VIP address is by default assigned from `sap_ha_pacemaker_cluster_vip_hana_primary_ip_address` input parameter used by Ansible Role [sap_ha_pacemaker_cluster](https://github.com/sap-linuxlab/community.sap_install/tree/main/roles/sap_ha_pacemaker_cluster).
+The VIP address is by default assigned from the variables:
+
+- `sap_vm_provision_ha_vip_hana_primary` from Ansible Role `sap_infrastructure.sap_vm_provision`.
+- `sap_ha_pacemaker_cluster_vip_hana_primary_ip_address` from Ansible Role `sap_install.sap_ha_pacemaker_cluster`.
 
 ### sap_vm_temp_vip_nwas_abap_ascs
 - _Type:_ `string`
-- _Default:_ `sap_ha_pacemaker_cluster_vip_nwas_abap_ascs_ip_address`
+- _Default:_ `sap_vm_provision_ha_vip_nwas_abap_ascs`
 
 This variable is mandatory for SAP ASCS/ERS cluster setup.</br>
-The VIP address is by default assigned from `sap_ha_pacemaker_cluster_vip_nwas_abap_ascs_ip_address` input parameter used by Ansible Role [sap_ha_pacemaker_cluster](https://github.com/sap-linuxlab/community.sap_install/tree/main/roles/sap_ha_pacemaker_cluster).
+The VIP address is by default assigned from the variables:
+
+- `sap_vm_provision_ha_vip_nwas_abap_ascs` from Ansible Role `sap_infrastructure.sap_vm_provision`.
+- `sap_ha_pacemaker_cluster_vip_nwas_abap_ascs_ip_address` from Ansible Role `sap_install.sap_ha_pacemaker_cluster`.
 
 ### sap_vm_temp_vip_nwas_abap_ers
 - _Type:_ `string`
-- _Default:_ `sap_ha_pacemaker_cluster_vip_nwas_abap_ers_ip_address`
+- _Default:_ `sap_vm_provision_ha_vip_nwas_abap_ers`
 
 This variable is mandatory for SAP ASCS/ERS cluster setup.</br>
-The VIP address is by default assigned from `sap_ha_pacemaker_cluster_vip_hana_primary_ip_address` input parameter used by Ansible Role [sap_ha_pacemaker_cluster](https://github.com/sap-linuxlab/community.sap_install/tree/main/roles/sap_ha_pacemaker_cluster).
+The VIP address is by default assigned from the variables:
+
+- `sap_vm_provision_ha_vip_nwas_abap_ers` from Ansible Role `sap_infrastructure.sap_vm_provision`.
+- `sap_ha_pacemaker_cluster_vip_nwas_abap_ers_ip_address` from Ansible Role `sap_install.sap_ha_pacemaker_cluster`.
 
 ### sap_vm_temp_vip_anydb_primary
 - _Type:_ `string`
+- _Default:_ `sap_vm_provision_ha_vip_anydb_primary`
 
-This variable is mandatory for SAP AnyDB cluster setup.
+This variable is mandatory for SAP AnyDB cluster setup.</br>
+The VIP address is by default assigned from the variable:
+
+- `sap_vm_provision_ha_vip_anydb_primary` from Ansible Role `sap_infrastructure.sap_vm_provision`.
+
 <!-- END Role Variables -->

--- a/roles/sap_vm_temp_vip/defaults/main.yml
+++ b/roles/sap_vm_temp_vip/defaults/main.yml
@@ -1,19 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0
 ---
+
 # General variables that are calculated from Ansible facts
-sap_vm_temp_vip_default_ip: "{{ ansible_default_ipv4.address | default('') }}"
-sap_vm_temp_vip_default_netmask: "{{ ansible_default_ipv4.netmask | default('') }}"
-sap_vm_temp_vip_default_prefix: "{{ ansible_default_ipv4.prefix | default('') }}"
-sap_vm_temp_vip_default_broadcast: "{{ ansible_default_ipv4.broadcast | default('') }}"
-sap_vm_temp_vip_default_interface: "{{ ansible_default_ipv4.interface | default('eth0') }}"
+sap_vm_temp_vip_default_ip: "{{ ansible_facts['default_ipv4'].address | d('') }}"
+sap_vm_temp_vip_default_netmask: "{{ ansible_facts['default_ipv4'].netmask | d('') }}"
+sap_vm_temp_vip_default_prefix: "{{ ansible_facts['default_ipv4'].prefix | d('') }}"
+sap_vm_temp_vip_default_broadcast: "{{ ansible_facts['default_ipv4'].broadcast | d('') }}"
+sap_vm_temp_vip_default_interface: "{{ ansible_facts['default_ipv4'].interface | d('eth0') }}"
 
 
-# SAP specific IPs are defined from sap_install.sap_ha_pacemaker_role input variables
-sap_vm_temp_vip_hana_primary: "{{ sap_ha_pacemaker_cluster_vip_hana_primary_ip_address | default('') }}"
-sap_vm_temp_vip_anydb_primary: ""
-sap_vm_temp_vip_nwas_abap_ascs: "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_ascs_ip_address | default('') }}"
-sap_vm_temp_vip_nwas_abap_ers: "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_ers_ip_address | default('') }}"
-# sap_vm_temp_vip_nwas_abap_pas: "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_pas_ip_address | default('') }}"
-# sap_vm_temp_vip_nwas_abap_aas: "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_aas_ip_address | default('') }}"
+# SAP specific IPs are defined from sap_vm_provision and sap_install.sap_ha_pacemaker_role input variables
+sap_vm_temp_vip_hana_primary:
+  "{{ sap_vm_provision_ha_vip_hana_primary | d(sap_ha_pacemaker_cluster_vip_hana_primary_ip_address) | d('') }}"
+sap_vm_temp_vip_anydb_primary:
+  "{{ sap_vm_provision_ha_vip_anydb_primary | d('') }}"
+sap_vm_temp_vip_nwas_abap_ascs:
+  "{{ sap_vm_provision_ha_vip_nwas_abap_ascs | d(sap_ha_pacemaker_cluster_vip_nwas_abap_ascs_ip_address) | d('') }}"
+sap_vm_temp_vip_nwas_abap_ers:
+  "{{ sap_vm_provision_ha_vip_nwas_abap_ers | d(sap_ha_pacemaker_cluster_vip_nwas_abap_ers_ip_address) | d('') }}"
 
 # Customized group names are used by sap_host_type in host_specifications_dictionary plan during provisioning.
 # Variables are loaded from sap_vm_provision variables first.

--- a/roles/sap_vm_temp_vip/tasks/get_temp_vip_details.yml
+++ b/roles/sap_vm_temp_vip/tasks/get_temp_vip_details.yml
@@ -1,49 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
 ---
+
 # Get details of default ip route to detect default network interface
-- name: Get network interface from ip route show default 0.0.0.0/0
+- name: SAP VM VIP - Get network interface from ip route show default 0.0.0.0/0
   ansible.builtin.shell:
     cmd: set -o pipefail && ip route show default 0.0.0.0/0 | awk '/default/ {print $5}'
-  register: __sap_vm_temp_vip_get_route
+  register: __sap_vm_temp_vip_register_get_route
   changed_when: false
   failed_when: false
 
 # Get content of ip address show filtered by primary IP
-- name: Get contents of ip address show for {{ sap_vm_temp_vip_default_ip }}
+- name: SAP VM VIP - Get contents of ip address show for {{ sap_vm_temp_vip_default_ip }}
   ansible.builtin.shell:
-    cmd: set -o pipefail && ip -oneline address show {{ __sap_vm_temp_vip_get_route.stdout }} | grep {{ sap_vm_temp_vip_default_ip }}
+    cmd: set -o pipefail && ip -oneline address show {{ __sap_vm_temp_vip_register_get_route.stdout }} | grep {{ sap_vm_temp_vip_default_ip }}
   when:
-    - __sap_vm_temp_vip_get_route.stdout is defined  and __sap_vm_temp_vip_get_route.stdout | length > 0
-  register: __sap_vm_temp_vip_get_ips
+    - __sap_vm_temp_vip_register_get_route.stdout is defined
+    - __sap_vm_temp_vip_register_get_route.stdout | length > 0
+  register: __sap_vm_temp_vip_register_get_ips
   changed_when: false
   failed_when: false
 
 # Extract prefix from netmask if it is available
 # Use localhost (execution host) Python3 instead of relying on target host
-- name: Calculate prefix from netmask {{ sap_vm_temp_vip_default_netmask }}
+- name: SAP VM VIP - Calculate prefix from netmask {{ sap_vm_temp_vip_default_netmask | d('') }}
   delegate_to: localhost
   ansible.builtin.command:
     cmd: >
-      python3 -c "import ipaddress; print(ipaddress.IPv4Network('{{ sap_vm_temp_vip_default_ip }}/{{ sap_vm_temp_vip_default_netmask }}', strict=False).prefixlen)"
+      python3 -c "import ipaddress; print(ipaddress.IPv4Network('{{ sap_vm_temp_vip_default_ip }}/{{
+        sap_vm_temp_vip_default_netmask }}', strict=False).prefixlen)"
   when:
-    - sap_vm_temp_vip_default_prefix == ''
-    - sap_vm_temp_vip_default_netmask | length > 0
-  register: __sap_vm_temp_vip_get_prefix_netmask
+    - sap_vm_temp_vip_default_prefix | d('') == ''
+    - sap_vm_temp_vip_default_netmask | d('') | length > 0
+  register: __sap_vm_temp_vip_register_get_prefix_netmask
   changed_when: false
   failed_when: false
 
 # Extract prefix from primary IP on default interface if netmask is not available
 # Stdout result is array instead of string. [0] is used to select only one in case of multiple results.
 # [0] could be replaced by join('') but it would require duplicate record validation.
-- name: Calculate prefix from IP {{ sap_vm_temp_vip_default_ip }} if sap_vm_temp_vip_default_netmask is empty
+- name: SAP VM VIP - Calculate prefix from IP {{ sap_vm_temp_vip_default_ip }} if sap_vm_temp_vip_default_netmask is empty
   ansible.builtin.set_fact:
-    __sap_vm_temp_vip_get_prefix_ip:
+    __sap_vm_temp_vip_fact_get_prefix_ip:
       "{{ __sap_vm_temp_vip_inet[0] if __sap_vm_temp_vip_inet | length > 0 else '' }}"
   vars:
-    __sap_vm_temp_vip_inet: "{{ __sap_vm_temp_vip_get_ips.stdout | regex_search('inet [0-9.]+/([0-9]+)', '\\1') }}"
+    __sap_vm_temp_vip_inet: "{{ __sap_vm_temp_vip_register_get_ips.stdout | regex_search('inet [0-9.]+/([0-9]+)', '\\1') }}"
   when:
-    - sap_vm_temp_vip_default_prefix == ''
-    - sap_vm_temp_vip_default_netmask == ''
-    - __sap_vm_temp_vip_get_ips.stdout is defined and __sap_vm_temp_vip_get_ips.stdout | length > 0
+    - sap_vm_temp_vip_default_prefix | d('') == ''
+    - sap_vm_temp_vip_default_netmask | d('') == ''
+    - __sap_vm_temp_vip_register_get_ips.stdout is defined
+    - __sap_vm_temp_vip_register_get_ips.stdout | length > 0
   changed_when: false
 
 
@@ -52,38 +57,42 @@
 # 2. Else use prefix calculated from netmask if it is available and sap_vm_temp_vip_default_prefix is empty
 # 3. Else use prefix calculated from primary IP if netmask is not available and sap_vm_temp_vip_default_prefix is empty
 # 4. Else use sap_vm_temp_vip_default_prefix (regardless of content) to be used to skip steps.
-- name: Update netmask prefix variable if it was calculated
+- name: SAP VM VIP - Update netmask prefix variable if it was calculated
   ansible.builtin.set_fact:
-    __sap_vm_temp_vip_prefix: >-
+    __sap_vm_temp_vip_fact_prefix: >-
       {%- if __sap_vm_temp_vip_force_static_32 -%}
         32
-      {%- elif sap_vm_temp_vip_default_prefix | length == 0
-       and __sap_vm_temp_vip_get_prefix_netmask.stdout is defined and __sap_vm_temp_vip_get_prefix_netmask.stdout | length > 0 -%}
-        {{ __sap_vm_temp_vip_get_prefix_netmask.stdout }}
-      {%- elif sap_vm_temp_vip_default_prefix | length == 0
-       and __sap_vm_temp_vip_get_prefix_ip is defined and __sap_vm_temp_vip_get_prefix_ip | length > 0 -%}
-        {{ __sap_vm_temp_vip_get_prefix_ip }}
+      {%- elif sap_vm_temp_vip_default_prefix | d('') | length == 0
+       and __sap_vm_temp_vip_register_get_prefix_netmask.stdout is defined and __sap_vm_temp_vip_register_get_prefix_netmask.stdout | length > 0 -%}
+        {{ __sap_vm_temp_vip_register_get_prefix_netmask.stdout }}
+      {%- elif sap_vm_temp_vip_default_prefix | d('') | length == 0
+       and __sap_vm_temp_vip_fact_get_prefix_ip is defined and __sap_vm_temp_vip_fact_get_prefix_ip | length > 0 -%}
+        {{ __sap_vm_temp_vip_fact_get_prefix_ip }}
       {%- else -%}
-        {{ sap_vm_temp_vip_default_prefix }}
+        {{ sap_vm_temp_vip_default_prefix | d('') }}
       {%- endif -%}
   vars:
     __sap_vm_temp_vip_force_static_32:
-      "{{ true if (('amazon' in (ansible_system_vendor | lower) or 'amazon' in (ansible_product_name | lower))
-        or (ansible_product_name == 'Google Compute Engine')) else false }}"
+      "{{ true
+        if ('amazon' in (ansible_facts['system_vendor'] | lower)
+          or 'amazon' in (ansible_facts['product_name'] | lower)
+          or ansible_facts['product_name'] == 'Google Compute Engine')
+        else false }}"
 
 
 # Extract broadcast IP from primary IP if it is present and ansible fact ansible_default_ipv4.broadcast is empty
 # Stdout result is array instead of string. [0] is used to select only one in case of multiple results.
 # [0] could be replaced by join('') but it would require duplicate record validation.
-- name: Calculate broadcast IP from IP {{ sap_vm_temp_vip_default_ip }} if sap_vm_temp_vip_default_broadcast is empty
+- name: SAP VM VIP - Calculate broadcast IP from IP {{ sap_vm_temp_vip_default_ip }} if sap_vm_temp_vip_default_broadcast is empty
   ansible.builtin.set_fact:
-    __sap_vm_temp_vip_get_broadcast_ip:
+    __sap_vm_temp_vip_fact_get_broadcast_ip:
       "{{ (__sap_vm_temp_vip_brd[0] | basename) if __sap_vm_temp_vip_brd | length > 0 else __sap_vm_temp_vip_brd }}"
   vars:
-    __sap_vm_temp_vip_brd: "{{ __sap_vm_temp_vip_get_ips.stdout | regex_search('brd ([0-9.]+)', '\\1') }}"
+    __sap_vm_temp_vip_brd: "{{ __sap_vm_temp_vip_register_get_ips.stdout | regex_search('brd ([0-9.]+)', '\\1') }}"
   when:
-    - sap_vm_temp_vip_default_broadcast == ''
-    - __sap_vm_temp_vip_get_ips.stdout is defined and __sap_vm_temp_vip_get_ips.stdout | length > 0
+    - sap_vm_temp_vip_default_broadcast | d('') == ''
+    - __sap_vm_temp_vip_register_get_ips.stdout is defined
+    - __sap_vm_temp_vip_register_get_ips.stdout | length > 0
     # regex_search is 'NoneType' when string is not found, therefore we have to skip it.
     - __sap_vm_temp_vip_brd is not none
   changed_when: false
@@ -91,12 +100,13 @@
 # Combine final broadcast IP based on decision below:
 # 1. Use calculated broadcast from primary IP if sap_vm_temp_vip_default_broadcast is empty
 # 2. Else use sap_vm_temp_vip_default_broadcast (regardless of content) to be used during VIP creation
-- name: Update broadcast IP variable if it was calculated
+- name: SAP VM VIP - Update broadcast IP variable if it was calculated
   ansible.builtin.set_fact:
-    __sap_vm_temp_vip_broadcast: >-
-      {%- if sap_vm_temp_vip_default_broadcast | length == 0
-        and __sap_vm_temp_vip_get_broadcast_ip is defined and __sap_vm_temp_vip_get_broadcast_ip | length > 0 -%}
-        {{ __sap_vm_temp_vip_get_broadcast_ip }}
+    __sap_vm_temp_vip_fact_broadcast: >-
+      {%- if sap_vm_temp_vip_default_broadcast | d('') | length == 0
+        and __sap_vm_temp_vip_fact_get_broadcast_ip is defined
+        and __sap_vm_temp_vip_fact_get_broadcast_ip | length > 0 -%}
+        {{ __sap_vm_temp_vip_fact_get_broadcast_ip }}
       {%- else -%}
-        {{ sap_vm_temp_vip_default_broadcast }}
+        {{ sap_vm_temp_vip_default_broadcast | d('') }}
       {%- endif -%}

--- a/roles/sap_vm_temp_vip/tasks/identify_network_interface.yml
+++ b/roles/sap_vm_temp_vip/tasks/identify_network_interface.yml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 ---
 
 # RHEL uses NetworkManager as default

--- a/roles/sap_vm_temp_vip/tasks/main.yml
+++ b/roles/sap_vm_temp_vip/tasks/main.yml
@@ -1,44 +1,50 @@
+# SPDX-License-Identifier: Apache-2.0
 ---
-# Ansible role to setup temporary Virtual IP (VIP)
-
-- name: Collect Ansible facts for required subsets - Hardware and Network Interfaces
-  ansible.builtin.setup:
-    gather_subset:
-      - hardware
-      - interfaces
-
-- name: Assert that sap_vm_temp_vip_default_ip is defined
-  ansible.builtin.assert:
-    that: sap_vm_temp_vip_default_ip is defined and sap_vm_temp_vip_default_ip | length > 0
-    fail_msg:
-      - "Unable to get ansible fact ansible_default_ipv4.address or variable sap_vm_temp_vip_default_ip is empty!"
-      - "Ensure that sap_vm_temp_vip_default_ip is not empty."
-
 
 - name: Block to ensure that only supported groups are allowed
   when:
-    - (group_names | intersect([sap_vm_temp_vip_group_hana_primary, sap_vm_temp_vip_group_hana_secondary, sap_vm_temp_vip_group_anydb_primary,
-      sap_vm_temp_vip_group_anydb_secondary, sap_vm_temp_vip_group_nwas_ascs, sap_vm_temp_vip_group_nwas_ers])) | length > 0
+    - (group_names | intersect([
+        sap_vm_temp_vip_group_hana_primary, sap_vm_temp_vip_group_hana_secondary,
+        sap_vm_temp_vip_group_anydb_primary, sap_vm_temp_vip_group_anydb_secondary,
+        sap_vm_temp_vip_group_nwas_ascs, sap_vm_temp_vip_group_nwas_ers])) | length > 0
   block:
 
-    # - name: Identify OS Primary Network Interface
-    #   ansible.builtin.include_tasks: "identify_network_interface.yml"
+    - name: SAP VM VIP - Collect Ansible facts for required subsets - Hardware and Network Interfaces
+      ansible.builtin.setup:
+        gather_subset:
+          - hardware
+          - interfaces
 
-    - name: Attempt to obtain missing network information
-      ansible.builtin.include_tasks: "get_temp_vip_details.yml"
+    - name: SAP VM VIP - Assert and prepare variables
+      ansible.builtin.include_tasks:
+        file: prepare_variables.yml
+
+    - name: Block for hosts with defined VIP
       when:
-        - not ansible_chassis_asset_tag == 'ibmcloud'  # Moved here instead of each task inside of "set_temp_vip.yml"
+        - __sap_vm_temp_vip_fact_address != 'UNSUPPORTED'
+        - __sap_vm_temp_vip_fact_address | trim | length > 0
+      block:
+        # - name: SAP VM VIP - Identify OS Primary Network Interface
+        #   ansible.builtin.include_tasks: "identify_network_interface.yml"
 
+        - name: SAP VM VIP - Attempt to obtain missing network information
+          ansible.builtin.include_tasks:
+            file: get_temp_vip_details.yml
+          # Moved here instead of each task inside of "set_temp_vip.yml"
+          when: not ansible_facts['chassis_asset_tag'] == 'ibmcloud'
 
-    - name: Execute temporary set of a Virtual IP (VIP) prior to Linux Pacemaker ownership
-      ansible.builtin.include_tasks: "set_temp_vip.yml"
-      when:
-        - not ansible_chassis_asset_tag == 'ibmcloud'  # Moved here instead of each task inside of "set_temp_vip.yml"
+        - name: SAP VM VIP - Execute temporary set of a Virtual IP (VIP) prior to Linux Pacemaker ownership
+          ansible.builtin.include_tasks:
+            file: set_temp_vip.yml
+          # Moved here instead of each task inside of "set_temp_vip.yml"
+          when: not ansible_facts['chassis_asset_tag'] == 'ibmcloud'
 
-
-    # Required when using Load Balancers (i.e. Google Cloud, IBM Cloud, MS Azure)
-    - name: Set Health Check Probe Listener for Virtual IP when Load Balancer
-      ansible.builtin.include_tasks: "set_temp_vip_lb_listener.yml"
-      when:
-        - (ansible_product_name == 'Google Compute Engine') or (ansible_chassis_asset_tag == 'ibmcloud')
-          or (ansible_chassis_vendor == 'Microsoft Corporation' and ansible_product_name == 'Virtual Machine')
+        # Required when using Load Balancers (i.e. Google Cloud, IBM Cloud, MS Azure)
+        - name: SAP VM VIP - Set Health Check Probe Listener for Virtual IP when Load Balancer
+          ansible.builtin.include_tasks:
+            file: set_temp_vip_lb_listener.yml
+          when:
+            - ansible_facts['product_name'] == 'Google Compute Engine'
+              or ansible_facts['chassis_asset_tag'] == 'ibmcloud'
+              or (ansible_facts['chassis_vendor'] == 'Microsoft Corporation'
+                and ansible_facts['product_name'] == 'Virtual Machine')

--- a/roles/sap_vm_temp_vip/tasks/prepare_variables.yml
+++ b/roles/sap_vm_temp_vip/tasks/prepare_variables.yml
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: Apache-2.0
+---
+
+# Define VIP address based on target host group which is filtered in main.yml.
+# Else returns 'UNSUPPORTED', because we cannot rely on consistent result.
+# Reason: Ansible 2.16 returns type AnsibleUnsafeText while Ansible 2.20 returns type NoneType.
+- name: SAP VM VIP - Set fact for VIP address depending on target host group
+  ansible.builtin.set_fact:
+    __sap_vm_temp_vip_fact_address: >-
+      {%- if groups[sap_vm_temp_vip_group_hana_secondary] | d([]) | length > 0 and inventory_hostname in groups[sap_vm_temp_vip_group_hana_primary] -%}
+        {{ sap_vm_temp_vip_hana_primary | d('') | regex_replace('/.*', '') }}
+      {%- elif groups[sap_vm_temp_vip_group_anydb_secondary] | d([]) | length > 0 and inventory_hostname in groups[sap_vm_temp_vip_group_anydb_primary] -%}
+        {{ sap_vm_temp_vip_anydb_primary | d('') | regex_replace('/.*', '') }}
+      {%- elif groups[sap_vm_temp_vip_group_nwas_ers] | d([]) | length > 0 and inventory_hostname in groups[sap_vm_temp_vip_group_nwas_ascs] -%}
+        {{ sap_vm_temp_vip_nwas_abap_ascs | d('') | regex_replace('/.*', '') }}
+      {%- elif groups[sap_vm_temp_vip_group_nwas_ers] | d([]) | length > 0 and inventory_hostname in groups[sap_vm_temp_vip_group_nwas_ers] -%}
+        {{ sap_vm_temp_vip_nwas_abap_ers | d('') | regex_replace('/.*', '') }}
+      {%- else -%}UNSUPPORTED{%- endif -%}
+
+# We could do whole reverse acceptance logic to allow execution, but using '__sap_vm_temp_vip_fact_address' is simplest approach:
+# - 'UNSUPPORTED' - Host is not part of any supported groups, so the execution will be skipped.
+# - Empty String - Host is part of supported group, but VIP variable is not defined, so we will trigger fail.
+# - Non-empty String - Host is part of supported group and VIP variable is defined, so we can continue with VIP configuration.
+
+- name: SAP VM VIP - Show information if host is not part of supported groups
+  ansible.builtin.debug:
+    msg: |
+      INFO: The host {{ inventory_hostname }} is not part of any supported groups for temporary VIP configuration, so the execution will be skipped.
+  when: __sap_vm_temp_vip_fact_address == 'UNSUPPORTED'
+
+# Fail is included, because VIP addresses will never be empty unless this role was executed without 'sap_vm_provision' and without role variables.
+- name: SAP VM VIP - Fail if VIP address is not defined
+  ansible.builtin.fail:
+    msg: |
+      FAIL: The host {{ inventory_hostname }} is part of a supported group, but the VIP address variable is not defined or empty.
+      Please ensure that the role 'sap_vm_provision' was executed before this role to set the required variables, or that the VIP variable is defined.
+      {% if groups[sap_vm_temp_vip_group_hana_secondary] | d([]) | length > 0 and inventory_hostname in groups[sap_vm_temp_vip_group_hana_primary] %}
+      - 'sap_vm_temp_vip_hana_primary' for configuring VIP for SAP HANA Primary group
+      {% endif %}
+      {% if groups[sap_vm_temp_vip_group_anydb_secondary] | d([]) | length > 0 and inventory_hostname in groups[sap_vm_temp_vip_group_anydb_primary] %}
+      - 'sap_vm_temp_vip_anydb_primary' for configuring VIP for SAP AnyDB Primary group
+      {% endif %}
+      {% if groups[sap_vm_temp_vip_group_nwas_ers] | d([]) | length > 0 and inventory_hostname in groups[sap_vm_temp_vip_group_nwas_ascs] %}
+      - 'sap_vm_temp_vip_nwas_abap_ascs' for configuring VIP for SAP Netweaver ASCS group
+      {% endif %}
+      {% if groups[sap_vm_temp_vip_group_nwas_ers] | d([]) | length > 0 and inventory_hostname in groups[sap_vm_temp_vip_group_nwas_ers] %}
+      - 'sap_vm_temp_vip_nwas_abap_ers' for configuring VIP for SAP Netweaver ERS group
+      {% endif %}
+  when:
+    - __sap_vm_temp_vip_fact_address | trim | length == 0
+
+
+- name: SAP VM VIP - Assert that sap_vm_temp_vip_default_ip is defined as non-empty string
+  ansible.builtin.assert:
+    that:
+      - sap_vm_temp_vip_default_ip is defined
+      - sap_vm_temp_vip_default_ip is string
+      - sap_vm_temp_vip_default_ip | trim | length > 0
+    fail_msg: |
+      FAIL: The variable sap_vm_temp_vip_default_ip is required to proceed with temporary VIP configuration,
+      but it is not defined, empty or not a string.
+  when: __sap_vm_temp_vip_fact_address != 'UNSUPPORTED'

--- a/roles/sap_vm_temp_vip/tasks/set_temp_vip.yml
+++ b/roles/sap_vm_temp_vip/tasks/set_temp_vip.yml
@@ -1,51 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
 ---
 
 ## Set Virtual IPs
 # for AWS VPC, must be outside of VPC Subnet CIDR Range
 # for MS Azure VNet, must be within the VNet Subnet CIDR Range attached to the Load Balancer
 # for GCP VPC, must be within the VNet Subnet CIDR Range attached to the Load Balancer
-# for IBM Cloud VPC, will automatically be within the VPC Subnet CIDR Range as Load Balancer owns/determines the Virtual IP; must not set VIP on the Host OS Network Interface as a secondary IP
+# for IBM Cloud VPC, will automatically be within the VPC Subnet CIDR Range
+#   as Load Balancer owns/determines the Virtual IP; must not set VIP on the Host OS Network Interface as a secondary IP
 # for IBM Power IaaS VLAN on IBM Cloud, must be within the VLAN Subnet CIDR Range
 # for IBM PowerVM, must be within the VLAN Subnet CIDR Range
 
 ## Set Virtual IP's Netmask / CIDR Prefix
 # Use of Primary IP Address default netmask prefix and/or the broadcast is automatic for Linux Pacemaker
 # For AWS, this would be static Netmask CIDR /32 (see AWS 'Overlay IP' documentation)
-# For GCP, this would be static Netmask CIDR /32, unless using custom OS Image - https://cloud.google.com/vpc/docs/create-use-multiple-interfaces#i_am_having_connectivity_issues_when_using_a_netmask_that_is_not_32
+# For GCP, this would be static Netmask CIDR /32, unless using custom OS Image
+#   https://cloud.google.com/vpc/docs/create-use-multiple-interfaces#i_am_having_connectivity_issues_when_using_a_netmask_that_is_not_32
 # For MS Azure, this would be the VNet Subnet Netmask CIDR e.g. /24
 
 ## Set Virtual IP - Other related information
-# In all cases, use noprefixroute parameter to avoid automatic creation of OS route table entries (i.e. 'ip route'), which occurs if the IP Address is outside of the existing Subnet Range
+# In all cases, use noprefixroute parameter to avoid automatic creation of OS route table entries
+# (i.e. 'ip route'), which occurs if the IP Address is outside of the existing Subnet Range
 
 # TODO: Add rare scenario for PAS/AAS VIP if needed.
 # (groups[sap_vm_temp_vip_group_nwas_pas] is defined and inventory_hostname in groups[sap_vm_temp_vip_group_nwas_pas])
 # and (groups[sap_vm_temp_vip_group_nwas_pas] is defined and (groups[sap_vm_temp_vip_group_nwas_pas]|length>0))
 
 
-# Define VIP address based on target host group which is filtered in main.yml
-# Else ensures that we always return String, not NoneType.
-- name: Set fact for VIP address depending on target host group
-  ansible.builtin.set_fact:
-    __sap_vm_temp_vip_address: >-
-      {% if groups[sap_vm_temp_vip_group_hana_secondary] | d([]) | length > 0 and inventory_hostname in groups[sap_vm_temp_vip_group_hana_primary] -%}
-        {{ sap_vm_temp_vip_hana_primary | regex_replace('/.*', '') }}
-      {%- elif groups[sap_vm_temp_vip_group_anydb_secondary] | d([]) | length > 0 and inventory_hostname in groups[sap_vm_temp_vip_group_anydb_primary] -%}
-        {{ sap_vm_temp_vip_anydb_primary | regex_replace('/.*', '') }}
-      {%- elif groups[sap_vm_temp_vip_group_nwas_ers] | d([]) | length > 0 and inventory_hostname in groups[sap_vm_temp_vip_group_nwas_ascs] -%}
-        {{ sap_vm_temp_vip_nwas_abap_ascs | regex_replace('/.*', '') }}
-      {%- elif groups[sap_vm_temp_vip_group_nwas_ers] | d([]) | length > 0 and inventory_hostname in groups[sap_vm_temp_vip_group_nwas_ers] -%}
-        {{ sap_vm_temp_vip_nwas_abap_ers | regex_replace('/.*', '') }}
-      {%- else -%}
-        {{ '' }}
-      {%- endif %}
-
 # Get content of ip address show filtered by VIP
-- name: Get contents of ip address show for {{ __sap_vm_temp_vip_address }}
+- name: SAP VM VIP - Get contents of ip address show for {{ __sap_vm_temp_vip_fact_address }}
   ansible.builtin.shell:
-    cmd: set -o pipefail && ip -oneline address show | grep {{ __sap_vm_temp_vip_address }}
-  when:
-    - __sap_vm_temp_vip_address | length > 0
-  register: __sap_vm_temp_vip_get_vip
+    cmd: set -o pipefail && ip -oneline address show | grep {{ __sap_vm_temp_vip_fact_address }}
+  register: __sap_vm_temp_vip_register_get_vip
   changed_when: false
   ignore_errors: true
   failed_when: false
@@ -57,81 +42,89 @@
 # 3. Else inform that more than one VIP was found
 # 4. Else inform that comparison failed because provided prefix was empty
 # join('') is used instead of [0] because duplicate records are filtered out
-- name: Show information if VIP is already present on network interfaces
+- name: SAP VM VIP - Show information if VIP is already present on network interfaces
   ansible.builtin.debug:
     msg: >-
       {%- if __vip_expected == __vip_found -%}
         VIP address {{ __vip_expected }} is already present. VIP creation will be skipped.
-      {%- elif __vip_expected != __vip_found and __sap_vm_temp_vip_prefix != '' and not __vip_multiple -%}
+      {%- elif __vip_expected != __vip_found and __sap_vm_temp_vip_fact_prefix != '' and not __vip_multiple -%}
         VIP address {{ __vip_expected }} is already present with different prefix {{ __vip_found }}. VIP creation will be skipped.
       {%- elif __vip_multiple -%}
         Multiple VIP address entries found. VIP creation will be skipped.
       {%- else -%}
-        VIP address {{ __sap_vm_temp_vip_address }} is already present, but comparison failed because of empty sap_vm_temp_vip_default_prefix.
+        VIP address {{ __sap_vm_temp_vip_fact_address }} is already present, but comparison failed because of empty sap_vm_temp_vip_default_prefix.
       {%- endif -%}
   vars:
-    __vip_expected: "{{ __sap_vm_temp_vip_address ~ '/' ~ __sap_vm_temp_vip_prefix }}"
-    __vip_found: "{{ __sap_vm_temp_vip_get_vip.stdout | regex_search('inet ([0-9.]+/[0-9]+)', '\\1') | join('') if not __vip_multiple else '' }}"
-    __vip_multiple: "{{ true if __sap_vm_temp_vip_get_vip.stdout_lines | length > 1 else false }}"
+    __vip_expected: "{{ __sap_vm_temp_vip_fact_address ~ '/' ~ __sap_vm_temp_vip_fact_prefix }}"
+    __vip_found: "{{ __sap_vm_temp_vip_register_get_vip.stdout | regex_search('inet ([0-9.]+/[0-9]+)', '\\1') | join('') if not __vip_multiple else '' }}"
+    __vip_multiple: "{{ true if __sap_vm_temp_vip_register_get_vip.stdout_lines | length > 1 else false }}"
   when:
-    - __sap_vm_temp_vip_get_vip.stdout is defined and __sap_vm_temp_vip_get_vip.stdout | length > 0
-    - __sap_vm_temp_vip_address | length > 0
+    - __sap_vm_temp_vip_register_get_vip.stdout is defined
+    - __sap_vm_temp_vip_register_get_vip.stdout | length > 0
 
 
 # Dynamically generate IP creation command depending on values gathered before:
 # 1. VIP address is defined based on target host group
 # 2. Prefix is defined or generated using netmask or primary IP prefix
 # 3. Broadcast IP is used only if it was defined or generated using primary IP broadcast
-- name: Generate command for IP creation - Prefix /{{ __sap_vm_temp_vip_prefix }} static IPs
+# NOTE: Command is split into multiple lines inside of jinja2 brackets to ensure newline characters are not added.
+- name: SAP VM VIP - Generate command for IP creation - Prefix /{{ __sap_vm_temp_vip_fact_prefix }} static IPs
   ansible.builtin.set_fact:
     __sap_vm_temp_vip_command: >-
-      {%- if __sap_vm_temp_vip_broadcast | length > 0 -%}
-        ip address add {{ __sap_vm_temp_vip_address }}/{{ __sap_vm_temp_vip_prefix }} brd {{ __sap_vm_temp_vip_broadcast }} dev {{ sap_vm_temp_vip_default_interface }} noprefixroute
+      {%- if __sap_vm_temp_vip_fact_broadcast | length > 0 -%}
+        ip address add {{ __sap_vm_temp_vip_fact_address }}/{{ __sap_vm_temp_vip_fact_prefix }} brd {{
+          __sap_vm_temp_vip_fact_broadcast }} dev {{ sap_vm_temp_vip_default_interface | d('eth0') }} noprefixroute
       {%- else -%}
-        ip address add {{ __sap_vm_temp_vip_address }}/{{ __sap_vm_temp_vip_prefix }} brd + dev {{ sap_vm_temp_vip_default_interface }} noprefixroute
+        ip address add {{ __sap_vm_temp_vip_fact_address }}/{{ __sap_vm_temp_vip_fact_prefix }} brd + dev {{
+          sap_vm_temp_vip_default_interface | d('eth0') }} noprefixroute
       {%- endif -%}
   when:
-    - __sap_vm_temp_vip_address | length > 0
-    - __sap_vm_temp_vip_prefix | length > 0
-    - __sap_vm_temp_vip_get_vip.stdout is defined and __sap_vm_temp_vip_get_vip.stdout | length == 0
+    - __sap_vm_temp_vip_fact_prefix | length > 0
+    - __sap_vm_temp_vip_register_get_vip.stdout is defined
+    - __sap_vm_temp_vip_register_get_vip.stdout | length == 0
 
 
 # Show debug information with input details if command was generated:
-- name: Show actions to be executed to create temporary VIP
+- name: SAP VM VIP - Show actions to be executed to create temporary VIP
   ansible.builtin.debug:
-    msg:
-      - "Ansible Facts:"
-      - primary_ip_address = {{ sap_vm_temp_vip_default_ip }}
-      - primary_ip_address_netmask = {{ sap_vm_temp_vip_default_netmask }}
-      - primary_ip_address_netmask_cidr_prefix = {{ __sap_vm_temp_vip_prefix }}
-      - primary_ip_broadcast_address = {{ __sap_vm_temp_vip_broadcast }}
-      - ""
-      - "Command to be executed:"
-      - "{{ __sap_vm_temp_vip_command }}"
+    msg: |
+      INFO: Temporary Virtual IP Address details:
+      - IP Address: {{ sap_vm_temp_vip_default_ip | d('N/A') }} from the variable 'sap_vm_temp_vip_default_ip'
+      - Netmask: {{ sap_vm_temp_vip_default_netmask | d('N/A') }} from the variable 'sap_vm_temp_vip_default_netmask'
+      - Netmask CIDR Prefix: {{ __sap_vm_temp_vip_fact_prefix | d('N/A') }} from the variable 'sap_vm_temp_vip_default_prefix'.
+      - Broadcast Address: {{ __sap_vm_temp_vip_fact_broadcast | d('N/A') }} from the variable 'sap_vm_temp_vip_default_broadcast'.
+      - Interface: {{ sap_vm_temp_vip_default_interface | d('eth0') }} from the variable 'sap_vm_temp_vip_default_interface'.
+
+      Command to be executed:
+      "{{ __sap_vm_temp_vip_command }}"
   when:
-    - __sap_vm_temp_vip_command is defined and __sap_vm_temp_vip_command | length > 0
-    - __sap_vm_temp_vip_get_vip.stdout is defined and __sap_vm_temp_vip_get_vip.stdout | length == 0
+    - __sap_vm_temp_vip_command | d('') | length > 0
+    - __sap_vm_temp_vip_register_get_vip.stdout is defined
+    - __sap_vm_temp_vip_register_get_vip.stdout | length == 0
 
 # Show debug information with input details if command was not generated and some inputs are empty:
-- name: Show information if command was unable to be generated
+- name: SAP VM VIP - Show information if command was unable to be generated
   ansible.builtin.debug:
-    msg:
-      - "ERROR: Unable to generate command because of lacking data."
-      - ""
-      - "Please review facts below, to see which are empty or missing:"
-      - primary_ip_address = {{ sap_vm_temp_vip_default_ip }}
-      - primary_ip_address_netmask = {{ sap_vm_temp_vip_default_netmask }}
-      - primary_ip_address_netmask_cidr_prefix = {{ __sap_vm_temp_vip_prefix }}
-      - primary_ip_broadcast_address = {{ __sap_vm_temp_vip_broadcast }}
+    msg: |
+      FAIL: Unable to generate command because of lack of data.
+
+      Please review Virtual IP Address details below, to see which are empty or missing:
+      - IP Address: {{ sap_vm_temp_vip_default_ip | d('N/A') }} from the variable 'sap_vm_temp_vip_default_ip'
+      - Netmask: {{ sap_vm_temp_vip_default_netmask | d('N/A') }} from the variable 'sap_vm_temp_vip_default_netmask'
+      - Netmask CIDR Prefix: {{ __sap_vm_temp_vip_fact_prefix | d('N/A') }} from the variable 'sap_vm_temp_vip_default_prefix'.
+      - Broadcast Address: {{ __sap_vm_temp_vip_fact_broadcast | d('N/A') }} from the variable 'sap_vm_temp_vip_default_broadcast'.
+      - Interface: {{ sap_vm_temp_vip_default_interface | d('eth0') }} from the variable 'sap_vm_temp_vip_default_interface'.
   when:
-    - __sap_vm_temp_vip_command is not defined or (__sap_vm_temp_vip_command is defined and __sap_vm_temp_vip_command | length == 0)
-    - __sap_vm_temp_vip_get_vip.stdout is defined and __sap_vm_temp_vip_get_vip.stdout | length == 0
+    - __sap_vm_temp_vip_command is not defined
+      or (__sap_vm_temp_vip_command is defined and __sap_vm_temp_vip_command | length == 0)
+    - __sap_vm_temp_vip_register_get_vip.stdout is defined
+    - __sap_vm_temp_vip_register_get_vip.stdout | length == 0
 
 # Execute generated command to add VIP to network interface if command is generated and VIP is not present yet.
-- name: Append temporary Virtual IP (VIP) to network interface  # noqa command-instead-of-shell
+- name: SAP VM VIP - Append temporary Virtual IP (VIP) to network interface  # noqa command-instead-of-shell
   ansible.builtin.shell:
     cmd: "{{ __sap_vm_temp_vip_command }}"
   when:
     - __sap_vm_temp_vip_command is defined and __sap_vm_temp_vip_command | length > 0
-    - __sap_vm_temp_vip_get_vip.stdout | length == 0
-  register: __sap_vm_temp_vip_command_output
+    - __sap_vm_temp_vip_register_get_vip.stdout | length == 0
+  changed_when: true

--- a/roles/sap_vm_temp_vip/tasks/set_temp_vip_lb_listener.yml
+++ b/roles/sap_vm_temp_vip/tasks/set_temp_vip_lb_listener.yml
@@ -1,13 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
 ---
+
 # Define listening port based on target host group. Same ports are used by sap_vm_provision during NLB creation
 # 55550 - SAP HANA and SAP AnyDB
 # 55551 - SAP SAP NetWeaver ASCS
 # 55552 - SAP NetWeaver ERS
-# Else ensures that we always return String, not NoneType.
-- name: Set fact for temporary listening port
+# Else returns 'UNSUPPORTED', because we cannot rely on consistent result.
+# Reason: Ansible 2.16 returns type AnsibleUnsafeText while Ansible 2.20 returns type NoneType.
+
+- name: SAP VM VIP - Set fact for temporary listening port
   ansible.builtin.set_fact:
-    __sap_vm_temp_vip_port: >-
-      {% if groups[sap_vm_temp_vip_group_hana_secondary] | d([]) | length > 0 and inventory_hostname in groups[sap_vm_temp_vip_group_hana_primary] -%}
+    __sap_vm_temp_vip_fact_port: >-
+      {%- if groups[sap_vm_temp_vip_group_hana_secondary] | d([]) | length > 0 and inventory_hostname in groups[sap_vm_temp_vip_group_hana_primary] -%}
         55550
       {%- elif groups[sap_vm_temp_vip_group_anydb_secondary] | d([]) | length > 0 and inventory_hostname in groups[sap_vm_temp_vip_group_anydb_primary] -%}
         55550
@@ -15,52 +19,57 @@
         55551
       {%- elif groups[sap_vm_temp_vip_group_nwas_ers] | d([]) | length > 0 and inventory_hostname in groups[sap_vm_temp_vip_group_nwas_ers] -%}
         55552
-      {%- else -%}
-        {{ '' }}
-      {%- endif %}
+      {%- else -%}UNSUPPORTED{%- endif -%}
 
 
-# Check if defined port is alreadu active and listening
+# Check if defined port is already active and listening
 # ss is used as it is present on both SUSE and Red Hat OS without need to install lsof or netstat
-- name: Check if temporary port is already open
+- name: SAP VM VIP - Check if temporary port is already open
   ansible.builtin.command:
-    cmd: ss -tulnH "sport = :{{ __sap_vm_temp_vip_port }}"
-  register: __sap_vm_temp_vip_port_check
+    cmd: ss -tulnH "sport = :{{ __sap_vm_temp_vip_fact_port }}"
+  register: __sap_vm_temp_vip_register_port_check
   when:
-    - __sap_vm_temp_vip_port | length > 0
+    - __sap_vm_temp_vip_fact_port != 'UNSUPPORTED'
+    - __sap_vm_temp_vip_fact_port | trim | length > 0
   changed_when: false
 
 
 - name: Block to start temporary netcat processes for Load Balancer Health Checks
   when:
-    - __sap_vm_temp_vip_address | length > 0
-    - __sap_vm_temp_vip_port | length > 0
-    - __sap_vm_temp_vip_port_check.stdout is defined and __sap_vm_temp_vip_port_check.stdout | length == 0
-    - __sap_vm_temp_vip_prefix | length > 0  # Dont execute if prefix was empty during VIP creation
+    - __sap_vm_temp_vip_fact_port != 'UNSUPPORTED'
+    - __sap_vm_temp_vip_fact_port | trim | length > 0
+    - __sap_vm_temp_vip_register_port_check.stdout is defined
+    - __sap_vm_temp_vip_register_port_check.stdout | length == 0
+    - __sap_vm_temp_vip_fact_prefix | trim | length > 0  # Don't execute if prefix was empty during VIP creation
   block:
 
     # Get content of ip address show filtered by VIP - Additional execution if VIP was previously created
-    - name: Check if VIP is was already attached to network interface
+    - name: SAP VM VIP - Check if VIP is was already attached to network interface
       ansible.builtin.shell:
-        cmd: "set -o pipefail && ip --oneline address show | grep {{ __sap_vm_temp_vip_address }}/{{ __sap_vm_temp_vip_prefix }}"
+        cmd: "set -o pipefail && ip --oneline address show | grep {{ __sap_vm_temp_vip_fact_address }}/{{ __sap_vm_temp_vip_fact_prefix }}"
         executable: /bin/bash
-      register: __sap_vm_temp_vip_check_ip
+      register: __sap_vm_temp_vip_register_check_ip
       changed_when: false
       ignore_errors: true
       failed_when: false
 
     # Install netcat package that is used to temporarily listen on ports
-    - name: Install netcat package
+    - name: SAP VM VIP - Install netcat package
       ansible.builtin.package:
         name:
-          - "{{ 'netcat' if ansible_os_family == 'Suse' else 'nc' }}"
+          - "{{ 'netcat' if ansible_facts['os_family'] == 'Suse' else 'nc' }}"
         state: present
-      when: __sap_vm_temp_vip_check_ip.stdout | length > 0
+      when:
+        - __sap_vm_temp_vip_register_check_ip.stdout is defined
+        - __sap_vm_temp_vip_register_check_ip.stdout | length > 0
 
 
     # Start netcat with timeout of 12 hours to ensure that SAP installation has enough time to complete.
-    - name: Start temporary 12 hour netcat process for Load Balancer Health Checks during SAP installation
-      ansible.builtin.shell: |
-        nohup timeout 12h bash -c "while true; do nc -vvv -l -k {{ __sap_vm_temp_vip_port }} ; done" </dev/null >/dev/null 2>&1 &
-        sleep 2
-      when: __sap_vm_temp_vip_check_ip.stdout | length > 0
+    - name: SAP VM VIP - Start temporary 12 hour netcat process for Load Balancer Health Checks during SAP installation
+      ansible.builtin.shell:
+        cmd: >-
+          nohup timeout 12h bash -c "while true; do nc -vvv -l -k {{ __sap_vm_temp_vip_fact_port }} ; done" </dev/null >/dev/null 2>&1 &
+      changed_when: true
+      when:
+        - __sap_vm_temp_vip_register_check_ip.stdout is defined
+        - __sap_vm_temp_vip_register_check_ip.stdout | length > 0


### PR DESCRIPTION
## Scope
This is effort in line with https://github.com/sap-linuxlab/community.sap_infrastructure/pull/155, but with smaller scope as actual optimization should be handled by role maintainer (I would cut it up very significantly).
- Remove linting ignores and fix all reported issues
  - Variable naming
  - Jinja2 formatting
  - Spacing and comments
- Update usage of injected ansible vars to remove deprecation warning in `ansible-core 2.20`
- Move tasks into prepare_variables task file to improve "fail fast" approach and to avoid running fact gathering if host is not relevant for this role.
- Added dedicated fail module to fail if correct host group is present, but VIP is not defined because that means role runs without sap_vm_provision facts and it is missing mandatory inputs.

## NOTE
Removed use of `NoneType` because it shows different behavior between Ansible versions as explained in comment in code:
```yaml
# Else returns 'UNSUPPORTED', because we cannot rely on consistent result.
# Reason: Ansible 2.16 returns type AnsibleUnsafeText while Ansible 2.20 returns type NoneType.
```

## Tests
Tested on SLES 15 SP7 on AWS and GCP platforms.

## Linting Results
Before `ansible-lint roles/sap_vm_temp_vip/ --offline`:
```console
# Rule Violation Summary

  2 jinja profile:basic tags:formatting
  2 no-changed-when profile:basic tags:command-shell,idempotency

Failed: 2 failure(s), 2 warning(s) in 9 files processed of 10 encountered. Last profile that met the validation criteria was 'min'.
```

After `ansible-lint roles/sap_vm_temp_vip/ --offline`:
```console
Passed: 0 failure(s), 0 warning(s) in 10 files processed of 11 encountered. Last profile that met the validation criteria was 'production'
```