### PR TITLE
sap_vm_provision/kubevirt_vm: Make evictionStrategy configurable

### DIFF
--- a/roles/sap_vm_provision/defaults/main.yml
+++ b/roles/sap_vm_provision/defaults/main.yml
@@ -822,6 +822,10 @@ sap_vm_provision_kubevirt_vm_os_user_password: ""
 # RAM Overhead [GiB] for virt-launcher container, this can be small for VMs < 1 TB and without SRIOV but should be increased to 16 or more for VMs > 1TB
 sap_vm_provision_kubevirt_vm_container_memory_overhead: 1
 
+# Eviction strategy for KubeVirt VMs.
+# Set to 'None' for local storage (ReadWriteOnce PVCs) or 'LiveMigrate' for shared storage (ReadWriteMany).
+sap_vm_provision_kubevirt_vm_eviction_strategy: "None"
+
 # CPU performance settings which are applied to VM
 # Note: Using dedicatedCpuPlacement=true together with numa.guestMappingPassthrough requires also usage of huge pages
 sap_vm_provision_kubevirt_vm_performance_cpu_settings:

--- a/roles/sap_vm_provision/defaults/main.yml
+++ b/roles/sap_vm_provision/defaults/main.yml
@@ -822,7 +822,7 @@ sap_vm_provision_kubevirt_vm_os_user_password: ""
 # RAM Overhead [GiB] for virt-launcher container, this can be small for VMs < 1 TB and without SRIOV but should be increased to 16 or more for VMs > 1TB
 sap_vm_provision_kubevirt_vm_container_memory_overhead: 1
 
-# Eviction strategy for KubeVirt VMs.
+# Eviction strategy for KubeVirt VMs (String).
 # Set to 'None' for local storage (ReadWriteOnce PVCs) or 'LiveMigrate' for shared storage (ReadWriteMany).
 sap_vm_provision_kubevirt_vm_eviction_strategy: "None"
 

--- a/roles/sap_vm_provision/tasks/platform_ansible/kubevirt_vm/execute_provision.yml
+++ b/roles/sap_vm_provision/tasks/platform_ansible/kubevirt_vm/execute_provision.yml
@@ -228,11 +228,11 @@
     __sap_vm_provision_fact_vm_deploy_config:
       volumes: "{{ __sap_vm_provision_fact_storage_disk_name_list + __sap_vm_provision_fact_cloud_init_volume }}"
       networks: "{{ __sap_vm_provision_fact_networks_definition }}"
+      evictionStrategy: "{{ sap_vm_provision_kubevirt_vm_eviction_strategy }}"
       domain:
         # shared | auto, auto prevents live migration
         ioThreadsPolicy: shared
         hostname: "{{ __sap_vm_provision_fact_vm_name }}"
-        evictionStrategy: LiveMigrate
         terminationGracePeriodSeconds: 1800 # 30 minutes after stop request before VM is force terminated
         resources:
           requests:

--- a/roles/sap_vm_provision/tasks/validations/kubevirt_vm.yml
+++ b/roles/sap_vm_provision/tasks/validations/kubevirt_vm.yml
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+---
+
+- name: Assert that the variable 'sap_vm_provision_kubevirt_vm_eviction_strategy' is defined as valid string
+  ansible.builtin.assert:
+    that:
+      - sap_vm_provision_kubevirt_vm_eviction_strategy is defined
+      - sap_vm_provision_kubevirt_vm_eviction_strategy is string
+      - sap_vm_provision_kubevirt_vm_eviction_strategy in ['None', 'LiveMigrate']
+    fail_msg: |
+      The variable 'sap_vm_provision_kubevirt_vm_eviction_strategy' is undefined or invalid.
+      It should be one of: 'None' for local storage (ReadWriteOnce PVCs) or 'LiveMigrate' for shared storage (ReadWriteMany).


### PR DESCRIPTION
evictionStrategy was hardcoded to LiveMigrate under spec.template.spec.domain.
Two problems with this:

- Wrong API level: KubeVirt expects evictionStrategy at spec.template.spec,
  not under domain. It was silently ignored (unknown field warning).
- LiveMigrate breaks VMs on local storage (ReadWriteOnce PVCs can't migrate).
  VMs enter CrashLoopBackOff due to repeated eviction attempts.

Moved evictionStrategy to the correct level and exposed it as a variable
(sap_vm_provision_kubevirt_vm_eviction_strategy). Defaults to None which
works with any storage type. Users can override to LiveMigrate when using
shared storage (RWX).