### PR TITLE
sap_vm_provision: Fix adding /etc/hosts for all in play not just itself

### DIFF
--- a/roles/sap_vm_provision/tasks/common/set_etc_hosts.yml
+++ b/roles/sap_vm_provision/tasks/common/set_etc_hosts.yml
@@ -43,19 +43,19 @@
   loop:
     # Since scaleout hosts are in same group, we have to skip it as it has separate file
     - "{{ [sap_vm_provision_dynamic_inventory_hana_primary_ip, sap_vm_provision_dynamic_inventory_hana_primary_hostname]
-        if __sap_vm_provision_fact_is_hana_primary and not __sap_vm_provision_fact_is_hana_scaleout else '' }}"
+        if sap_vm_provision_dynamic_inventory_hana_primary_ip is not none and not __sap_vm_provision_fact_is_hana_scaleout else '' }}"
 
     - "{{ [sap_vm_provision_dynamic_inventory_anydb_primary_ip, sap_vm_provision_dynamic_inventory_anydb_primary_hostname]
-        if __sap_vm_provision_fact_is_anydb_primary else '' }}"
+        if sap_vm_provision_dynamic_inventory_anydb_primary_ip is not none else '' }}"
 
     - "{{ [sap_vm_provision_dynamic_inventory_nw_ascs_ip, sap_vm_provision_dynamic_inventory_nw_ascs_hostname]
-        if __sap_vm_provision_fact_is_nwas_ascs and (ansible_play_hosts_all | length) > 1 else '' }}"
+        if sap_vm_provision_dynamic_inventory_nw_ascs_ip is not none and (ansible_play_hosts_all | length) > 1 else '' }}"
 
     - "{{ [sap_vm_provision_dynamic_inventory_nw_pas_ip, sap_vm_provision_dynamic_inventory_nw_pas_hostname]
-        if __sap_vm_provision_fact_is_nwas_pas else '' }}"
+        if sap_vm_provision_dynamic_inventory_nw_pas_ip is not none else '' }}"
 
     - "{{ [sap_vm_provision_dynamic_inventory_nw_aas_ip, sap_vm_provision_dynamic_inventory_nw_aas_hostname]
-        if __sap_vm_provision_fact_is_nwas_aas and (ansible_play_hosts_all | length) > 1 else '' }}"
+        if sap_vm_provision_dynamic_inventory_nw_aas_ip is not none and (ansible_play_hosts_all | length) > 1 else '' }}"
 
   loop_control:
     loop_var: hosts_item


### PR DESCRIPTION
## Changes
I have incorrectly identified intent behind initial updating of `/etc/hosts` and reworked approach in https://github.com/sap-linuxlab/community.sap_infrastructure/pull/155 has not correctly set them. It has resulted on only own entry added because of flag fact.

This changes fixes that, so that all hosts in play are present in `/etc/hosts`.

FYI: We are not checking if defined because `set_fact` sets these facts always.
```yaml
  ansible.builtin.set_fact:
    sap_vm_provision_dynamic_inventory_anydb_primary_ip:
      "{{ hostvars[sap_vm_provision_dynamic_inventory_anydb_primary_hostname].ansible_host | d(none) }}"
```
