### PR TITLE
sap_vm_provision/kubevirt_vm: Custom evictionStrategy variable

### DIFF
--- a/roles/sap_vm_provision/defaults/main.yml
+++ b/roles/sap_vm_provision/defaults/main.yml
@@ -822,6 +822,11 @@ sap_vm_provision_kubevirt_vm_os_user_password: ""
 # RAM Overhead [GiB] for virt-launcher container, this can be small for VMs < 1 TB and without SRIOV but should be increased to 16 or more for VMs > 1TB
 sap_vm_provision_kubevirt_vm_container_memory_overhead: 1
 
+# Eviction strategy for the VM. Set to 'None' when using ReadWriteOnce PVCs (local storage),
+# as live migration requires ReadWriteMany access mode.
+# Valid values: 'LiveMigrate', 'None', or 'External'
+sap_vm_provision_kubevirt_vm_eviction_strategy: "None"
+
 # CPU performance settings which are applied to VM
 sap_vm_provision_kubevirt_vm_performance_cpu_settings:
   dedicatedCpuPlacement: true

--- a/roles/sap_vm_provision/tasks/platform_ansible/kubevirt_vm/execute_provision.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/kubevirt_vm/execute_provision.yml
@@ -226,13 +226,12 @@
 - name: SAP VM Provision - KubeVirt - Set fact for VM deploy config
   ansible.builtin.set_fact:
     __sap_vm_provision_fact_vm_deploy_config:
+      evictionStrategy: "{{ sap_vm_provision_kubevirt_vm_eviction_strategy }}"
       volumes: "{{ __sap_vm_provision_fact_storage_disk_name_list + __sap_vm_provision_fact_cloud_init_volume }}"
       networks: "{{ __sap_vm_provision_fact_networks_definition }}"
       domain:
-        # shared | auto, auto prevents live migration
         ioThreadsPolicy: shared
         hostname: "{{ __sap_vm_provision_fact_vm_name }}"
-        evictionStrategy: LiveMigrate
         terminationGracePeriodSeconds: 1800 # 30 minutes after stop request before VM is force terminated
         resources:
           requests:


### PR DESCRIPTION
evictionStrategy was hardcoded to LiveMigrate under spec.template.spec.domain. Two problems with this:
- Wrong API level: KubeVirt expects evictionStrategy at spec.template.spec, not under domain. It was silently ignored (unknown field warning).
- LiveMigrate breaks VMs on local storage (ReadWriteOnce PVCs cant migrate). VMs enter CrashLoopBackOff due to repeated eviction attempts. Moved evictionStrategy to the correct level and exposed it as a variable (sap_vm_provision_kubevirt_vm_eviction_strategy). Defaults to None which works with any storage type. Users can override to LiveMigrate when using shared storage (RWX).