### PR TITLE
collection: Prepare changelog for 1.4.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,29 @@ community.sap\_infrastructure Release Notes
 
 .. contents:: Topics
 
+v1.4.0
+======
+
+Release Summary
+---------------
+
+Refactored all roles following best practices, complete linting and compatibility with ansible-core 2.20.
+
+Minor Changes
+--------
+- sap_vm_provision - Rework role with best practices to align with project (https://github.com/sap-linuxlab/community.sap_infrastructure/pull/155)
+- sap_vm_provision - Update ibmcloud PowerVS image dictionaries (https://github.com/sap-linuxlab/community.sap_infrastructure/pull/152)
+- sap_vm_provision - Add MS Azure disclaimer about reliability of azure collection (https://github.com/sap-linuxlab/community.sap_infrastructure/pull/159)
+- sap_hypervisor_node_preconfigure - Refactor role and conform to linting (https://github.com/sap-linuxlab/community.sap_infrastructure/pull/156)
+- sap_vm_temp_vip - Refactor variables and improve logic for skipping hosts (https://github.com/sap-linuxlab/community.sap_infrastructure/pull/157)
+
+Bugfixes
+--------
+- sap_vm_provision - Fix deprecated network parameter for amazon.aws.ec2_instance (https://github.com/sap-linuxlab/community.sap_infrastructure/pull/153)
+- sap_vm_provision - Fix adding /etc/hosts for all in play not just itself (https://github.com/sap-linuxlab/community.sap_infrastructure/pull/160)
+- sap_vm_temp_vip - Fix NoneType broadcast variable (https://github.com/sap-linuxlab/community.sap_infrastructure/pull/154)
+
+
 v1.3.1
 ======
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -25,47 +25,23 @@ For specific role maintainers, see the `README.md` file in the corresponding rol
 | Name | Commits | Lines Changed | Last Commit |
 | ---- | ------- | ------------- | ----------- |
 | [Sean Freeman](https://github.com/sean-freeman) | 100 | 27358 | 2025-06-20 |
-| [Marcel Mamula](https://github.com/marcelmamula) | 60 | 6100 | 2026-01-07 |
+| [Marcel Mamula](https://github.com/marcelmamula) | 82 | 26609 | 2026-03-20 |
 | [Nils Koenig](https://github.com/newkit) | 59 | 3971 | 2026-01-12 |
 | [Bernd Finger](https://github.com/berndfinger) | 7 | 285 | 2025-02-25 |
 | [Geetika Kapoor](https://github.com/geetikakay) | 6 | 124 | 2025-11-14 |
+| Edmund Häfele | 1 | 7 | 2026-01-13 |
 | [Janine Fuchs](https://github.com/ja9fuchs) | 1 | 2 | 2024-09-03 |
 | [Markus Koch](https://github.com/rhmk) | 1 | 35 | 2024-08-27 |
 
 ## Contributions by Role
-
-### Role: sap_vm_verify
-
-| Name | Commits | Lines Changed | Last Commit |
-| ---- | ------- | ------------- | ----------- |
-| [Sean Freeman](https://github.com/sean-freeman) | 2 | 504 | 2025-02-13 |
-| [Marcel Mamula](https://github.com/marcelmamula) | 1 | 1 | 2025-08-01 |
-
-### Role: sap_vm_temp_vip
-
-| Name | Commits | Lines Changed | Last Commit |
-| ---- | ------- | ------------- | ----------- |
-| [Marcel Mamula](https://github.com/marcelmamula) | 13 | 1149 | 2025-08-15 |
-| [Sean Freeman](https://github.com/sean-freeman) | 6 | 607 | 2024-08-30 |
-
-### Role: sap_vm_provision
-
-| Name | Commits | Lines Changed | Last Commit |
-| ---- | ------- | ------------- | ----------- |
-| [Sean Freeman](https://github.com/sean-freeman) | 85 | 22396 | 2025-05-26 |
-| [Marcel Mamula](https://github.com/marcelmamula) | 34 | 3496 | 2026-01-07 |
-| [Nils Koenig](https://github.com/newkit) | 23 | 1136 | 2026-01-12 |
-| [Bernd Finger](https://github.com/berndfinger) | 3 | 5 | 2025-02-19 |
-| [Janine Fuchs](https://github.com/ja9fuchs) | 1 | 2 | 2024-09-03 |
-| [Markus Koch](https://github.com/rhmk) | 1 | 35 | 2024-08-27 |
 
 ### Role: sap_hypervisor_node_preconfigure
 
 | Name | Commits | Lines Changed | Last Commit |
 | ---- | ------- | ------------- | ----------- |
 | [Nils Koenig](https://github.com/newkit) | 31 | 1847 | 2025-12-23 |
+| [Marcel Mamula](https://github.com/marcelmamula) | 6 | 1583 | 2026-03-16 |
 | [Geetika Kapoor](https://github.com/geetikakay) | 6 | 123 | 2025-11-14 |
-| [Marcel Mamula](https://github.com/marcelmamula) | 3 | 455 | 2025-08-20 |
 | [Sean Freeman](https://github.com/sean-freeman) | 2 | 1870 | 2024-05-07 |
 
 ### Role: sap_vm_preconfigure
@@ -74,4 +50,30 @@ For specific role maintainers, see the `README.md` file in the corresponding rol
 | ---- | ------- | ------------- | ----------- |
 | [Marcel Mamula](https://github.com/marcelmamula) | 2 | 17 | 2025-09-30 |
 | [Sean Freeman](https://github.com/sean-freeman) | 1 | 594 | 2024-02-01 |
+
+### Role: sap_vm_provision
+
+| Name | Commits | Lines Changed | Last Commit |
+| ---- | ------- | ------------- | ----------- |
+| [Sean Freeman](https://github.com/sean-freeman) | 85 | 22396 | 2025-05-26 |
+| [Marcel Mamula](https://github.com/marcelmamula) | 49 | 22264 | 2026-03-20 |
+| [Nils Koenig](https://github.com/newkit) | 23 | 1136 | 2026-01-12 |
+| [Bernd Finger](https://github.com/berndfinger) | 3 | 5 | 2025-02-19 |
+| Edmund Häfele | 1 | 7 | 2026-01-13 |
+| [Janine Fuchs](https://github.com/ja9fuchs) | 1 | 2 | 2024-09-03 |
+| [Markus Koch](https://github.com/rhmk) | 1 | 35 | 2024-08-27 |
+
+### Role: sap_vm_temp_vip
+
+| Name | Commits | Lines Changed | Last Commit |
+| ---- | ------- | ------------- | ----------- |
+| [Marcel Mamula](https://github.com/marcelmamula) | 15 | 1637 | 2026-02-19 |
+| [Sean Freeman](https://github.com/sean-freeman) | 6 | 607 | 2024-08-30 |
+
+### Role: sap_vm_verify
+
+| Name | Commits | Lines Changed | Last Commit |
+| ---- | ------- | ------------- | ----------- |
+| [Sean Freeman](https://github.com/sean-freeman) | 2 | 504 | 2025-02-13 |
+| [Marcel Mamula](https://github.com/marcelmamula) | 1 | 1 | 2025-08-01 |
 

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -132,3 +132,18 @@ releases:
         - sap_hypervisor_node_preconfigure - Add check for webhook endpoint availability (https://github.com/sap-linuxlab/community.sap_infrastructure/pull/142)
       bugfixes:
         - sap_hypervisor_node_preconfigure/kubevirt_vm - Fix installation of CNV operator (https://github.com/sap-linuxlab/community.sap_infrastructure/pull/148)
+
+  1.4.0:
+    release_date: '2026-03-24'
+    changes:
+      release_summary: Refactored all roles following best practices, complete linting and compatibility with ansible-core 2.20
+      minor_changes:
+        - sap_vm_provision - Rework role with best practices to align with project (https://github.com/sap-linuxlab/community.sap_infrastructure/pull/155)
+        - sap_vm_provision - Update ibmcloud PowerVS image dictionaries (https://github.com/sap-linuxlab/community.sap_infrastructure/pull/152)
+        - sap_vm_provision - Add MS Azure disclaimer about reliability of azure collection (https://github.com/sap-linuxlab/community.sap_infrastructure/pull/159)
+        - sap_hypervisor_node_preconfigure - Refactor role and conform to linting (https://github.com/sap-linuxlab/community.sap_infrastructure/pull/156)
+        - sap_vm_temp_vip - Refactor variables and improve logic for skipping hosts (https://github.com/sap-linuxlab/community.sap_infrastructure/pull/157)
+      bugfixes:
+        - sap_vm_provision - Fix deprecated network parameter for amazon.aws.ec2_instance (https://github.com/sap-linuxlab/community.sap_infrastructure/pull/153)
+        - sap_vm_provision - Fix adding /etc/hosts for all in play not just itself (https://github.com/sap-linuxlab/community.sap_infrastructure/pull/160)
+        - sap_vm_temp_vip - Fix NoneType broadcast variable (https://github.com/sap-linuxlab/community.sap_infrastructure/pull/154)

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -10,7 +10,7 @@ namespace: community
 name: sap_infrastructure
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.3.1
+version: 1.4.0
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md


### PR DESCRIPTION
Release Summary
---------------

Refactored all roles following best practices, complete linting and compatibility with ansible-core 2.20.

Minor Changes
--------
- sap_vm_provision - Rework role with best practices to align with project (https://github.com/sap-linuxlab/community.sap_infrastructure/pull/155)
- sap_vm_provision - Update ibmcloud PowerVS image dictionaries (https://github.com/sap-linuxlab/community.sap_infrastructure/pull/152)
- sap_vm_provision - Add MS Azure disclaimer about reliability of azure collection (https://github.com/sap-linuxlab/community.sap_infrastructure/pull/159)
- sap_hypervisor_node_preconfigure - Refactor role and conform to linting (https://github.com/sap-linuxlab/community.sap_infrastructure/pull/156)
- sap_vm_temp_vip - Refactor variables and improve logic for skipping hosts (https://github.com/sap-linuxlab/community.sap_infrastructure/pull/157)

Bugfixes
--------
- sap_vm_provision - Fix deprecated network parameter for amazon.aws.ec2_instance (https://github.com/sap-linuxlab/community.sap_infrastructure/pull/153)
- sap_vm_provision - Fix adding /etc/hosts for all in play not just itself (https://github.com/sap-linuxlab/community.sap_infrastructure/pull/160)
- sap_vm_temp_vip - Fix NoneType broadcast variable (https://github.com/sap-linuxlab/community.sap_infrastructure/pull/154)
