### PR TITLE
sap_vm_provision/kubevirt_vm: Add cpu flags and hugepages to vars file and playbook

### DIFF
--- a/playbooks/vars/sample-variables-sap-vm-provision-redhat-ocpv.yml
+++ b/playbooks/vars/sample-variables-sap-vm-provision-redhat-ocpv.yml
@@ -30,6 +30,21 @@ sap_vm_provision_execution_host: localhost # on AAP, this is localhost
 # What's the host specification plan that should be rolled out?
 sap_vm_provision_host_specification_plan: example_host_specification_plan
 
+# CPU performance settings which are applied to VM
+# Note: Using dedicatedCpuPlacement=true together with numa.guestMappingPassthrough requires also usage of huge pages
+sap_vm_provision_kubevirt_vm_performance_cpu_settings:
+  dedicatedCpuPlacement: true
+  model: host-passthrough
+  numa:
+    guestMappingPassthrough: {}
+  features:
+    - name: x2apic
+      policy: require
+    - name: rdtscp
+      policy: require
+    - name: invtsc
+      policy: require
+
 sap_vm_provision_kubevirt_vm_host_specifications_dictionary:
   example_host_specification_plan:
     host1: # Hostname, must be 13 characters or less
@@ -37,6 +52,10 @@ sap_vm_provision_kubevirt_vm_host_specifications_dictionary:
       kubevirt_vm_cpu_smt: 2
       kubevirt_vm_cpu_cores: 2
       kubevirt_vm_memory_gib: 24
+      # Defines size of huge pages for kubervirt hypervisor (e.g. '2Mi' or '1Gi')
+      # This can be disabled by setting value to false. The default value is '1Gi'.
+      # When set to false, remove NUMA and dedicatedCpuPlacement from sap_vm_provision_kubevirt_vm_performance_cpu_settings
+      kubevirt_vm_memory_hypervisor_hugepages: '1Gi'
       sap_system_type: project_dev # project_dev, project_tst, project_prd
       sap_host_type: hana_primary # hana_primary, hana_secondary, anydb_primary, anydb_secondary, nwas_ascs, nwas_ers, nwas_pas, nwas_aas
       # Provide either an existing PVC or a URL for an OS image

--- a/roles/sap_vm_provision/defaults/main.yml
+++ b/roles/sap_vm_provision/defaults/main.yml
@@ -823,6 +823,7 @@ sap_vm_provision_kubevirt_vm_os_user_password: ""
 sap_vm_provision_kubevirt_vm_container_memory_overhead: 1
 
 # CPU performance settings which are applied to VM
+# Note: Using dedicatedCpuPlacement=true together with numa.guestMappingPassthrough requires also usage of huge pages
 sap_vm_provision_kubevirt_vm_performance_cpu_settings:
   dedicatedCpuPlacement: true
   model: host-passthrough


### PR DESCRIPTION
Just added the `sap_vm_provision_kubevirt_vm_performance_cpu_settings` and `kubevirt_vm_memory_hypervisor_hugepages`  also to the vars file `playbooks/vars/sample-variables-sap-vm-provision-redhat-ocpv.yml` to make it more prominent to the user.